### PR TITLE
Change path to pry in script/console

### DIFF
--- a/script/console
+++ b/script/console
@@ -4,4 +4,4 @@
 set -e
 
 cd $(dirname "$0")/..
-exec ruby -S bin/pry -Ilib -r rugged -r rugged/console
+exec ruby -S pry -Ilib -r rugged -r rugged/console


### PR DESCRIPTION
This updated path to pry worked for me with Pry installed globally. I'm guessing that this was a relative path at somepoint. 
