### PR TITLE
Fix compiler warnings

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -272,7 +272,7 @@ static void cleanup_cb(void *unused)
 	git_threads_shutdown();
 }
 
-void rugged_exception_raise()
+void rugged_exception_raise(void)
 {
 	VALUE err_klass, err_obj;
 	const git_error *error;
@@ -321,7 +321,7 @@ VALUE rugged_strarray_to_rb_ary(git_strarray *str_array)
 	return rb_array;
 }
 
-void Init_rugged()
+void Init_rugged(void)
 {
 	rb_mRugged = rb_define_module("Rugged");
 

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -45,25 +45,25 @@
 /*
  * Initialization functions
  */
-void Init_rugged_object();
-void Init_rugged_branch();
-void Init_rugged_commit();
-void Init_rugged_tree();
-void Init_rugged_tag();
-void Init_rugged_blob();
-void Init_rugged_index();
-void Init_rugged_repo();
-void Init_rugged_revwalk();
-void Init_rugged_reference();
-void Init_rugged_config();
-void Init_rugged_remote();
-void Init_rugged_notes();
-void Init_rugged_settings();
-void Init_rugged_diff();
-void Init_rugged_diff_patch();
-void Init_rugged_diff_delta();
-void Init_rugged_diff_hunk();
-void Init_rugged_diff_line();
+void Init_rugged_object(void);
+void Init_rugged_branch(void);
+void Init_rugged_commit(void);
+void Init_rugged_tree(void);
+void Init_rugged_tag(void);
+void Init_rugged_blob(void);
+void Init_rugged_index(void);
+void Init_rugged_repo(void);
+void Init_rugged_revwalk(void);
+void Init_rugged_reference(void);
+void Init_rugged_config(void);
+void Init_rugged_remote(void);
+void Init_rugged_notes(void);
+void Init_rugged_settings(void);
+void Init_rugged_diff(void);
+void Init_rugged_diff_patch(void);
+void Init_rugged_diff_delta(void);
+void Init_rugged_diff_hunk(void);
+void Init_rugged_diff_line(void);
 
 VALUE rb_git_object_init(git_otype type, int argc, VALUE *argv, VALUE self);
 
@@ -103,7 +103,7 @@ static inline VALUE rugged_owner(VALUE object)
 	return rb_iv_get(object, "@owner");
 }
 
-extern void rugged_exception_raise();
+extern void rugged_exception_raise(void);
 
 static inline void rugged_exception_check(int errorcode)
 {

--- a/ext/rugged/rugged_blob.c
+++ b/ext/rugged/rugged_blob.c
@@ -384,7 +384,7 @@ static VALUE rb_git_blob_is_binary(VALUE self)
 	return git_blob_is_binary(blob) ? Qtrue : Qfalse;
 }
 
-void Init_rugged_blob()
+void Init_rugged_blob(void)
 {
 	id_read = rb_intern("read");
 

--- a/ext/rugged/rugged_branch.c
+++ b/ext/rugged/rugged_branch.c
@@ -303,7 +303,7 @@ static VALUE rb_git_branch_head_p(VALUE self)
 	return git_branch_is_head(branch) ? Qtrue : Qfalse;
 }
 
-void Init_rugged_branch()
+void Init_rugged_branch(void)
 {
 	rb_cRuggedBranch = rb_define_class_under(rb_mRugged, "Branch", rb_cRuggedReference);
 

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -382,7 +382,7 @@ cleanup:
 	return rugged_create_oid(&commit_oid);
 }
 
-void Init_rugged_commit()
+void Init_rugged_commit(void)
 {
 	rb_cRuggedCommit = rb_define_class_under(rb_mRugged, "Commit", rb_cRuggedObject);
 

--- a/ext/rugged/rugged_config.c
+++ b/ext/rugged/rugged_config.c
@@ -302,7 +302,7 @@ static VALUE rb_git_config_open_default(VALUE klass)
 	return rugged_config_new(klass, Qnil, cfg);
 }
 
-void Init_rugged_config()
+void Init_rugged_config(void)
 {
 	/*
 	 * Config

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -494,7 +494,7 @@ static VALUE rb_git_diff_size(VALUE self)
 	return INT2FIX(git_diff_num_deltas(diff));
 }
 
-void Init_rugged_diff()
+void Init_rugged_diff(void)
 {
 	rb_cRuggedDiff = rb_define_class_under(rb_mRugged, "Diff", rb_cObject);
 

--- a/ext/rugged/rugged_diff_delta.c
+++ b/ext/rugged/rugged_diff_delta.c
@@ -88,7 +88,7 @@ VALUE rugged_diff_delta_new(VALUE owner, const git_diff_delta *delta)
 	return rb_delta;
 }
 
-void Init_rugged_diff_delta()
+void Init_rugged_diff_delta(void)
 {
 	rb_cRuggedDiffDelta = rb_define_class_under(rb_cRuggedDiff, "Delta", rb_cObject);
 }

--- a/ext/rugged/rugged_diff_hunk.c
+++ b/ext/rugged/rugged_diff_hunk.c
@@ -92,7 +92,7 @@ static VALUE rb_git_diff_hunk_each_line(VALUE self)
 	return self;
 }
 
-void Init_rugged_diff_hunk()
+void Init_rugged_diff_hunk(void)
 {
 	rb_cRuggedDiffHunk = rb_define_class_under(rb_cRuggedDiff, "Hunk", rb_cObject);
 

--- a/ext/rugged/rugged_diff_line.c
+++ b/ext/rugged/rugged_diff_line.c
@@ -73,7 +73,7 @@ VALUE rugged_diff_line_new(
 	return rb_line;
 }
 
-void Init_rugged_diff_line()
+void Init_rugged_diff_line(void)
 {
 	rb_cRuggedDiffLine = rb_define_class_under(rb_cRuggedDiff, "Line", rb_cObject);
 }

--- a/ext/rugged/rugged_diff_patch.c
+++ b/ext/rugged/rugged_diff_patch.c
@@ -154,7 +154,7 @@ static VALUE rb_git_diff_patch_context(VALUE self)
 	return INT2FIX(context);
 }
 
-void Init_rugged_diff_patch()
+void Init_rugged_diff_patch(void)
 {
 	rb_cRuggedDiffPatch = rb_define_class_under(rb_cRuggedDiff, "Patch", rb_cObject);
 

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -681,7 +681,7 @@ static VALUE rb_git_index_conflicts_p(VALUE self)
  *    A Time instance representing the index entry's time of last status change
  *    (ie. change of owner, group, mode, etc.).
  */
-void Init_rugged_index()
+void Init_rugged_index(void)
 {
 	/*
 	 * Index

--- a/ext/rugged/rugged_note.c
+++ b/ext/rugged/rugged_note.c
@@ -361,7 +361,7 @@ static VALUE rb_git_note_default_ref_GET(VALUE self)
 	return rugged_str_new2(ref_name, NULL);
 }
 
-void Init_rugged_notes()
+void Init_rugged_notes(void)
 {
 	rb_define_method(rb_cRuggedObject, "notes", rb_git_note_lookup, -1);
 	rb_define_method(rb_cRuggedObject, "create_note", rb_git_note_create, 1);

--- a/ext/rugged/rugged_object.c
+++ b/ext/rugged/rugged_object.c
@@ -368,7 +368,7 @@ static VALUE rb_git_object_read_raw(VALUE self)
 	return rugged_raw_read(git_object_owner(object), git_object_id(object));
 }
 
-void Init_rugged_object()
+void Init_rugged_object(void)
 {
 	rb_cRuggedObject = rb_define_class_under(rb_mRugged, "Object", rb_cObject);
 	rb_define_singleton_method(rb_cRuggedObject, "lookup", rb_git_object_lookup, 2);

--- a/ext/rugged/rugged_reference.c
+++ b/ext/rugged/rugged_reference.c
@@ -644,7 +644,7 @@ static VALUE rb_git_ref_is_remote(VALUE self)
 	return git_reference_is_remote(ref) ? Qtrue : Qfalse;
 }
 
-void Init_rugged_reference()
+void Init_rugged_reference(void)
 {
 	rb_cRuggedReference = rb_define_class_under(rb_mRugged, "Reference", rb_cObject);
 

--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -708,7 +708,7 @@ static VALUE rb_git_remote_rename(VALUE self, VALUE rb_new_name)
 	return RARRAY_LEN(rb_refspec_ary) == 0 ? Qnil : rb_refspec_ary;
 }
 
-void Init_rugged_remote()
+void Init_rugged_remote(void)
 {
 	rb_cRuggedRemote = rb_define_class_under(rb_mRugged, "Remote", rb_cObject);
 

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -1342,7 +1342,7 @@ static VALUE rb_git_repo_ahead_behind(VALUE self, VALUE rb_local, VALUE rb_upstr
 	return rb_result;
 }
 
-void Init_rugged_repo()
+void Init_rugged_repo(void)
 {
 	id_call = rb_intern("call");
 

--- a/ext/rugged/rugged_revwalk.c
+++ b/ext/rugged/rugged_revwalk.c
@@ -198,7 +198,7 @@ static VALUE rb_git_walker_reset(VALUE self)
 	return Qnil;
 }
 
-void Init_rugged_revwalk()
+void Init_rugged_revwalk(void)
 {
 	rb_cRuggedWalker = rb_define_class_under(rb_mRugged, "Walker", rb_cObject);
 	rb_define_singleton_method(rb_cRuggedWalker, "new", rb_git_walker_new, 1);

--- a/ext/rugged/rugged_settings.c
+++ b/ext/rugged/rugged_settings.c
@@ -100,7 +100,7 @@ static VALUE rb_git_get_option(VALUE self, VALUE option)
 	}
 }
 
-void Init_rugged_settings()
+void Init_rugged_settings(void)
 {
 	VALUE rb_cRuggedSettings = rb_define_class_under(rb_mRugged, "Settings", rb_cObject);
 	rb_define_module_function(rb_cRuggedSettings, "[]=", rb_git_set_option, 2);

--- a/ext/rugged/rugged_tag.c
+++ b/ext/rugged/rugged_tag.c
@@ -334,7 +334,7 @@ static VALUE rb_git_tag_delete(VALUE self, VALUE rb_repo, VALUE rb_name)
 	return Qnil;
 }
 
-void Init_rugged_tag()
+void Init_rugged_tag(void)
 {
 	rb_cRuggedTag = rb_define_class_under(rb_mRugged, "Tag", rb_cRuggedObject);
 

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -658,7 +658,7 @@ static VALUE rb_git_treebuilder_filter(VALUE self)
 	return Qnil;
 }
 
-void Init_rugged_tree()
+void Init_rugged_tree(void)
 {
 	/*
 	 * Tree


### PR DESCRIPTION
Fix a two compiler warnings and remove an unused parameter in `rugged_exception_raise`.
