### PR TITLE
Add some missing instance variable getters on Rugged::Diff::Hunk.

### DIFF
--- a/ext/rugged/rugged_diff_hunk.c
+++ b/ext/rugged/rugged_diff_hunk.c
@@ -84,5 +84,20 @@ void Init_rugged_diff_hunk(void)
 {
 	rb_cRuggedDiffHunk = rb_define_class_under(rb_cRuggedDiff, "Hunk", rb_cObject);
 
+	rb_include_module(rb_cRuggedDiffHunk, rb_mEnumerable);
+
+	rb_define_method(rb_cRuggedDiffHunk, "each", rb_git_diff_hunk_each_line, 0);
 	rb_define_method(rb_cRuggedDiffHunk, "each_line", rb_git_diff_hunk_each_line, 0);
+
+	rb_define_attr(rb_cRuggedDiffHunk, "header", 1, 0);
+	rb_define_attr(rb_cRuggedDiffHunk, "line_count", 1, 0);
+	rb_define_attr(rb_cRuggedDiffHunk, "hunk_index", 1, 0);
+
+	rb_define_attr(rb_cRuggedDiffHunk, "old_start", 1, 0);
+	rb_define_attr(rb_cRuggedDiffHunk, "old_lines", 1, 0);
+	rb_define_attr(rb_cRuggedDiffHunk, "new_start", 1, 0);
+	rb_define_attr(rb_cRuggedDiffHunk, "new_lines", 1, 0);
+
+	rb_define_alias(rb_cRuggedDiffHunk, "count", "line_count");
+	rb_define_alias(rb_cRuggedDiffHunk, "size", "line_count");
 }

--- a/lib/rugged/diff/hunk.rb
+++ b/lib/rugged/diff/hunk.rb
@@ -1,17 +1,12 @@
 module Rugged
   class Diff
     class Hunk
-      include Enumerable
-      alias each each_line
-
-      attr_reader :line_count, :header, :range, :owner
-
-      alias size line_count
-      alias count line_count
-      alias delta owner
+      def delta
+        @owner
+      end
 
       def inspect
-        "#<#{self.class.name}:#{object_id} {header: #{header.inspect}, range: #{range.inspect}>"
+        "#<#{self.class.name}:#{object_id} {header: #{header.inspect}, count: #{count.inspect}}>"
       end
 
       # Returns an Array containing all lines of the hunk.

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -745,8 +745,25 @@ EOS
     assert_equal 3, hunks.size
 
     assert hunks[0].header.start_with? "@@ -1,5 +1,5 @@"
+    assert_equal 6, hunks[0].line_count
+    assert_equal 1, hunks[0].old_start
+    assert_equal 5, hunks[0].old_lines
+    assert_equal 1, hunks[0].new_start
+    assert_equal 5, hunks[0].new_lines
+
     assert hunks[1].header.start_with? "@@ -8,10 +8,6 @@" 
+    assert_equal 10, hunks[1].line_count
+    assert_equal 8, hunks[1].old_start
+    assert_equal 10, hunks[1].old_lines
+    assert_equal 8, hunks[1].new_start
+    assert_equal 6, hunks[1].new_lines
+
     assert hunks[2].header.start_with? "@@ -32,6 +28,10 @@"
+    assert_equal 10, hunks[2].line_count
+    assert_equal 32, hunks[2].old_start
+    assert_equal 6, hunks[2].old_lines
+    assert_equal 28, hunks[2].new_start
+    assert_equal 10, hunks[2].new_lines
 
     assert_equal "readme.txt", patches[1].delta.old_file[:path]
     assert_equal "readme.txt", patches[1].delta.new_file[:path]


### PR DESCRIPTION
This should fix #358.

I'll add some specific test cases for these getters later, then we can get this merged.
