### PR TITLE
fix memory leak when passing invalid parents type to Commit.create

### DIFF
--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -277,6 +277,7 @@ static VALUE rb_git_commit_parent_ids_GET(VALUE self)
 static VALUE rb_git_commit_create(VALUE self, VALUE rb_repo, VALUE rb_data)
 {
 	VALUE rb_message, rb_tree, rb_parents, rb_ref;
+	VALUE err_obj = Qnil;
 	int parent_count, i, error;
 	const git_commit **parents = NULL;
 	git_commit **free_list = NULL;
@@ -343,7 +344,8 @@ static VALUE rb_git_commit_create(VALUE self, VALUE rb_repo, VALUE rb_data)
 		} else if (rb_obj_is_kind_of(p, rb_cRuggedCommit)) {
 			Data_Get_Struct(p, git_commit, parent);
 		} else {
-			rb_raise(rb_eTypeError, "Invalid type for parent object");
+			err_obj = rb_exc_new2(rb_eTypeError, "Invalid type for parent object");
+			goto cleanup;
 		}
 
 		parents[parent_count] = parent;
@@ -374,6 +376,10 @@ cleanup:
 
 	xfree(parents);
 	xfree(free_list);
+
+	if (!NIL_P(err_obj))
+		rb_exc_raise(err_obj);
+
 	rugged_exception_check(error);
 
 	return rugged_create_oid(&commit_oid);

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -78,4 +78,17 @@ class CommitWriteTest < Rugged::TestCase
     commit = @repo.lookup(oid)
     assert_equal 3600, commit.committer[:time_offset]
   end
+
+  def test_write_invalid_parents
+    person = {:name => 'Jake', :email => 'jake@github.com', :time => Time.now, :time_offset => 3600}
+
+    assert_raises TypeError do
+      Rugged::Commit.create(@repo,
+        :message => "This is the commit message\n\nThis commit is created from Rugged",
+        :committer => person,
+        :author => person,
+        :parents => [:invalid_parent],
+        :tree => "c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b")
+    end
+  end
 end


### PR DESCRIPTION
Passing invalid parents type to Commit.create just raises
an exception without freeing the allocated signatures,
arrays and tree obj.
