### PR TITLE
Add string encoding support for 1.9+, respecting Encoding.default_internal

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -33,7 +33,12 @@ static VALUE rb_git_hex_to_raw(VALUE self, VALUE hex)
 
 	Check_Type(hex, T_STRING);
 	git_oid_mkstr(&oid, RSTRING_PTR(hex));
+#ifdef HAVE_RUBY_ENCODING_H
+	/* make sure we use the binary encoding for raw bytes */
+	return rb_enc_str_new((&oid)->id, 20, rb_ascii8bit_encoding());
+#else
 	return rb_str_new((&oid)->id, 20);
+#endif
 }
 
 static VALUE rb_git_raw_to_hex(VALUE self, VALUE raw)
@@ -44,7 +49,8 @@ static VALUE rb_git_raw_to_hex(VALUE self, VALUE raw)
 	Check_Type(raw, T_STRING);
 	git_oid_mkraw(&oid, RSTRING_PTR(raw));
 	git_oid_fmt(out, &oid);
-	return rb_str_new(out, 40);
+
+	return LG2_STR_NEW(out, 40, NULL);
 }
 
 static VALUE rb_git_type_to_string(VALUE self, VALUE type)
@@ -54,7 +60,7 @@ static VALUE rb_git_type_to_string(VALUE self, VALUE type)
 	Check_Type(type, T_FIXNUM);
 	git_otype t = (git_otype)FIX2INT(type);
 	str = git_object_type2string(t);
-	return str ? rb_str_new2(str) : Qfalse;
+	return str ? LG2_STR_NEW2(str, NULL) : Qfalse;
 }
 
 static VALUE rb_git_string_to_type(VALUE self, VALUE string_type)

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -99,5 +99,44 @@ typedef struct {
 	_val = (_rugged_obj->owner);\
 }
 
+/* support for string encodings in 1.9 */
+#ifdef HAVE_RUBY_ENCODING_H
+
+#include <ruby/encoding.h>
+#define LG2_STR_NEW(str, len, rb_enc)                                 \
+  ({                                                                  \
+    VALUE _string;                                                    \
+    rb_encoding *internal_encoding = rb_default_internal_encoding();  \
+    if(rb_enc) {                                                      \
+      _string = rb_enc_str_new(str, len, rb_enc);                     \
+    } else {                                                          \
+      _string = rb_str_new(str, len);                                 \
+    }                                                                 \
+    if(internal_encoding) {                                           \
+      _string = rb_str_export_to_enc(_string, internal_encoding);     \
+    }                                                                 \
+    _string;                                                          \
+  })
+
+#define LG2_STR_NEW2(str, rb_enc)                                     \
+  ({                                                                  \
+    VALUE _string;                                                    \
+    rb_encoding *internal_encoding = rb_default_internal_encoding();  \
+    _string = rb_str_new2(str);                                       \
+    if(rb_enc) {                                                      \
+      rb_enc_associate(_string, rb_enc);                              \
+    }                                                                 \
+    if(internal_encoding) {                                           \
+      _string = rb_str_export_to_enc(_string, internal_encoding);     \
+    }                                                                 \
+    _string;                                                          \
+  })
+
+#else
+
+#define LG2_STR_NEW(str, len, rb_enc)  rb_str_new(str, len)
+#define LG2_STR_NEW2(str, rb_enc) rb_str_new2(str)
+
+#endif
 
 #endif

--- a/ext/rugged/rugged_backend.c
+++ b/ext/rugged/rugged_backend.c
@@ -44,7 +44,7 @@ int rugged_backend__exists(git_odb_backend *_backend, const git_oid *oid)
 		return 0; /* not found! */
 
 	git_oid_fmt(oid_out, oid);
-	exists = rb_funcall(back->self, method, 1, rb_str_new(oid_out, 40));
+	exists = rb_funcall(back->self, method, 1, LG2_STR_NEW(oid_out, 40, NULL));
 
 	if (TYPE(exists) == T_TRUE)
 		return 1;
@@ -93,7 +93,7 @@ int rugged_backend__generic_read(int header_only, git_rawobj *obj, git_odb_backe
 
 	git_oid_fmt(oid_out, oid);
 
-	read_obj = rb_funcall(back->self, method, 1, rb_str_new(oid_out, 40));
+	read_obj = rb_funcall(back->self, method, 1, LG2_STR_NEW(oid_out, 40, NULL));
 
 	if (NIL_P(read_obj))
 		return GIT_ENOTFOUND;

--- a/ext/rugged/rugged_blob.c
+++ b/ext/rugged/rugged_blob.c
@@ -54,9 +54,26 @@ static VALUE rb_git_blob_content_GET(VALUE self)
 	
 	size = git_blob_rawsize(blob);
 	if (size == 0)
+#ifdef HAVE_RUBY_ENCODING_H
+		return rb_enc_str_new("", 0, rb_ascii8bit_encoding());
+#else
 		return rb_str_new2("");
+#endif
 
+#ifdef HAVE_RUBY_ENCODING_H
+	/*
+	 * since we don't really ever know the encoding of a blob
+	 * lets default to the binary encoding (ascii-8bit)
+	 * If there is a way to tell, we should just pass 0/null here instead
+	 *
+	 * we're skipping the use of STR_NEW because we don't want our string to
+	 * eventually end up converted to Encoding.default_internal because this
+	 * string could very well be binary data
+	 */
+	return rb_enc_str_new(git_blob_rawcontent(blob), size, rb_ascii8bit_encoding());
+#else
 	return rb_str_new(git_blob_rawcontent(blob), size);
+#endif
 }
 
 static VALUE rb_git_blob_rawsize(VALUE self)

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -42,7 +42,7 @@ static VALUE rb_git_commit_message_GET(VALUE self)
 	git_commit *commit;
 	RUGGED_OBJ_UNWRAP(self, git_commit, commit);
 
-	return rb_str_new2(git_commit_message(commit));
+	return LG2_STR_NEW2(git_commit_message(commit), NULL);
 }
 
 static VALUE rb_git_commit_message_SET(VALUE self, VALUE val)
@@ -60,7 +60,7 @@ static VALUE rb_git_commit_message_short_GET(VALUE self)
 	git_commit *commit;
 	RUGGED_OBJ_UNWRAP(self, git_commit, commit);
 
-	return rb_str_new2(git_commit_message_short(commit));
+	return LG2_STR_NEW2(git_commit_message_short(commit), NULL);
 }
 
 static VALUE rb_git_commit_committer_GET(VALUE self)

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -294,7 +294,7 @@ static VALUE rb_git_indexentry_path_GET(VALUE self)
 	if (entry->path == NULL)
 		return Qnil;
 
-	return rb_str_new2(entry->path);
+	return LG2_STR_NEW2(entry->path, NULL);
 }
 
 static VALUE rb_git_indexentry_path_SET(VALUE self, VALUE val)
@@ -317,7 +317,7 @@ static VALUE rb_git_indexentry_oid_GET(VALUE self)
 	char out[40];
 	Data_Get_Struct(self, git_index_entry, entry);
 	git_oid_fmt(out, &entry->oid);
-	return rb_str_new(out, 40);
+	return LG2_STR_NEW(out, 40, NULL);
 }
 
 static VALUE rb_git_indexentry_oid_SET(VALUE self, VALUE v) 

--- a/ext/rugged/rugged_object.c
+++ b/ext/rugged/rugged_object.c
@@ -185,7 +185,7 @@ static VALUE rb_git_object_sha_GET(VALUE self)
 	RUGGED_OBJ_UNWRAP(self, git_object, object);
 
 	git_oid_fmt(hex, git_object_id(object));
-	return rb_str_new(hex, 40);
+	return LG2_STR_NEW(hex, 40, NULL);
 }
 
 static VALUE rb_git_object_type_GET(VALUE self)
@@ -193,7 +193,7 @@ static VALUE rb_git_object_type_GET(VALUE self)
 	git_object *object;
 	RUGGED_OBJ_UNWRAP(self, git_object, object);
 
-	return rb_str_new2(git_object_type2string(git_object_type(object)));
+	return LG2_STR_NEW2(git_object_type2string(git_object_type(object)), NULL);
 }
 
 static VALUE rb_git_object_read_raw(VALUE self)
@@ -217,7 +217,7 @@ static VALUE rb_git_object_write(VALUE self)
 	rugged_exception_check(error);
 
 	git_oid_fmt(new_hex, git_object_id(object));
-	sha = rb_str_new(new_hex, 40);
+	sha = LG2_STR_NEW(new_hex, 40, NULL);
 
 	return sha;
 }

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -37,7 +37,11 @@ VALUE rugged_rawobject_new(const git_rawobj *obj)
 	VALUE rb_obj_args[3];
 
 	rb_obj_args[0] = INT2FIX(obj->type);
+#ifdef HAVE_RUBY_ENCODING_H
+	rb_obj_args[1] = rb_enc_str_new(obj->data, obj->len, rb_ascii8bit_encoding());
+#else
 	rb_obj_args[1] = rb_str_new(obj->data, obj->len);
+#endif
 	rb_obj_args[2] = INT2FIX(obj->len);
 
 	return rb_class_new_instance(3, rb_obj_args, rb_cRuggedRawObject);
@@ -245,7 +249,7 @@ static VALUE rb_git_repo_obj_hash(VALUE self, VALUE rb_rawobj)
 	rugged_exception_check(error);
 
 	git_oid_fmt(out, &oid);
-	return rb_str_new(out, 40);
+	return LG2_STR_NEW(out, 40, NULL);
 }
 
 static VALUE rb_git_repo_write(VALUE self, VALUE rb_rawobj)
@@ -268,7 +272,7 @@ static VALUE rb_git_repo_write(VALUE self, VALUE rb_rawobj)
 	rugged_exception_check(error);
 
 	git_oid_fmt(out, &oid);
-	return rb_str_new(out, 40);
+	return LG2_STR_NEW(out, 40, NULL);
 }
 
 static VALUE rb_git_repo_lookup(int argc, VALUE *argv, VALUE self)

--- a/ext/rugged/rugged_signature.c
+++ b/ext/rugged/rugged_signature.c
@@ -69,14 +69,14 @@ static VALUE rb_git_signature_name_GET(VALUE self)
 {
 	git_signature *sig;
 	Data_Get_Struct(self, git_signature, sig);
-	return rb_str_new2(sig->name);
+	return LG2_STR_NEW2(sig->name, NULL);
 }
 
 static VALUE rb_git_signature_email_GET(VALUE self)
 {
 	git_signature *sig;
 	Data_Get_Struct(self, git_signature, sig);
-	return rb_str_new2(sig->email);
+	return LG2_STR_NEW2(sig->email, NULL);
 }
 
 static VALUE rb_git_signature_email_SET(VALUE self, VALUE rb_email)

--- a/ext/rugged/rugged_tag.c
+++ b/ext/rugged/rugged_tag.c
@@ -61,7 +61,7 @@ static VALUE rb_git_tag_target_type_GET(VALUE self)
 	git_tag *tag;
 	RUGGED_OBJ_UNWRAP(self, git_tag, tag);
 
-	return rb_str_new2(git_object_type2string(git_tag_type(tag)));
+	return LG2_STR_NEW2(git_object_type2string(git_tag_type(tag)), NULL);
 }
 
 static VALUE rb_git_tag_name_GET(VALUE self)
@@ -69,7 +69,7 @@ static VALUE rb_git_tag_name_GET(VALUE self)
 	git_tag *tag;
 	RUGGED_OBJ_UNWRAP(self, git_tag, tag);
 
-	return rb_str_new2(git_tag_name(tag));
+	return LG2_STR_NEW2(git_tag_name(tag), NULL);
 }
 
 static VALUE rb_git_tag_name_SET(VALUE self, VALUE val)
@@ -104,7 +104,7 @@ static VALUE rb_git_tag_message_GET(VALUE self)
 	git_tag *tag;
 	RUGGED_OBJ_UNWRAP(self, git_tag, tag);
 
-	return rb_str_new2(git_tag_message(tag));
+	return LG2_STR_NEW2(git_tag_message(tag), NULL);
 }
 
 static VALUE rb_git_tag_message_SET(VALUE self, VALUE val)

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -91,7 +91,7 @@ static VALUE rb_git_tree_entry_name_GET(VALUE self)
 	rugged_tree_entry *tree_entry;
 	Data_Get_Struct(self, rugged_tree_entry, tree_entry);
 
-	return rb_str_new2(git_tree_entry_name(tree_entry->entry));
+	return LG2_STR_NEW2(git_tree_entry_name(tree_entry->entry), NULL);
 }
 
 static VALUE rb_git_tree_entry_name_SET(VALUE self, VALUE val)
@@ -111,7 +111,7 @@ static VALUE rb_git_tree_entry_sha_GET(VALUE self)
 	Data_Get_Struct(self, rugged_tree_entry, tree_entry);
 
 	git_oid_fmt(out, git_tree_entry_id(tree_entry->entry));
-	return rb_str_new(out, 40);
+	return LG2_STR_NEW(out, 40, NULL);
 }
 
 static VALUE rb_git_tree_entry_sha_SET(VALUE self, VALUE val)

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -11,20 +11,60 @@ context "Rugged::Commit tests" do
     obj = @repo.lookup(sha)
 
     assert_equal obj.sha, sha
-	  assert_equal obj.type, "commit"
+    assert_equal obj.type, "commit"
     assert_equal obj.message, "testing\n"
     assert_equal obj.message_short, "testing"
     assert_equal obj.time.to_i, 1273360386
+
     c = obj.committer
     assert_equal c.name, "Scott Chacon"
     assert_equal c.time.to_i, 1273360386
     assert_equal c.email, "schacon@gmail.com"
+
     c = obj.author
     assert_equal c.name, "Scott Chacon"
     assert_equal c.time.to_i, 1273360386
     assert_equal c.email, "schacon@gmail.com"
     assert_equal obj.tree.sha, "181037049a54a1eb5fab404658a3a250b44335d7"
     assert_equal [], obj.parents
+
+    if defined? Encoding
+      with_default_encoding('utf-8') do |enc|
+        obj = @repo.lookup(sha)
+
+        assert_equal enc, obj.sha.encoding
+        assert_equal enc, obj.type.encoding
+        assert_equal enc, obj.message.encoding
+        assert_equal enc, obj.message_short.encoding
+
+        c = obj.committer
+        assert_equal enc, c.name.encoding
+        assert_equal enc, c.email.encoding
+
+        c = obj.author
+        assert_equal enc, c.name.encoding
+        assert_equal enc, c.email.encoding
+        assert_equal enc, obj.tree.sha.encoding
+      end
+
+      with_default_encoding('ascii') do |enc|
+        obj = @repo.lookup(sha)
+
+        assert_equal enc, obj.sha.encoding
+        assert_equal enc, obj.type.encoding
+        assert_equal enc, obj.message.encoding
+        assert_equal enc, obj.message_short.encoding
+
+        c = obj.committer
+        assert_equal enc, c.name.encoding
+        assert_equal enc, c.email.encoding
+
+        c = obj.author
+        assert_equal enc, c.name.encoding
+        assert_equal enc, c.email.encoding
+        assert_equal enc, obj.tree.sha.encoding
+      end
+    end
   end
   
   test "can have multiple parents" do
@@ -39,7 +79,22 @@ context "Rugged::Commit tests" do
     sha = "8496071c1b46c854b31185ea97743be6a8774479"
     obj = @repo.lookup(sha)
     obj.message = 'new message'
-    obj.write
+    sha = obj.write
+    if defined? Encoding
+      with_default_encoding('utf-8') do |enc|
+        obj = @repo.lookup(sha)
+        obj.message = 'new message'
+        sha = obj.write
+        assert_equal enc, sha.encoding
+      end
+
+      with_default_encoding('ascii') do |enc|
+        obj = @repo.lookup(sha)
+        obj.message = 'new message'
+        sha = obj.write
+        assert_equal enc, sha.encoding
+      end
+    end
   end
 
   test "can write new commit data" do

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -55,6 +55,18 @@ context "Rugged::Index reading stuff" do
     e = @index.get_entry(1)
     assert_equal 'new.txt', e.path
     assert_equal 'fa49b077972391ad58037050f2a75f74e3671e92', e.sha
+
+    if defined? Encoding
+      with_default_encoding('utf-8') do |enc|
+        e = @index.get_entry(1)
+        assert_equal enc, e.path.encoding
+      end
+
+      with_default_encoding('ascii') do |enc|
+        e = @index.get_entry(1)
+        assert_equal enc, e.path.encoding
+      end
+    end
   end
 
   test "can iterate over the entries" do

--- a/test/lib_test.rb
+++ b/test/lib_test.rb
@@ -16,12 +16,27 @@ context "Rugged::Lib stuff" do
     raw1 = Rugged::hex_to_raw(hex)
     raw2 = [hex].pack("H*")
     assert_equal raw1, raw2
+    if defined? Encoding
+      raw = Rugged::hex_to_raw(hex)
+      assert_equal Encoding.find('binary'), raw.encoding
+    end
   end
 
   test "can convert raw sha into hex" do
     raw = Base64.decode64("FqASNFZ4mrze9Ld1ITwjqL109eA=")
     hex = Rugged::raw_to_hex(raw)
     assert_equal "16a0123456789abcdef4b775213c23a8bd74f5e0", hex
+    if defined? Encoding
+      with_default_encoding('utf-8') do |enc|
+        hex = Rugged::raw_to_hex(raw)
+        assert_equal enc, hex.encoding
+      end
+
+      with_default_encoding('ascii') do |enc|
+        hex = Rugged::raw_to_hex(raw)
+        assert_equal enc, hex.encoding
+      end
+    end
   end
 
   test "converts raw into hex sha correctly" do

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -9,14 +9,28 @@ context "Rugged::Object stuff" do
 
   test "cannot lookup a non-existant object" do
     assert_raise RuntimeError do 
-		obj = @repo.lookup("a496071c1b46c854b31185ea97743be6a8774479")
-	end
+      obj = @repo.lookup("a496071c1b46c854b31185ea97743be6a8774479")
+    end
   end
 
   test "can lookup an object" do
     obj = @repo.lookup("8496071c1b46c854b31185ea97743be6a8774479")
     assert_equal 'commit', obj.type
     assert_equal '8496071c1b46c854b31185ea97743be6a8774479', obj.sha
+
+    if defined? Encoding
+      with_default_encoding('utf-8') do |enc|
+        obj = @repo.lookup("8496071c1b46c854b31185ea97743be6a8774479")
+        assert_equal enc, obj.type.encoding
+        assert_equal enc, obj.sha.encoding
+      end
+
+      with_default_encoding('ascii') do |enc|
+        obj = @repo.lookup("8496071c1b46c854b31185ea97743be6a8774479")
+        assert_equal enc, obj.type.encoding
+        assert_equal enc, obj.sha.encoding
+      end
+    end
   end
 
   test "same looked up objects are the same" do

--- a/test/repo_test.rb
+++ b/test/repo_test.rb
@@ -51,6 +51,18 @@ context "Rugged::Repository stuff" do
     assert_equal "76b1b55ab653581d6f2c7230d34098e837197674", sha
     assert @repo.exists("76b1b55ab653581d6f2c7230d34098e837197674")
     rm_loose("76b1b55ab653581d6f2c7230d34098e837197674")
+
+    if defined? Encoding
+      with_default_encoding('utf-8') do |enc|
+        sha = @repo.write(@obj)
+        assert_equal enc, sha.encoding
+      end
+
+      with_default_encoding('ascii') do |enc|
+        sha = @repo.write(@obj)
+        assert_equal enc, sha.encoding
+      end
+    end
   end
 
   test "can use the builtin walk method" do

--- a/test/tag_test.rb
+++ b/test/tag_test.rb
@@ -20,6 +20,22 @@ context "Rugged::Tag tests" do
     assert_equal "Scott Chacon", c.name
     assert_equal 1288114383, c.time.to_i
     assert_equal "schacon@gmail.com", c.email
+
+    if defined? Encoding
+      with_default_encoding('utf-8') do |enc|
+        obj = @repo.lookup(sha)
+        assert_equal enc, obj.message.encoding
+        assert_equal enc, obj.name.encoding
+        assert_equal enc, obj.target_type.encoding
+      end
+
+      with_default_encoding('ascii') do |enc|
+        obj = @repo.lookup(sha)
+        assert_equal enc, obj.message.encoding
+        assert_equal enc, obj.target_type.encoding
+        assert_equal enc, obj.name.encoding
+      end
+    end
   end
   
   test "can write the tag data" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,3 +33,13 @@ def rm_loose(sha)
   `rm -f #{file}`
 end
 
+def with_default_encoding(encoding, &block)
+  old_encoding = Encoding.default_internal
+
+  new_encoding = Encoding.find(encoding)
+  Encoding.default_internal = new_encoding
+
+  yield new_encoding
+
+  Encoding.default_internal = old_encoding
+end

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -27,6 +27,18 @@ context "Rugged::Tree tests" do
     assert_equal "subdir", tent.name
     assert_equal "619f9935957e010c419cb9d15621916ddfcc0b96", tent.to_object.sha
     assert_equal "tree", tent.to_object.type
+
+    if defined? Encoding
+      with_default_encoding('utf-8') do |enc|
+        assert_equal enc, bent.name.encoding
+        assert_equal enc, bent.sha.encoding
+      end
+
+      with_default_encoding('ascii') do |enc|
+        assert_equal enc, bent.name.encoding
+        assert_equal enc, bent.sha.encoding
+      end
+    end
   end
 
   test "can iterate over the tree" do


### PR DESCRIPTION
This patch introduces two new macros for creating Ruby strings from C. LG2_STR_NEW and LG2_STR_NEW2. They can be used exactly like rb_str_new and rb_str_new2 but with an extra parameter (rb_encoding *) which is used to set the encoding flag of the string before it's finally converted to Encoding.default_internal if set.

http://yehudakatz.com/2010/05/05/ruby-1-9-encodings-a-primer-and-the-solution-for-rails/ is a great read on Encoding.default_internal and how Rails uses it.

I'm pretty sure I've converted all string creation over to the new macros where needed, but we need to be sure to avoid converting strings that may contain binary data to any other encoding as it will corrupt it. I'm also pretty sure there are tests for everything, but I'd love this patch to see some more eyes if at all possible.
