### PR TITLE
Allow rbx 1.9 mode to fail on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ rvm:
   - 1.8.7
   - 1.9.3
   - rbx-18mode
-#  - rbx-19mode
+matrix:
+ allow_failures:
+   - rvm: rbx-19mode
 
 # We need the config so the tests don't fail
 script:


### PR DESCRIPTION
As part of the drive in rubinius/rubinius#2006
Trying to get gems with C-extensions to test on Rubinius.

Gracias
