### PR TITLE
Remove Enumerable from Rugged::Diff::Delta

### DIFF
--- a/lib/rugged/diff/delta.rb
+++ b/lib/rugged/diff/delta.rb
@@ -1,8 +1,6 @@
 module Rugged
   class Diff
     class Delta
-      include Enumerable
-
       attr_reader :owner
       alias diff owner
 


### PR DESCRIPTION
It would seem to be a relic of times long past
