### PR TITLE
Make native extension building more robust

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -10,47 +10,16 @@ if RbConfig::MAKEFILE_CONFIG['CC'] =~ /gcc|clang/
   $CFLAGS << " -Wall"
 end
 
-def sys(cmd)
-  puts " -- #{cmd}"
-  unless ret = xsystem(cmd)
-    raise "ERROR: '#{cmd}' failed"
-  end
-  ret
-end
-
 MAKE_PROGRAM = find_executable('gmake') || find_executable('make')
 
 if MAKE_PROGRAM.nil?
-  STDERR.puts "ERROR: GNU make is required to build Rugged"
-  exit(1)
+  abort 'GNU make is required to build Rugged'
 end
 
-if p = ENV['LIBGIT2_PATH']
-  $INCFLAGS[0,0] = " -I#{File.join(p, 'include')} "
-  $LDFLAGS << " -L#{p} "
-  unless have_library 'git2' and have_header 'git2.h'
-    STDERR.puts "ERROR: Invalid `LIBGIT2_PATH` environment"
-    exit(1)
-  end
-else
-  CWD = File.expand_path(File.dirname(__FILE__))
-  LIBGIT2_DIR = File.join(CWD, '..', '..', 'vendor', 'libgit2')
-  LIBGIT2_LIB_PATH = "#{CWD}/libgit2_embed.a"
+dir_config('libgit2')
 
-  if !File.exists?(LIBGIT2_LIB_PATH)
-    Dir.chdir(LIBGIT2_DIR) do
-      sys("#{MAKE_PROGRAM} -f Makefile.embed")
-      FileUtils.cp 'libgit2.a', LIBGIT2_LIB_PATH
-    end
-  end
-
-  $INCFLAGS[0,0] = " -I#{LIBGIT2_DIR}/include "
-  $LDFLAGS << " -L#{CWD} "
-
-  unless have_library 'git2_embed' and have_header 'git2.h'
-    STDERR.puts "ERROR: Failed to build libgit2"
-    exit(1)
-  end
+unless have_library 'git2' and have_header 'git2.h'
+  abort 'libgit2 is missing.  please install libgit2'
 end
 
 create_makefile("rugged/rugged")

--- a/rugged.gemspec
+++ b/rugged.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |s|
   s.files                 += Dir.glob("man/**/*")
   s.files                 += Dir.glob("test/**/*")
   s.files                 += Dir.glob("ext/**/*.[ch]")
-  s.files                 += Dir.glob("vendor/libgit2/{include,src,deps}/**/*.[ch]")
+  s.files                 += Dir.glob("vendor/libgit2/{include,src,deps}/**/*.{c,h,rb}")
   s.files                 += Dir.glob("vendor/libgit2/Makefile.embed")
   s.extensions            = ['ext/rugged/extconf.rb']
+  s.require_paths         = [ 'lib', 'ext' ]
   s.required_ruby_version = '>= 1.9.3'
   s.description           = <<desc
 Rugged is a Ruby bindings to the libgit2 linkable C Git library. This is


### PR DESCRIPTION
Changed gemspec to include proper directives for the native extension library so
that it can be found on every platform.

Removed the dependency on having libgit2 built in vendor/bundle and instead
provided --with-libgit2-{dir,include,lib} build options with dir_config in
extconf.rb. If libgit2 is installed system wide it will be found in the normal
directories, if it is installde in a non-standard location the location can be
supplide with the new build options. When desired libgit2 can be built
statically in any location, the new build options can then be used to specify
the static version to be preferred over any system version.

The new build options can be supplied to extconf.rb directly, to gem install
with e.g. gem install rugged -- --with-libgit2-include=vendor/libgit2/include
--with-libgit2-lib=vendor/libgit2/build or to bundle config with e.g. bundle
config rugged.build --with-libgit2-dir=/opt/libgit2
