### PR TITLE
ignore the testrepo that gets created during `rake test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.bundle
 *.swp
 tmp/
+test/fixtures/testrepo.git


### PR DESCRIPTION
Just thought it would be nice to have this ignored since it isn't currently in the repo, and I don't think it is something that belongs.
