### PR TITLE
Update tree object documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ person = tag.tagger
 ### Tree Objects
 
 ```ruby
-tree = repo.lookup('779fbb1e17e666832773a9825875300ea736c2da')
+tree = repo.lookup('779fbb1e17e666832773a9825875300ea736c2da').tree
 # => #<Rugged::Tree:2245194360>
 
 # number of tree entries


### PR DESCRIPTION
`repo.lookup( some_sha )` returns a `<Rugged::Commit>` object, and not a
tree

Am I mistaken? Under what circumstances could `repo.lookup` return a tree object?
