### PR TITLE
Changes to the Travis build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,10 @@ rvm:
   - rbx-19mode
   - rbx-20mode
 
-matrix:
-  allow_failures:
-    - rvm: rbx-19mode
-    - rvm: rbx-20mode
-
 # We need the config so the tests don't fail
 script:
   - git config --global user.name 'The rugged tests are fragile'
-  - rake
+  - bundle exec rake
 
 # Notify development list when needed
 notifications:


### PR DESCRIPTION
This changes the Travis configuration file to watch for changes on all branches, and to ignore Rubinius build failures.
