### PR TITLE
Fix linking problem on OS X for iconv

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -34,7 +34,8 @@ Dir.chdir(LIBGIT2_DIR) do
   Dir.mkdir("build") if !Dir.exists?("build")
 
   Dir.chdir("build") do
-    sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC")
+    sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_FIND_FRAMEWORK=LAST")
+
     sys(MAKE)
 
     pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")


### PR DESCRIPTION
On OS X Mavericks, the built-in version of iconv is missing the symbol "libiconv_open", resulting in an error like this when you build and test:

```
dyld: lazy symbol binding failed: Symbol not found: _libiconv_open
  Referenced from: /Users/dan/workspace/3dna/rugged/lib/rugged/rugged.bundle
  Expected in: flat namespace

dyld: Symbol not found: _libiconv_open
  Referenced from: /Users/dan/workspace/3dna/rugged/lib/rugged/rugged.bundle
  Expected in: flat namespace

rake aborted!
SIGTRAP
```

The Homebrew version of iconv is compatible, but in order to use that library we need to place system-level frameworks last in the cmake search path. That's what this patch does. I haven't had a chance to test on Linux or other systems so I don't know yet whether it breaks the package there.
