### PR TITLE
Init libgit2 submodule if missing

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -30,6 +30,11 @@ else
   LIBGIT2_LIB_PATH = "#{CWD}/libgit2_embed.a"
 
   if !File.exists?(LIBGIT2_LIB_PATH)
+    if !File.exists?(File.join(LIBGIT2_DIR, "Makefile.embed")) and File.exists?(File.join(CWD, '..', '..', '.git'))
+      Dir.chdir(File.join(CWD, '..', '..')) do
+        sys("git submodule update --init")
+      end
+    end
     Dir.chdir(LIBGIT2_DIR) do
       sys("#{MAKE_PROGRAM} -f Makefile.embed")
       FileUtils.cp 'libgit2.a', LIBGIT2_LIB_PATH


### PR DESCRIPTION
When I use the git repository in a bundler Gemfile like this:

```
gem 'rugged', git: 'git://github.com/libgit2/rugged.git', branch: 'development'
```

It fails because it can't find `Makefile.embed`.

I made `extconf.rb` initialize the libgit2 submodule in this case.
