### PR TITLE
Add `:update_ref` to the example Rugged::Commit.create code in the READM...

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ Rugged::Commit.create(r,
 	:message => "Hello world\n\n",
 	:committer => author,
 	:parents => ["2cb831a8aea28b2c1b9c63385585b864e4d3bad1"],
-	:tree => some_tree) #=> "f148106ca58764adc93ad4e2d6b1d168422b9796"
+	:tree => some_tree,
+	:update_ref => "HEAD") #=> "f148106ca58764adc93ad4e2d6b1d168422b9796"
 ```
 
 ### Tag Objects


### PR DESCRIPTION
I thought this slight change to the example code in the README might help people like me to save some time in the future. It took me hours (slightly ashamed to admit this!) to figure out why I couldn't get Rugged to create a commit.

Eventually it turned out that somebody else had been through a similar experience, and thankfully they wrote a [blog post](http://jeffwelling.github.com/2012/09/26/How-to-commit-with-rugged.html) about it which explains it better than I could.

> The :update_ref option to the Commit.create command isn’t documented in the README on the Rugged Github page, but if it documented in the comments in the ext/rugged_commit.c file in the Github repository, and I’ve tested using it. The catch is that without that, the commit will be created and written to the ODB but no reference will be updated so it will appear to most people that Commit.create is broken because they can’t see it on any of their branches.

On that basis, I thought it might be nice to add the `:update_ref` parameter to the example code in the README. What say you?
