### PR TITLE
Fix wrong usage example in a comment

### DIFF
--- a/ext/rugged/rugged_revwalk.c
+++ b/ext/rugged/rugged_revwalk.c
@@ -175,7 +175,7 @@ static VALUE rb_git_walker_hide(VALUE self, VALUE rb_commit)
 
 /*
  *  call-seq:
- *    walker.sorting = sort_mode
+ *    walker.sorting(sort_mode) -> nil
  *
  *  Change the sorting mode for the revision walk.
  *


### PR DESCRIPTION
According to the test: https://github.com/libgit2/rugged/blob/development/test/walker_test.rb#L53
