### PR TITLE
adjust load path to avoid expand_path copy / paste.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,7 @@ task :cover do
 end
 
 Rake::TestTask.new do |t|
-  t.libs << 'lib'
+  t.libs << 'lib:test'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false
 end

--- a/test/blob_test.rb
+++ b/test/blob_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 
 context "Rugged::Blob tests" do
   setup do

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 
 context "Rugged::Commit tests" do
   setup do

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 
 context "Rugged::Config tests" do
   setup do

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 require 'base64'
 require 'tempfile'
 require 'fileutils'

--- a/test/lib_test.rb
+++ b/test/lib_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 require 'base64'
 
 context "Rugged::Lib stuff" do

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 require 'base64'
 
 context "Rugged::Object stuff" do

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 
 context "Rugged::Reference stuff" do
   setup do

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 
 context "Rugged::Tag tests" do
   setup do

--- a/test/repo_pack_test.rb
+++ b/test/repo_pack_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 require 'base64'
 
 context "Rugged::Repository packed stuff" do

--- a/test/repo_test.rb
+++ b/test/repo_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require 'test_helper'
 require 'base64'
 
 context "Rugged::Repository stuff" do

--- a/test/tag_test.rb
+++ b/test/tag_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 
 context "Rugged::Tag tests" do
   setup do

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 
 context "Rugged::Tree tests" do
   setup do

--- a/test/walker_test.rb
+++ b/test/walker_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path "../test_helper", __FILE__
+require "test_helper"
 require 'base64'
 
 context "Rugged::Walker stuff" do


### PR DESCRIPTION
Individual files must be run as:

  $ ruby -I lib:test test/whatever_test.rb

All tests:

  $ rake test
