### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 1.8.7
   - 1.9.3
   - rbx-18mode
+  - rbx-19mode
 matrix:
  allow_failures:
    - rvm: rbx-19mode


### PR DESCRIPTION
Do run Rubinius 1.9 mode

The previous commit added rbx 1.9 to the allowed failures, but didn't actually enable running
