### PR TITLE
Segfault due to missing error handling

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -199,16 +199,20 @@ void rugged_exception_raise(int errorcode)
 	VALUE err_klass = rb_eRuggedError;
 	VALUE err_obj;
 	const git_error *error;
+	const char *message;
 
 	error = giterr_last();
 
-	if (!error)
-		return;
-
-	if (error->klass >= 0 && error->klass < RUGGED_ERROR_COUNT)
+	if (error && error->klass >= 0 && error->klass < RUGGED_ERROR_COUNT)
 		err_klass = rb_eRuggedErrors[error->klass];
 
-	err_obj = rb_exc_new2(err_klass, error->message);
+	if (error)
+		message = error->message;
+	else
+		message = "The library returned an error without setting a message";
+
+	err_obj = rb_exc_new2(err_klass, message);
+
 	giterr_clear();
 	rb_exc_raise(err_obj);
 }


### PR DESCRIPTION
`rugged_exception_raise` does not handle all types of errors that can be returned by libgit.

E.g. if you don't have a global .gitconfig file and run the tests, you will see a segfault happening. This is due to the fact that `git_config_open_global` can't find a .gitconfig file, and correctly returns `-3`, but does not set any git error (so `giterr_last` will return nothing).

Now, rugged's `rugged_exception_raise` simply ignores any errors when giterr_last() is not set, which causes the segfault later on when trying to read a value from the global config.

What'd be the best way to tackle this?
