### PR TITLE
Test error conditions for the raw and hex conversion method

### DIFF
--- a/test/lib_test.rb
+++ b/test/lib_test.rb
@@ -33,7 +33,7 @@ class RuggedTest < Rugged::TestCase
 
   def test_hex_to_raw_with_invalid_character_raises_invalid_error
     assert_raises Rugged::InvalidError do
-      Rugged::hex_to_raw("\x16\xA0\x124VWATx\x9A\xBC\xDE\xF4") # invalid characters
+      Rugged::hex_to_raw("\x16\xA0\x124VWATx\x9A\xBC\xDE\xF4") # invalid bytes
     end
   end
 


### PR DESCRIPTION
This adds two new tests that confirm the correct behavior for `raw_to_hex` and `hex_to_raw` when given certain invalid input.

cc @vmg
