### PR TITLE
Fix potential crash in peel when the ref is symbolic

### DIFF
--- a/ext/rugged/rugged_reference.c
+++ b/ext/rugged/rugged_reference.c
@@ -155,7 +155,8 @@ static VALUE rb_git_ref_peel(VALUE self)
 	else
 		rugged_exception_check(error);
 
-	if (!git_oid_cmp(git_object_id(object), git_reference_target(ref))) {
+	if (git_reference_type(ref) == GIT_REF_OID &&
+			!git_oid_cmp(git_object_id(object), git_reference_target(ref))) {
 		git_object_free(object);
 		return Qnil;
 	} else {

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -37,6 +37,17 @@ class ReferenceTest < Rugged::TestCase
     assert_nil ref.peel
   end
 
+  def test_can_open_a_symbolic_reference
+    ref = Rugged::Reference.lookup(@repo, "HEAD")
+    assert_equal "refs/heads/master", ref.target
+    assert_equal :symbolic, ref.type
+
+    resolved = ref.resolve
+    assert_equal :direct, resolved.type
+    assert_equal "36060c58702ed4c2a40832c51758d5344201d89a", resolved.target
+    assert_equal resolved.target, ref.peel
+  end
+
   def test_looking_up_missing_ref_returns_nil
     ref = Rugged::Reference.lookup(@repo, "lol/wut")
     assert_equal nil, ref


### PR DESCRIPTION
If the original reference we're peeling was symbolic, Rugged would crash in `git_oid_cmp` because `git_reference_target` would return nil as the right side. So if the reference is symbolic, skip the oid comparison since we'd have to resolve it down to the same value `git_reference_peel` is handing us anyway.
