### PR TITLE
fix couple of compilation warnings

### DIFF
--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -174,8 +174,6 @@ static void load_alternates(git_repository *repo, VALUE rb_alternates)
 
 static void set_repository_options(git_repository *repo, VALUE rb_options)
 {
-	int error = 0;
-
 	if (NIL_P(rb_options))
 		return;
 


### PR DESCRIPTION
```
../rugged_repo.c:1080:1: warning: control reaches end of non-void function [-Wreturn-type]
../rugged_repo.c:177:6: warning: unused variable ‘error’ [-Wunused-variable]
```
