### PR TITLE
Updated Rugged::Index.add to get tests to pass

### DIFF
--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -175,7 +175,7 @@ static VALUE rb_git_index_add(VALUE self, VALUE rb_entry)
 
 	if (rb_obj_is_kind_of(rb_entry, rb_cRuggedIndexEntry)) {
 		Data_Get_Struct(rb_entry, git_index_entry, entry);
-		error = git_index_insert(index->index, entry);
+		error = git_index_add2(index->index, entry);
 	} else if (TYPE(rb_entry) == T_STRING) {
 		error = git_index_add(index->index, RSTRING_PTR(rb_entry), 0);
 	} else {


### PR DESCRIPTION
Rugged was choking on git_index_insert because of
https://github.com/libgit2/libgit2/commit/f7a5058aaf51635b3171eda182820a8f8c750060
Replaced git_index_insert with git_index_add2

Haven't touched C code in years, would happily fix if I've done something wrong.
