### PR TITLE
Expose reading commit parents

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ to simply read the current value out
       prsn  = gobjc.committer
       gobjr = gobjc.tree
       sha   = gobjc.tree_sha
-      arr   = gobjc.parents [*] # TODO
+      arr   = gobjc.parents [*] # TODO: write
 
     gobtg =
     Rugged::Tag.new < Rugged::Object

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -170,6 +170,22 @@ static VALUE rb_git_commit_tree_SET(VALUE self, VALUE val)
 	return Qnil;
 }
 
+static VALUE rb_git_commit_parents_GET(VALUE self)
+{
+	git_commit *commit;
+	git_commit *parent;
+	unsigned int n;
+	VALUE ret_arr;
+	Data_Get_Struct(self, git_commit, commit);
+
+	ret_arr = rb_ary_new();
+	for (n = 0; (parent = git_commit_parent(commit, n)) != NULL; n++) {
+		rb_ary_store(ret_arr, n, rugged_object_c2rb((git_object *)parent));
+	}
+
+	return ret_arr;
+}
+
 void Init_rugged_commit()
 {
 	rb_cRuggedCommit = rb_define_class_under(rb_mRugged, "Commit", rb_cRuggedObject);
@@ -193,5 +209,8 @@ void Init_rugged_commit()
 
 	rb_define_method(rb_cRuggedCommit, "tree", rb_git_commit_tree_GET, 0);
 	rb_define_method(rb_cRuggedCommit, "tree=", rb_git_commit_tree_SET, 1);
+
+	/* Read only, at least for now */
+	rb_define_method(rb_cRuggedCommit, "parents", rb_git_commit_parents_GET, 0);
 }
 

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -24,6 +24,15 @@ context "Rugged::Commit tests" do
     assert_equal c.time.to_i, 1273360386
     assert_equal c.email, "schacon@gmail.com"
     assert_equal obj.tree.sha, "181037049a54a1eb5fab404658a3a250b44335d7"
+    assert_equal [], obj.parents
+  end
+  
+  test "can have multiple parents" do
+    sha = "a4a7dce85cf63874e984719f4fdd239f5145052f"
+    obj = @repo.lookup(sha)
+    parents = obj.parents.map {|c| c.sha }
+    assert parents.include?("9fd738e8f7967c078dceed8190330fc8648ee56a")
+    assert parents.include?("c47800c7266a2be04c571c04d5a6614691ea99bd")
   end
   
   test "can write the commit data" do


### PR DESCRIPTION
Returns array of commit objects; read-only so far.
