### PR TITLE
Include the C files in the gemspec, so it can actually build the extension.

### DIFF
--- a/rugged.gemspec
+++ b/rugged.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("lib/**/*.rb")
   s.files            += Dir.glob("man/**/*")
   s.files            += Dir.glob("test/**/*")
+  s.files            += Dir.glob("ext/**/*.c") + Dir.glob("ext/**/*.h")
   s.extensions        = ['ext/rugged/extconf.rb']
   s.description       = <<desc
 Rugged is a Ruby bindings to the libgit2 linkable C Git library. This is


### PR DESCRIPTION
Obnoxiously, this was a silent error during gem install, since make just stopped with nothing to do.
