### PR TITLE
Add owner attr_reader for diff and tree

### DIFF
--- a/lib/rugged/diff.rb
+++ b/lib/rugged/diff.rb
@@ -8,6 +8,9 @@ module Rugged
     include Enumerable
     alias each each_patch
 
+    attr_reader :owner
+    alias tree owner
+
     def patches
       each_patch.to_a
     end

--- a/lib/rugged/tree.rb
+++ b/lib/rugged/tree.rb
@@ -2,6 +2,9 @@ module Rugged
   class Tree
     include Enumerable
 
+    attr_reader :owner
+    alias repo owner
+
     def inspect
       data = "#<Rugged::Tree:#{object_id} {oid: #{oid}}>\n"
       self.each { |e| data << "  <\"#{e[:name]}\" #{e[:oid]}>\n" }


### PR DESCRIPTION
Allows accessing Tree from Diff, and Repository from Tree

I was missing a way to get an instance of `Repository` from `Diff` or `Patch`.
