### PR TITLE
Don't use dir_config.

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -42,7 +42,8 @@ Dir.chdir(LIBGIT2_DIR) do
   end
 end
 
-dir_config('git2', "#{LIBGIT2_DIR}/include", "#{LIBGIT2_DIR}/build")
+$CPPFLAGS << "-I#{LIBGIT2_DIR}/include"
+$LIBPATH.unshift "#{LIBGIT2_DIR}/build"
 
 unless have_library 'git2' and have_header 'git2.h'
   abort "ERROR: Failed to build libgit2"


### PR DESCRIPTION
`dir_config` is only honoring the given include and lib paths, if libgit2 is not found in any of the "standard" system include/lib paths. 

his means that for people who had libgit2 installed on their system, rugged would get build against their system libgit2 and not against our bundled version.

This fixes #351.
