### PR TITLE
Add 2.1.0 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - rbx-19mode
   - rbx-20mode
 


### PR DESCRIPTION
Ruby 2.1.0-preview1 was released today. Even though it'll still take
some time until a final version is released, we can already make sure
that rugged will be compliant from day one.
