### PR TITLE
Toggle raw types for signatures

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -50,6 +50,27 @@ VALUE rb_eRuggedErrors[RUGGED_ERROR_COUNT];
 
 static VALUE rb_mShutdownHook;
 
+/* Enable or disable the generation of raw types instead of
+ * complex types. This is useful when running Ruby in a high
+ * performance setting.
+ *
+ * The following types are affected:
+ *
+ * - `time` on signatures will be returned as an integer
+ * instead of a Time object.
+ */
+int rugged_raw_types = 0;
+
+static VALUE rb_rugged_raw_types_get(VALUE self)
+{
+	return rugged_raw_types ? Qtrue : Qfalse;
+}
+
+static VALUE rb_rugged_raw_types_set(VALUE self, VALUE val)
+{
+	rugged_raw_types = rugged_parse_bool(val);
+}
+
 /*
  *	call-seq:
  * 		Rugged.libgit2_version -> version
@@ -340,6 +361,9 @@ void Init_rugged()
 	rb_define_const(rb_mRugged, "SORT_TOPO", INT2FIX(1));
 	rb_define_const(rb_mRugged, "SORT_DATE", INT2FIX(2));
 	rb_define_const(rb_mRugged, "SORT_REVERSE", INT2FIX(4));
+ 
+	rb_define_singleton_method(rb_mRugged, "raw_types", rb_rugged_raw_types_get, 0);
+	rb_define_singleton_method(rb_mRugged, "raw_types=", rb_rugged_raw_types_set, 1);
 
 	/* Initialize libgit2 */
 	git_threads_init();

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -60,6 +60,8 @@ void Init_rugged_remote();
 void Init_rugged_notes();
 void Init_rugged_settings();
 
+extern int rugged_raw_types;
+
 VALUE rb_git_object_init(git_otype type, int argc, VALUE *argv, VALUE self);
 
 VALUE rugged_raw_read(git_repository *repo, const git_oid *oid);


### PR DESCRIPTION
They say an IRB session is worth a thousand words:

```
irb(main):008:0> commit = Rugged::Commit.lookup(repo, h.target)
=> #<Rugged::Commit:69881584773740 ...?
irb(main):009:0> commit.author
=> {:email=>"vicent@github.com", :name=>"Vicent Mart\303\255", :time_offset=>-28800, :time=>Sat Feb 23 12:39:11 +0100 2013}
irb(main):010:0> Rugged.raw_types = true
=> true
irb(main):011:0> commit.author
=> {:email=>"vicent@github.com", :name=>"Vicent Mart\303\255", :time_offset=>-28800, :time=>1361619551}
irb(main):012:0> 
```

/cc @rtomayko
