### PR TITLE
Ignore library search paths returned by `pkg-config`.

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -38,7 +38,7 @@ Dir.chdir(LIBGIT2_DIR) do
     sys(MAKE)
 
     pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")
-    $LDFLAGS << " " + `pkg-config --libs --static #{pcfile}`.strip
+    $libs << " " + `pkg-config --libs-only-l --static #{pcfile}`.strip
   end
 end
 


### PR DESCRIPTION
Instead of adding the output of `pkg-config --libs --static` directly
to `$LDFLAGS`, we append only the `-l` part to `$libs`.

This is to fix an issue where trying to build rugged with a
pre-installed libgit2 version would link against that version.

`pkg-config --libs --static` includes something along the lines
of `-L${libdir}`, where `${libdir}` could point to the folder
containing the pre-installed libgit2 version.

This fixes #351.
