### PR TITLE
fix compiler warnings when using clang

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -42,7 +42,7 @@ const char *RUGGED_ERROR_NAMES[] = {
 	"IndexerError", /* GITERR_INDEXER, */
 };
 
-#define RUGGED_ERROR_COUNT ((sizeof(RUGGED_ERROR_NAMES)/sizeof(RUGGED_ERROR_NAMES[0])))
+#define RUGGED_ERROR_COUNT (int)((sizeof(RUGGED_ERROR_NAMES)/sizeof(RUGGED_ERROR_NAMES[0])))
 
 VALUE rb_mRugged;
 VALUE rb_eRuggedError;
@@ -67,7 +67,7 @@ static VALUE rb_git_hex_to_raw(VALUE self, VALUE hex)
 	Check_Type(hex, T_STRING);
 	rugged_exception_check(git_oid_fromstr(&oid, StringValueCStr(hex)));
 
-	return rugged_str_ascii(oid.id, 20);
+	return rugged_str_ascii((const char *)oid.id, 20);
 }
 
 /*
@@ -90,7 +90,7 @@ static VALUE rb_git_raw_to_hex(VALUE self, VALUE raw)
 	if (RSTRING_LEN(raw) != GIT_OID_RAWSZ)
 		rb_raise(rb_eTypeError, "Invalid buffer size for an OID");
 
-	git_oid_fromraw(&oid, RSTRING_PTR(raw));
+	git_oid_fromraw(&oid, (const unsigned char *)RSTRING_PTR(raw));
 	git_oid_fmt(out, &oid);
 
 	return rugged_str_new(out, 40, NULL);

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -80,7 +80,7 @@ static inline void rugged_set_owner(VALUE object, VALUE owner)
 
 static inline VALUE rugged_owner(VALUE object)
 {
-	rb_iv_get(object, "@owner");
+	return rb_iv_get(object, "@owner");
 }
 
 extern void rugged_exception_raise(int errorcode);
@@ -105,15 +105,9 @@ static inline int rugged_parse_bool(VALUE boolean)
 #	define rugged_str_new2(str, enc) rb_enc_str_new(str, strlen(str), enc)
 #	define rugged_str_ascii(str, len) rb_enc_str_new(str, len, rb_ascii8bit_encoding());
 
-static VALUE rugged_str_repoenc(const char *str, long len, VALUE rb_repo)
-{
-	VALUE rb_enc = rb_iv_get(rb_repo, "@encoding");
-	return rb_enc_str_new(str, len, NIL_P(rb_enc) ? NULL : rb_to_encoding(rb_enc));
-}
 #else
 #	define rugged_str_new(str, len, rb_enc)  rb_str_new(str, len)
 #	define rugged_str_new2(str, rb_enc) rb_str_new2(str)
-#	define rugged_str_repoenc(str, len, repo) rb_str_new(str, len)
 #	define rugged_str_ascii(str, len) rb_str_new(str, len)
 #endif
 

--- a/ext/rugged/rugged_blob.c
+++ b/ext/rugged/rugged_blob.c
@@ -23,6 +23,7 @@
  */
 
 #include "rugged.h"
+#include <ctype.h>
 
 extern VALUE rb_mRugged;
 extern VALUE rb_cRuggedObject;

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -173,7 +173,6 @@ static VALUE rb_git_commit_tree_oid_GET(VALUE self)
 {
 	git_commit *commit;
 	const git_oid *tree_oid;
-	int error;
 
 	Data_Get_Struct(self, git_commit, commit);
 
@@ -233,7 +232,6 @@ static VALUE rb_git_commit_parent_oids_GET(VALUE self)
 	const git_oid *parent_oid;
 	unsigned int n, parent_count;
 	VALUE ret_arr;
-	int error;
 
 	Data_Get_Struct(self, git_commit, commit);
 

--- a/ext/rugged/rugged_config.c
+++ b/ext/rugged/rugged_config.c
@@ -166,7 +166,6 @@ static VALUE rb_git_config_delete(VALUE self, VALUE rb_key)
 {
 	git_config *config;
 	int error;
-	VALUE result;
 
 	Data_Get_Struct(self, git_config, config);
 	Check_Type(rb_key, T_STRING);

--- a/ext/rugged/rugged_tag.c
+++ b/ext/rugged/rugged_tag.c
@@ -67,7 +67,6 @@ static VALUE rb_git_tag_target_oid_GET(VALUE self)
 {
 	git_tag *tag;
 	const git_oid *target_oid;
-	int error;
 
 	Data_Get_Struct(self, git_tag, tag);
 


### PR DESCRIPTION
This patch removes unused code, adds return keywords, and casts things so that clang won't emit warnings.
