### PR TITLE
Multi OS Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,12 @@ rvm:
   - 2.0.0
   - 2.1.2
   - ruby-head
-  - rbx
+  - rbx-2
 
 matrix:
   fast_finish: true
   allow_failures:
+    - rvm: rbx-2
     - { os: osx, rvm: 2.1.2 }
 
 install:


### PR DESCRIPTION
This enables OS X builds alongside the Linux builds we already do for Rugged.

It also bumps the Ruby 2.1.x version we build against, and puts rubinius builds back into the `allowed_failures` list, because fuck rubinius.

---

**EDIT**: I actually changed the Travis config to specify the rubinius version more tightly. That should fix the rbx build issues, I hope.
