### PR TITLE
README: Rugged::Commit.create() example from rugged_commit.c docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,13 +161,14 @@ commit.parents
 You can also write new objects to the database this way:
 
 ```ruby
-person = Rugged::Signature.new('Scott', 'schacon@gmail.com', Time.now)
+author = {:email=>"tanoku@gmail.com", :time=>Time.now, :name=>"Vicent Mart\303\255"}
 
-commit = Rugged::Commit.new(repo)
-commit.message = "my message"
-commit.author = person
-commit.tree = commit
-commit.write
+Rugged::Commit.create(r,
+	:author => author,
+	:message => "Hello world\n\n",
+	:committer => author,
+	:parents => ["2cb831a8aea28b2c1b9c63385585b864e4d3bad1"],
+	:tree => some_tree) #=> "f148106ca58764adc93ad4e2d6b1d168422b9796"
 ```
 
 ### Tag Objects


### PR DESCRIPTION
The previous example using `Rugged::Commit.new(repo)` no longer worked, producing `ArgumentError: wrong number of arguments(1 for 2)`.

This example from [`rugged_commit.c`](https://github.com/libgit2/rugged/blob/40181a6fbeb8bbfedb843bc130a265090fa111bc/ext/rugged/rugged_commit.c#L197-225) works correctly, returning the new commit SHA1.
