### PR TITLE
Fix crash in 1.9.2

### DIFF
--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -97,7 +97,7 @@ void rb_git_repo__mark(rugged_repository *repo)
 {
 	int i;
 
-	for (i = 0; i < rb_ary_size(repo->backends); ++i)
+	for (i = 0; i < RARRAY_LEN(repo->backends); ++i)
 		rb_gc_mark(rb_ary_entry(repo->backends, i));
 }
 

--- a/test/repo_test.rb
+++ b/test/repo_test.rb
@@ -50,4 +50,9 @@ context "Rugged::Repository stuff" do
     assert list.map {|c| c.sha[0,5] }.join('.'), "a4a7d.c4780.9fd73.4a202.5b5b0.84960"
   end
 
+  test "garbage collection methods don't crash" do
+    Rugged::Repository.new(@path)
+    ObjectSpace.garbage_collect
+  end
+
 end


### PR DESCRIPTION
rb_ary_size is not available in 1.9.2; use RARRAY_LEN macro to abstract over difference.  Add test for crashes during garbage collection.
