### PR TITLE
Return complete content even when it contains nulls.

### DIFF
--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -49,7 +49,7 @@ VALUE rugged_raw_read(git_repository *repo, const git_oid *oid)
 	data = obj.data;
 	str_type = git_obj_type_to_string(obj.type);
 
-	rb_ary_store(ret_arr, 0, rb_str_new2(data));
+	rb_ary_store(ret_arr, 0, rb_str_new(data, obj.len));
 	rb_ary_store(ret_arr, 1, INT2FIX((int)obj.len));
 	rb_ary_store(ret_arr, 2, rb_str_new2(str_type));
 

--- a/test/blob_test.rb
+++ b/test/blob_test.rb
@@ -29,4 +29,14 @@ context "Rugged::Blob tests" do
     blob.content = "a new blob content"
     blob.write
   end
+
+  test "gets the complete content if it has nulls" do
+    @content = "100644 example_helper.rb\x00\xD3\xD5\xED\x9DA4_"+
+               "\xE3\xC3\nK\xCD<!\xEA-_\x9E\xDC=40000 examples\x00"+
+               "\xAE\xCB\xE9d!|\xB9\xA6\x96\x024],U\xEE\x99\xA2\xEE\xD4\x92"
+    sha = @repo.write(@content, 'tree')
+    blob = @repo.lookup(sha)
+    assert_equal @content, blob.read_raw.first
+  end
+
 end


### PR DESCRIPTION
rugged_raw_read was using rb_str_new2, which expects a null-terminated string.  If the content was binary and contained nulls, it would become truncated.
