### PR TITLE
Allow using the system provided libgit2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ To load Rugged, you'll usually want to add something like this:
 require 'rugged'
 ```
 
+### Use the system provided libgit2
+
+By default, Rugged builds and uses a bundled version of libgit2. If you
+want to use the system library instead, you can install rugged as follows:
+
+```
+gem install rugged -- --use-system-libraries
+```
+
+Or if you are using bundler:
+
+```
+bundle config build.rugged --use-system-libraries
+bundle install
+```
+
+However, note that Rugged does only support specific versions of libgit2.
+
 ## Usage
 
 Rugged gives you access to the many parts of a Git repository. You can read and

--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -27,34 +27,48 @@ if !find_executable('pkg-config')
   abort "ERROR: pkg-config is required to build Rugged."
 end
 
-CWD = File.expand_path(File.dirname(__FILE__))
-LIBGIT2_DIR = File.join(CWD, '..', '..', 'vendor', 'libgit2')
+if arg_config("--use-system-libraries", !!ENV['RUGGED_USE_SYSTEM_LIBRARIES'])
+  puts "Building Rugged using system libraries.\n"
 
-Dir.chdir(LIBGIT2_DIR) do
-  Dir.mkdir("build") if !Dir.exists?("build")
+  dir_config('git2').any? or pkg_config('libgit2')
 
-  Dir.chdir("build") do
-    sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo")
-    sys(MAKE)
+  try_compile(<<-SRC) or abort "libgit2 version is not compatible"
+#include <git2/version.h>
 
-    pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")
-    $LDFLAGS << " " + `pkg-config --libs --static #{pcfile}`.strip
+#if LIBGIT2_SOVERSION != 21
+#error libgit2 version is not compatible
+#endif
+  SRC
+else
+  CWD = File.expand_path(File.dirname(__FILE__))
+  LIBGIT2_DIR = File.join(CWD, '..', '..', 'vendor', 'libgit2')
+
+  Dir.chdir(LIBGIT2_DIR) do
+    Dir.mkdir("build") if !Dir.exists?("build")
+
+    Dir.chdir("build") do
+      sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo")
+      sys(MAKE)
+
+      pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")
+      $LDFLAGS << " " + `pkg-config --libs --static #{pcfile}`.strip
+    end
   end
-end
 
-# Prepend the vendored libgit2 build dir to the $DEFLIBPATH.
-#
-# By default, $DEFLIBPATH includes $(libpath), which usually points
-# to something like /usr/lib for system ruby versions (not those
-# installed through rbenv or rvm).
-#
-# This was causing system-wide libgit2 installations to be preferred
-# over of our vendored libgit2 version when building rugged.
-#
-# By putting the path to the vendored libgit2 library at the front of
-# $DEFLIBPATH, we can ensure that our bundled version is always used.
-$DEFLIBPATH.unshift("#{LIBGIT2_DIR}/build")
-dir_config('git2', "#{LIBGIT2_DIR}/include", "#{LIBGIT2_DIR}/build")
+  # Prepend the vendored libgit2 build dir to the $DEFLIBPATH.
+  #
+  # By default, $DEFLIBPATH includes $(libpath), which usually points
+  # to something like /usr/lib for system ruby versions (not those
+  # installed through rbenv or rvm).
+  #
+  # This was causing system-wide libgit2 installations to be preferred
+  # over of our vendored libgit2 version when building rugged.
+  #
+  # By putting the path to the vendored libgit2 library at the front of
+  # $DEFLIBPATH, we can ensure that our bundled version is always used.
+  $DEFLIBPATH.unshift("#{LIBGIT2_DIR}/build")
+  dir_config('git2', "#{LIBGIT2_DIR}/include", "#{LIBGIT2_DIR}/build")
+end
 
 unless have_library 'git2' and have_header 'git2.h'
   abort "ERROR: Failed to build libgit2"


### PR DESCRIPTION
This adds a `--use-system-libraries` to the `extconf.rb` file. This allows Rugged to be built with the system provided libgit2 installation, instead of using the vendored version.

I'm using the `LIBGIT2_SOVERSION` to check for API compatibility. Right now, this is hard-coded into the `extconf.rb` file, but I think we could also just pull the version out of the bundled libgit2 version and compare the two.

This should fix https://github.com/libgit2/rugged/issues/368.
