### PR TITLE
tree_test: remove loose tree left in the fixture

### DIFF
--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 context "Rugged::Tree tests" do
   setup do
-    path = File.dirname(__FILE__) + '/fixtures/testrepo.git/'
-    @repo = Rugged::Repository.new(path)
+    @path = File.dirname(__FILE__) + '/fixtures/testrepo.git/'
+    @repo = Rugged::Repository.new(@path)
     @oid = "c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b"
     @tree = @repo.lookup(@oid)
   end
@@ -65,6 +65,8 @@ context "Rugged::Tree tests" do
     sha = builder.write(@repo)
     obj = @repo.lookup(sha)
     assert_equal 38, obj.read_raw.len
+
+    rm_loose(sha)
   end
 
 end


### PR DESCRIPTION
A tree with OID 7f043268ea43ce18e3540acaabf9e090c91965b0
was present in the testrepo.git fixture after a test run.
Now the repo should remain in the same state as when the tests
started.
