### PR TITLE
Add a minimum required ruby version to the gemspec.

### DIFF
--- a/rugged.gemspec
+++ b/rugged.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.homepage              = "http://github.com/libgit2/rugged"
   s.email                 = "schacon@gmail.com"
   s.authors               = [ "Scott Chacon", "Vicent Marti" ]
+  s.license               = "MIT"
   s.files                 = %w( README.md Rakefile LICENSE )
   s.files                 += Dir.glob("lib/**/*.rb")
   s.files                 += Dir.glob("man/**/*")


### PR DESCRIPTION
Just to make sure noone tries to install rugged on some unsupported ruby versions.
