### PR TITLE
Update README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ more high-level, so it may be preferable:
 
 ```ruby
 oid = repo.write("This is a blob.", :blob)
-index = Rugged::Index.new
+index = repo.index
+index.read_tree(repo.head.target.tree)
 index.add(:path => "README.md", :oid => oid, :mode => 0100644)
 
 options = {}


### PR DESCRIPTION
Add `index.read_tree(repo.head.target.tree)` to README, it took me a good hour to find out I need to write the current tree into the index otherwise I would lose the files that are not in the there. Just nice to have that on the README so people wont make the same mistake.
