### PR TITLE
"Fixing" a failing test in index_test.rb

### DIFF
--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -75,7 +75,7 @@ context "Rugged::Index reading stuff" do
   end
 
   test "can update entries" do
-    now = Time.now
+    now = Time.at Time.now.to_i
     e = @index.get_entry(0)
 
     e[:oid] = "12ea3153a78002a988bb92f4123e7e831fd1138a"


### PR DESCRIPTION
The test_can_update_entries was failing as follow:

```
$ ruby -I test test/index_test.rb -n test_can_update_entries
Run options: -n test_can_update_entries

# Running tests:

F

Finished tests in 0.006502s, 153.8041 tests/s, 153.8041 assertions/s.

  1) Failure:
test_can_update_entries(#<Class:0x0000000213fb80>) [test/index_test.rb:95]:
<{:path=>"README",
 :oid=>"12ea3153a78002a988bb92f4123e7e831fd1138a",
 :dev=>234881027,
 :ino=>88888,
 :mode=>33199,
 :gid=>502,
 :uid=>502,
 :file_size=>1000,
 :valid=>false,
 :stage=>3,
 :ctime=>2012-06-06 16:02:22 -0700,
 :mtime=>2012-06-06 16:02:22 -0700}> expected but was
<{:path=>"README",
 :oid=>"12ea3153a78002a988bb92f4123e7e831fd1138a",
 :dev=>234881027,
 :ino=>88888,
 :mode=>33199,
 :gid=>502,
 :uid=>502,
 :file_size=>1000,
 :valid=>false,
 :stage=>3,
 :ctime=>2012-06-06 16:02:22 -0700,
 :mtime=>2012-06-06 16:02:22 -0700}>.

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
```

This was caused by the fraction part of Time.now. I got rid of it by discarding the fractions in the original time.

References:
http://www.ruby-doc.org/core-1.9.3/Time.html
http://stackoverflow.com/questions/8763050/how-to-compare-time-in-ruby
