### PR TITLE
index: add stats to git_indexer_run call

### DIFF
--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -330,6 +330,7 @@ static VALUE rb_git_indexer(VALUE self, VALUE rb_packfile_path)
 {
 	int error;
 	git_indexer *indexer;
+	git_transfer_progress stats;
 	VALUE rb_oid;
 
 	Check_Type(rb_packfile_path, T_STRING);
@@ -337,7 +338,7 @@ static VALUE rb_git_indexer(VALUE self, VALUE rb_packfile_path)
 	error = git_indexer_new(&indexer, StringValueCStr(rb_packfile_path));
 	rugged_exception_check(error);
 
-	error = git_indexer_run(indexer, NULL);
+	error = git_indexer_run(indexer, &stats);
 	rugged_exception_check(error);
 
 	error = git_indexer_write(indexer);

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -22,7 +22,8 @@ end
 
 context "Rugged::Index reading stuff" do
   setup do
-    path = File.dirname(__FILE__) + '/fixtures/testrepo.git/index'
+    @repo_path = File.dirname(__FILE__) + '/fixtures/testrepo.git/'
+    path = @repo_path + 'index'
     @index = Rugged::Index.new(path)
   end
 
@@ -102,6 +103,12 @@ context "Rugged::Index reading stuff" do
     itr_test = @index.sort { |a, b| a[:oid] <=> b[:oid] }.map { |x| x[:path] }.join(':')
     assert_equal "README:new_path:new.txt", itr_test
   end
+
+  test "can read the index from a packfile" do
+    pack_path = @repo_path + 'objects/pack/pack-d7c6adf9f61318f041845b01440d09aa7a91e1b5.pack'
+    assert_equal 'd7c6adf9f61318f041845b01440d09aa7a91e1b5', Rugged::Index.index_pack(pack_path)
+  end
+
 end
 
 context "Rugged::Index writing stuff" do


### PR DESCRIPTION
Apparenly git_indexer_run requires stats to be passed. This fixes:
src/indexer.c:812: git_indexer_run: Assertion `idx && stats' failed.
