### PR TITLE
Build libgit2 with optimizations

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -34,7 +34,7 @@ Dir.chdir(LIBGIT2_DIR) do
   Dir.mkdir("build") if !Dir.exists?("build")
 
   Dir.chdir("build") do
-    sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC")
+    sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo")
     sys(MAKE)
 
     pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")


### PR DESCRIPTION
Hey guys,

unless I'm missing something, there's no reason _not_ to build libgit2 with optimizations. I've decided to go  with "RelWithDebInfo" (`-O2 -g` on my machine) instead of "Release" (`-O3`) because it seems to be a bit faster and also debugging symbols are always nice to have.

The benchmark taken from #343 shows that it's indeed slightly faster:

**Before**

```
Rehearsal ----------------------------------------------------------
rugged commit_info       4.410000   0.200000   4.610000 (  4.666749)
git commit_info          0.020000   0.090000   0.450000 (  0.533722)
------------------------------------------------- total: 5.060000sec

                            user     system      total        real
rugged commit_info       4.340000   0.220000   4.560000 (  4.595411)
git commit_info          0.020000   0.070000   0.420000 (  0.507531)
```

**After**

```
Rehearsal ----------------------------------------------------------
rugged commit_info       3.630000   0.280000   3.910000 (  3.956166)
git commit_info          0.040000   0.110000   0.550000 (  0.579047)
------------------------------------------------- total: 4.460000sec

                            user     system      total        real
rugged commit_info       3.570000   0.250000   3.820000 (  3.873389)
git commit_info          0.030000   0.080000   0.510000 (  0.532609)
```
