### PR TITLE
Look for time_offset in rugged_signature_get

### DIFF
--- a/ext/rugged/rugged_signature.c
+++ b/ext/rugged/rugged_signature.c
@@ -2,17 +2,17 @@
  * The MIT License
  *
  * Copyright (c) 2013 GitHub, Inc
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -51,7 +51,7 @@ VALUE rugged_signature_new(const git_signature *sig, const char *encoding_name)
 git_signature *rugged_signature_get(VALUE rb_sig)
 {
 	int error;
-	VALUE rb_time, rb_unix_t, rb_offset, rb_name, rb_email;
+	VALUE rb_time, rb_unix_t, rb_offset, rb_name, rb_email, rb_time_offset;
 	git_signature *sig;
 
 	Check_Type(rb_sig, T_HASH);
@@ -59,6 +59,7 @@ git_signature *rugged_signature_get(VALUE rb_sig)
 	rb_name = rb_hash_aref(rb_sig, CSTR2SYM("name"));
 	rb_email = rb_hash_aref(rb_sig, CSTR2SYM("email"));
 	rb_time = rb_hash_aref(rb_sig, CSTR2SYM("time"));
+	rb_time_offset = rb_hash_aref(rb_sig, CSTR2SYM("time_offset"));
 
 	Check_Type(rb_name, T_STRING);
 	Check_Type(rb_email, T_STRING);
@@ -66,7 +67,13 @@ git_signature *rugged_signature_get(VALUE rb_sig)
 		rb_raise(rb_eTypeError, "expected Time object");
 
 	rb_unix_t = rb_funcall(rb_time, rb_intern("tv_sec"), 0);
-	rb_offset = rb_funcall(rb_time, rb_intern("utc_offset"), 0);
+
+	if (NIL_P(rb_time_offset)) {
+		rb_offset = rb_funcall(rb_time, rb_intern("utc_offset"), 0);
+	} else {
+		Check_Type(rb_time_offset, T_FIXNUM);
+		rb_offset = rb_time_offset;
+	}
 
 	error = git_signature_new(&sig,
 		StringValueCStr(rb_name),

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -54,7 +54,7 @@ end
 class CommitWriteTest < Rugged::TestCase
   include Rugged::TempRepositoryAccess
 
-  def test_write_a_commit 
+  def test_write_a_commit
     person = {:name => 'Scott', :email => 'schacon@gmail.com', :time => Time.now }
 
     Rugged::Commit.create(@repo,
@@ -63,5 +63,19 @@ class CommitWriteTest < Rugged::TestCase
       :author => person,
       :parents => [@repo.head.target],
       :tree => "c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b")
+  end
+
+  def test_write_commit_with_time_offset
+    person = {:name => 'Jake', :email => 'jake@github.com', :time => Time.now, :time_offset => 3600}
+
+    oid = Rugged::Commit.create(@repo,
+      :message => "This is the commit message\n\nThis commit is created from Rugged",
+      :committer => person,
+      :author => person,
+      :parents => [@repo.head.target],
+      :tree => "c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b")
+
+    commit = @repo.lookup(oid)
+    assert_equal 3600, commit.committer[:time_offset]
   end
 end


### PR DESCRIPTION
Right now, `rugged_signature_get` ignores the `time_offset` attribute. This branch changes it so that it tries to use the `time_offset` attribute, and falls back on the time's `utc_offset` attribute if it's `nil`.
