### PR TITLE
Repository#file_at: don't throw an exception on nonexistent path

### DIFF
--- a/lib/rugged/repository.rb
+++ b/lib/rugged/repository.rb
@@ -62,6 +62,7 @@ module Rugged
       tree = Rugged::Commit.lookup(self, revision).tree
       subtree = tree.get_subtree(path)
       blob_data = subtree.get_entry(File.basename path)
+      return nil unless blob_data
       blob = Rugged::Blob.lookup(self, blob_data[:oid])
       blob.content
     end


### PR DESCRIPTION
If the path doesn't exist, trying to access blob_data[:oid] would
throw a NoMethodError. Check whether the file exists and return nil if
it doesn't instead.
