### PR TITLE
Implement tree#diff method

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -198,6 +198,11 @@ void Init_rugged()
 	rb_define_const(rb_mRugged, "SORT_DATE", INT2FIX(2));
 	rb_define_const(rb_mRugged, "SORT_REVERSE", INT2FIX(4));
 
+	rb_define_const(rb_mRugged, "GIT_STATUS_ADDED", INT2FIX(1));
+	rb_define_const(rb_mRugged, "GIT_STATUS_DELETED", INT2FIX(2));
+	rb_define_const(rb_mRugged, "GIT_STATUS_MODIFIED", INT2FIX(3));
+
+
 	/* Initialize libgit2 */
 	git_threads_init();
 

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -80,7 +80,7 @@ static inline void rugged_set_owner(VALUE object, VALUE owner)
 
 static inline VALUE rugged_owner(VALUE object)
 {
-	rb_iv_get(object, "@owner");
+	return rb_iv_get(object, "@owner");
 }
 
 static inline void rugged_exception_check(int errorcode)

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -216,8 +216,20 @@ static VALUE rb_git_tree_walk(VALUE self, VALUE rb_mode)
 
 static int rugged__treediff_cb(const git_tree_diff_data *ptr, void *proc)
 {
-	rb_funcall((VALUE)proc, rb_intern("call"), 1,
-		rugged_str_new2(ptr->path, NULL));
+	char old[GIT_OID_HEXSZ+1];
+	char new[GIT_OID_HEXSZ+1];
+
+	git_oid_tostr(new, GIT_OID_HEXSZ+1, &ptr->new_oid);
+	git_oid_tostr(old, GIT_OID_HEXSZ+1, &ptr->old_oid);
+
+	rb_funcall((VALUE)proc, rb_intern("call"), 6,
+		INT2FIX(ptr->old_attr),
+		INT2FIX(ptr->new_attr),
+		rugged_str_new2(old, NULL),
+		rugged_str_new2(new, NULL),
+		INT2FIX(ptr->status),
+		rugged_str_new2(ptr->path, NULL)
+		);
 
 	return GIT_SUCCESS;
 }

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -67,4 +67,17 @@ context "Rugged::Tree tests" do
     assert_equal 38, obj.read_raw.len
   end
 
+  test "can diff two sha1s" do
+    source = @repo.lookup('8496071c1b46c854b31185ea97743be6a8774479').tree
+    destination = @repo.lookup('36060c58702ed4c2a40832c51758d5344201d89a').tree
+    found = false
+    source.diff(destination) do |old_attribute, new_attribute, old_oid, new_oid, status, path|
+      if path == "new.txt"
+        found = true
+        assert_equal 'fa49b077972391ad58037050f2a75f74e3671e92', new_oid
+        assert_equal Rugged::GIT_STATUS_ADDED, status
+      end
+    end
+    assert_equal true, found
+  end
 end


### PR DESCRIPTION
Simple port of the C function in Ruby. I needed that for some project in-house so I've spend some time adding it to the library.

I've also added a simple test on the test repository.
