### PR TITLE
Switch test base class to minitest/spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "http://rubygems.org"
 
 gem 'rake-compiler'
+gem 'minitest', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    minitest (3.0.1)
     rake (0.9.2.2)
     rake-compiler (0.7.9)
       rake
@@ -9,4 +10,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  minitest (~> 3.0.0)
   rake-compiler

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 context "Rugged::Config tests" do
   setup do
-    @repo = Rugged::Repository.new(test_repo('testrepo.git'))
+    @repo = Rugged::Repository.new(temp_repo('testrepo.git'))
   end
 
   test "can read the config file from repo" do


### PR DESCRIPTION
Switching base test class to minitest/spec so that test/spec/mini 3 can
be removed.  Method aliases keep backwards compatibility so that we
don't have to change every test file.
