### PR TITLE
Add Rugged::Commit#as_email.

### DIFF
--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -255,3 +255,225 @@ class CommitWriteTest < Rugged::TestCase
       :tree => "c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b")
   end
 end
+
+class CommitToMboxTest < Rugged::SandboxedTestCase
+  def setup
+    super
+
+    @repo = sandbox_init "diff_format_email"
+  end
+
+  def teardown
+    @repo.close
+
+    super
+  end
+
+  def test_format_to_mbox
+    assert_equal <<-EOS, @repo.lookup("9264b96c6d104d0e07ae33d3007b6a48246c6f92").to_mbox
+From 9264b96c6d104d0e07ae33d3007b6a48246c6f92 Mon Sep 17 00:00:00 2001
+From: Jacques Germishuys <jacquesg@striata.com>
+Date: Wed, 9 Apr 2014 20:57:01 +0200
+Subject: [PATCH] Modify some content
+
+---
+ file1.txt | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/file1.txt b/file1.txt
+index 94aaae8..af8f41d 100644
+--- a/file1.txt
++++ b/file1.txt
+@@ -1,15 +1,17 @@
+ file1.txt
+ file1.txt
++_file1.txt_
+ file1.txt
+ file1.txt
+ file1.txt
+ file1.txt
++
++
+ file1.txt
+ file1.txt
+ file1.txt
+ file1.txt
+ file1.txt
+-file1.txt
+-file1.txt
+-file1.txt
++_file1.txt_
++_file1.txt_
+ file1.txt
+--
+libgit2 0.20.0
+
+EOS
+  end
+
+  def test_format_to_mbox_multiple
+    commit = @repo.lookup("10808fe9c9be5a190c0ba68d1a002233fb363508")
+    assert_equal <<-EOS, commit.to_mbox(patch_no: 1, total_patches: 2)
+From 10808fe9c9be5a190c0ba68d1a002233fb363508 Mon Sep 17 00:00:00 2001
+From: Jacques Germishuys <jacquesg@striata.com>
+Date: Thu, 10 Apr 2014 19:37:05 +0200
+Subject: [PATCH 1/2] Added file2.txt file3.txt
+
+---
+ file2.txt | 5 +++++
+ file3.txt | 5 +++++
+ 2 files changed, 10 insertions(+), 0 deletions(-)
+ create mode 100644 file2.txt
+ create mode 100644 file3.txt
+
+diff --git a/file2.txt b/file2.txt
+new file mode 100644
+index 0000000..e909123
+--- /dev/null
++++ b/file2.txt
+@@ -0,0 +1,5 @@
++file2
++file2
++file2
++file2
++file2
+diff --git a/file3.txt b/file3.txt
+new file mode 100644
+index 0000000..9435022
+--- /dev/null
++++ b/file3.txt
+@@ -0,0 +1,5 @@
++file3
++file3
++file3
++file3
++file3
+--
+libgit2 0.20.0
+
+EOS
+
+    commit = @repo.lookup("873806f6f27e631eb0b23e4b56bea2bfac14a373")
+    assert_equal <<-EOS, commit.to_mbox(patch_no: 2, total_patches: 2)
+From 873806f6f27e631eb0b23e4b56bea2bfac14a373 Mon Sep 17 00:00:00 2001
+From: Jacques Germishuys <jacquesg@striata.com>
+Date: Thu, 10 Apr 2014 19:37:36 +0200
+Subject: [PATCH 2/2] Modified file2.txt, file3.txt
+
+---
+ file2.txt | 2 +-
+ file3.txt | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/file2.txt b/file2.txt
+index e909123..7aff11d 100644
+--- a/file2.txt
++++ b/file2.txt
+@@ -1,5 +1,5 @@
+ file2
+ file2
+ file2
+-file2
++file2!
+ file2
+diff --git a/file3.txt b/file3.txt
+index 9435022..9a2d780 100644
+--- a/file3.txt
++++ b/file3.txt
+@@ -1,5 +1,5 @@
+ file3
+-file3
++file3!
+ file3
+ file3
+ file3
+--
+libgit2 0.20.0
+
+EOS
+
+  end
+
+  def test_format_to_mbox_exclude_marker
+    commit = @repo.lookup("9264b96c6d104d0e07ae33d3007b6a48246c6f92")
+    assert_equal <<-EOS, commit.to_mbox(exclude_subject_patch_marker: true)
+From 9264b96c6d104d0e07ae33d3007b6a48246c6f92 Mon Sep 17 00:00:00 2001
+From: Jacques Germishuys <jacquesg@striata.com>
+Date: Wed, 9 Apr 2014 20:57:01 +0200
+Subject: Modify some content
+
+---
+ file1.txt | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/file1.txt b/file1.txt
+index 94aaae8..af8f41d 100644
+--- a/file1.txt
++++ b/file1.txt
+@@ -1,15 +1,17 @@
+ file1.txt
+ file1.txt
++_file1.txt_
+ file1.txt
+ file1.txt
+ file1.txt
+ file1.txt
++
++
+ file1.txt
+ file1.txt
+ file1.txt
+ file1.txt
+ file1.txt
+-file1.txt
+-file1.txt
+-file1.txt
++_file1.txt_
++_file1.txt_
+ file1.txt
+--
+libgit2 0.20.0
+
+EOS
+  end
+
+  def test_format_to_mbox_diff_options
+    commit = @repo.lookup("9264b96c6d104d0e07ae33d3007b6a48246c6f92")
+    assert_equal <<-EOS, commit.to_mbox(context_lines: 1, interhunk_lines: 1)
+From 9264b96c6d104d0e07ae33d3007b6a48246c6f92 Mon Sep 17 00:00:00 2001
+From: Jacques Germishuys <jacquesg@striata.com>
+Date: Wed, 9 Apr 2014 20:57:01 +0200
+Subject: [PATCH] Modify some content
+
+---
+ file1.txt | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/file1.txt b/file1.txt
+index 94aaae8..af8f41d 100644
+--- a/file1.txt
++++ b/file1.txt
+@@ -2,2 +2,3 @@ file1.txt
+ file1.txt
++_file1.txt_
+ file1.txt
+@@ -6,2 +7,4 @@ file1.txt
+ file1.txt
++
++
+ file1.txt
+@@ -11,5 +14,4 @@ file1.txt
+ file1.txt
+-file1.txt
+-file1.txt
+-file1.txt
++_file1.txt_
++_file1.txt_
+ file1.txt
+--
+libgit2 0.20.0
+
+EOS
+  end
+
+end


### PR DESCRIPTION
This adds `Rugged::Commit#as_email`, exposing `rb_git_commit_as_email`.

I'm not too fond of the name, if you got a better idea, let me know.
