### PR TITLE
Test #minimize_oid

### DIFF
--- a/test/lib_test.rb
+++ b/test/lib_test.rb
@@ -61,7 +61,7 @@ class RuggedTest < Rugged::TestCase
 
   def test_minimize_oid_with_block
     minimized_oids = []
-    Rugged.minimize_oid(@@oids) { |oid| minimized_oids << oid }
+    Rugged::minimize_oid(@@oids) { |oid| minimized_oids << oid }
     expected_oids = [
       "d8786bfc974a",
       "d8786bfc974b",


### PR DESCRIPTION
Adds three tests for the `minimize_oid` method.

Here we are testing it: plain, with a minimum length argument, with a block.
