### PR TITLE
use rugged_check_repo everywhere

### DIFF
--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -286,8 +286,7 @@ static VALUE rb_git_commit_create(VALUE self, VALUE rb_repo, VALUE rb_data)
 
 	Check_Type(rb_data, T_HASH);
 
-	if (!rb_obj_is_kind_of(rb_repo, rb_cRuggedRepo))
-		rb_raise(rb_eTypeError, "Expecting a Rugged::Repository instance");
+	rugged_check_repo(rb_repo);
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	rb_ref = rb_hash_aref(rb_data, CSTR2SYM("update_ref"));

--- a/ext/rugged/rugged_reference.c
+++ b/ext/rugged/rugged_reference.c
@@ -56,8 +56,7 @@ static VALUE rb_git_ref__each(int argc, VALUE *argv, VALUE self, int only_names)
 			rb_repo, rb_glob);
 	}
 
-	if (!rb_obj_is_kind_of(rb_repo, rb_cRuggedRepo))
-		rb_raise(rb_eTypeError, "Expecting a Rugged::Repository instance");
+	rugged_check_repo(rb_repo);
 
 	Data_Get_Struct(rb_repo, git_repository, repo);
 

--- a/ext/rugged/rugged_tag.c
+++ b/ext/rugged/rugged_tag.c
@@ -196,9 +196,7 @@ static VALUE rb_git_tag_create(VALUE self, VALUE rb_repo, VALUE rb_data)
 
 	VALUE rb_name, rb_target, rb_tagger, rb_message, rb_force;
 
-	if (!rb_obj_is_kind_of(rb_repo, rb_cRuggedRepo))
-		rb_raise(rb_eTypeError, "Expecting a Rugged::Repository instance");
-
+	rugged_check_repo(rb_repo);
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	if (TYPE(rb_data) == T_STRING) {
@@ -297,9 +295,8 @@ static VALUE rb_git_tag_each(int argc, VALUE *argv, VALUE self)
 		pattern = StringValueCStr(rb_pattern);
 	}
 
-	if (!rb_obj_is_kind_of(rb_repo, rb_cRuggedRepo))
-		rb_raise(rb_eTypeError, "Expecting a Rugged::Repository instance");
 
+	rugged_check_repo(rb_repo);
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	error = git_tag_list_match(&tags, pattern ? pattern : "", repo);
@@ -327,8 +324,7 @@ static VALUE rb_git_tag_delete(VALUE self, VALUE rb_repo, VALUE rb_name)
 	git_repository *repo;
 	int error;
 
-	if (!rb_obj_is_kind_of(rb_repo, rb_cRuggedRepo))
-		rb_raise(rb_eTypeError, "Expecting a Rugged::Repository instance");
+	rugged_check_repo(rb_repo);
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	Check_Type(rb_name, T_STRING);

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -616,11 +616,10 @@ static VALUE rb_git_treebuilder_write(VALUE self, VALUE rb_repo)
 	git_oid written_id;
 	int error;
 
-	if (!rb_obj_is_kind_of(rb_repo, rb_cRuggedRepo))
-		rb_raise(rb_eTypeError, "Expecting a Rugged::Repository instance");
+	rugged_check_repo(rb_repo);
+	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	Data_Get_Struct(self, git_treebuilder, builder);
-	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	error = git_treebuilder_write(&written_id, repo, builder);
 	rugged_exception_check(error);


### PR DESCRIPTION
The usage in `rugged_branch.c` is fixed in #242
