### PR TITLE
Mention CMake more prominently

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Rugged is a self-contained gem. You can install it by running:
 
     $ gem install rugged
 
-We recomment that you have CMake installed on your system for libgit2 to be able to build with HTTPS and SSH support. You can check out the list of optional [libgit2 dependencies](https://github.com/libgit2/libgit2#optional-dependencies).
+We recommend that you have CMake installed on your system for libgit2 to be able to build with HTTPS and SSH support. You can check out the list of optional [libgit2 dependencies](https://github.com/libgit2/libgit2#optional-dependencies).
 
 If you're using bundler and want to bundle libgit2 with rugged, you can use the `:submodules` option:
 


### PR DESCRIPTION
We need CMake in order to build with the functionality most people want,
so let's mention it explicitly.
