### PR TITLE
inspect method is called recursively

### DIFF
--- a/lib/rugged/commit.rb
+++ b/lib/rugged/commit.rb
@@ -2,7 +2,7 @@ module Rugged
   class Commit
 
     def inspect
-      "#<Rugged::Commit:#{object_id} {message: #{message.inspect}, tree: #{tree.inspect}, parents: #{parents.inspect}>"
+      "#<Rugged::Commit:#{object_id} {message: #{message.inspect}, tree: #{tree.inspect}, parents: #{parent_ids}>"
     end
 
     # The time when this commit was made effective. This is the same value
@@ -21,6 +21,10 @@ module Rugged
         :tree => tree,
         :parents => parents,
       }
+    end
+    
+    def parent_ids
+      parents.map { |parent| parent.oid }
     end
 
     def modify(new_args, update_ref=nil)


### PR DESCRIPTION
The original inspect will cause recursive calling of each parents' inspect untill the earliest
