### PR TITLE
reference: allow 'force' in .create to be truthy

### DIFF
--- a/ext/rugged/rugged_reference.c
+++ b/ext/rugged/rugged_reference.c
@@ -263,8 +263,7 @@ static VALUE rb_git_ref_create(int argc, VALUE *argv, VALUE klass)
 	Check_Type(rb_name, T_STRING);
 	Check_Type(rb_target, T_STRING);
 
-	if (!NIL_P(rb_force))
-		force = rugged_parse_bool(rb_force);
+	force = RTEST(rb_force);
 
 	if (git_oid_fromstr(&oid, StringValueCStr(rb_target)) == GIT_OK) {
 		error = git_reference_create(

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -108,6 +108,20 @@ end
 class ReferenceWriteTest < Rugged::TestCase
   include Rugged::TempRepositoryAccess
 
+  def test_create_force
+    Rugged::Reference.create(@repo, "refs/heads/unit_test", "refs/heads/master")
+
+    Rugged::Reference.create(@repo,
+                             "refs/heads/unit_test",
+                             "refs/heads/master",
+                             true)
+
+    Rugged::Reference.create(@repo,
+                             "refs/heads/unit_test",
+                             "refs/heads/master",
+                             :force)
+  end
+
   def test_list_unicode_refs
     Rugged::Reference.create(@repo,
       "refs/heads/#{ReferenceTest::UNICODE_REF_NAME}",


### PR DESCRIPTION
While looking at the checkout PR, I saw a couple of `Reference.create` calls and I had to check the docs about the third argument. Allowing non boolean values can make those a bit more readable.

``` ruby
 Rugged::Reference.create(@repo,
                             "refs/heads/unit_test",
                             "refs/heads/master",
                             :force)
```
