### PR TITLE
Fix a stray semicolon that could lead to a segfault.

### DIFF
--- a/ext/rugged/rugged_reference_collection.c
+++ b/ext/rugged/rugged_reference_collection.c
@@ -333,7 +333,7 @@ static VALUE rb_git_reference_collection_rename(int argc, VALUE *argv, VALUE sel
 			log_message = StringValueCStr(rb_val);
 	}
 
-	if ((error = git_reference_lookup(&ref, repo, StringValueCStr(rb_name_or_ref))) == GIT_OK);
+	if ((error = git_reference_lookup(&ref, repo, StringValueCStr(rb_name_or_ref))) == GIT_OK)
 		error = git_reference_rename(&out, ref, StringValueCStr(rb_new_name), force, signature, log_message);
 
 	git_reference_free(ref);


### PR DESCRIPTION
We'd try to rename a reference even if loading it failed.
