### PR TITLE
Change :name key to :path in the README's Builder example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ You can also write trees with the `TreeBuilder`:
 
 ```ruby
 entry = {:type => :blob,
-         :name => "README.txt",
+         :path => "README.txt",
          :oid  => "1385f264afb75a56a5bec74243be9b367ba4ca08",
          :attributes => 33188}
 


### PR DESCRIPTION
In README.md, :name is described as the right key to use when building a tree.
However, when I pass that key, I get an exception from Builder#<<... something
along the lines of "invalid type nil, expecting String".

Looking at the C code, I see mention of "path" as a key, and passing my
path component in the :path slot fixes the problem.  (Note this is in
contrast to iterating through the entries of a tree object; in that case,
the key used is indeed :name.)

Change the docs to match what's working.
