### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ tree.count
 tree[0]           # or...
 tree.first        # or...
 tree.get_entry(0)
-# => {:type=>:blob, :oid=>"99e7edb53db9355f10c6f2dfaa5a183f205d93bf", :attributes=>33188, :name=>".gitignore"}
+# => {:type=>:blob, :oid=>"99e7edb53db9355f10c6f2dfaa5a183f205d93bf", :filemode=>33188, :name=>".gitignore"}
 ```
 
 The tree object is an Enumerable, so you can also do stuff like this:
@@ -219,7 +219,7 @@ You can also write trees with the `TreeBuilder`:
 entry = {:type => :blob,
          :name => "README.txt",
          :oid  => "1385f264afb75a56a5bec74243be9b367ba4ca08",
-         :attributes => 33188}
+         :filemode => 33188}
 
 builder = Rugged::Tree::Builder.new
 builder << entry


### PR DESCRIPTION
Readme incorrectly stated the `:attributes` key has to be used in the `Rugged::Tree::Builder`. However:

``` ruby
builder = Rugged::Tree::Builder.new
builder << {:type => :blob, :name => "README.txt", :oid => new_blob, :attributes => 33188} # => TypeError: wrong argument type nil (expected Fixnum)
builder << {:type => :blob, :name => "README.txt", :oid => new_blob, :filemode => 33188} # => nil
```

I updated the readme. It also seems that `:attributes` in the other place is incorrect. It's `:filemode` everywhere.
