### PR TITLE
Remove `Rugged::Diff#tree` and `Rugged::Diff#owner`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Remove `Rugged::Diff#tree` and `Rugged::Diff#owner`.
+
+    Fixes #389.
+
+    *Arthur Schreiber*
+
 *   Add `#additions` and `#deletions` to `Rugged::Patch`.
 
     *Mindaugas Mozūras*

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -84,7 +84,7 @@ VALUE rugged_config_new(VALUE klass, VALUE owner, git_config *cfg);
 VALUE rugged_object_new(VALUE owner, git_object *object);
 VALUE rugged_object_rev_parse(VALUE rb_repo, VALUE rb_spec, int as_obj);
 VALUE rugged_ref_new(VALUE klass, VALUE owner, git_reference *ref);
-VALUE rugged_diff_new(VALUE klass, VALUE owner, git_diff *diff);
+VALUE rugged_diff_new(VALUE klass, git_diff *diff);
 VALUE rugged_patch_new(VALUE owner, git_patch *patch);
 VALUE rugged_diff_delta_new(VALUE owner, const git_diff_delta *delta);
 VALUE rugged_diff_hunk_new(VALUE owner, size_t hunk_idx, const git_diff_hunk *hunk, size_t lines_in_hunk);

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -27,11 +27,9 @@
 extern VALUE rb_mRugged;
 VALUE rb_cRuggedDiff;
 
-VALUE rugged_diff_new(VALUE klass, VALUE owner, git_diff *diff)
+VALUE rugged_diff_new(VALUE klass, git_diff *diff)
 {
-	VALUE rb_diff = Data_Wrap_Struct(klass, NULL, git_diff_free, diff);
-	rugged_set_owner(rb_diff, owner);
-	return rb_diff;
+	return Data_Wrap_Struct(klass, NULL, git_diff_free, diff);
 }
 
 /**

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -831,7 +831,7 @@ static VALUE rb_git_index_diff(int argc, VALUE *argv, VALUE self)
 	xfree(opts.pathspec.strings);
 	rugged_exception_check(error);
 
-	return rugged_diff_new(rb_cRuggedDiff, self, diff);
+	return rugged_diff_new(rb_cRuggedDiff, diff);
 }
 
 /*

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -473,7 +473,7 @@ static VALUE rb_git_tree_diff_(int argc, VALUE *argv, VALUE self)
 	xfree(opts.pathspec.strings);
 	rugged_exception_check(error);
 
-	return rugged_diff_new(rb_cRuggedDiff, self, diff);
+	return rugged_diff_new(rb_cRuggedDiff, diff);
 }
 
 /*
@@ -508,7 +508,7 @@ static VALUE rb_git_tree_diff_workdir(int argc, VALUE *argv, VALUE self)
 	xfree(opts.pathspec.strings);
 	rugged_exception_check(error);
 
-	return rugged_diff_new(rb_cRuggedDiff, self, diff);
+	return rugged_diff_new(rb_cRuggedDiff, diff);
 }
 
 void rugged_parse_merge_options(git_merge_options *opts, VALUE rb_options)

--- a/lib/rugged/diff.rb
+++ b/lib/rugged/diff.rb
@@ -7,9 +7,6 @@ module Rugged
     include Enumerable
     alias each each_patch
 
-    attr_reader :owner
-    alias tree owner
-
     def patches
       each_patch.to_a
     end


### PR DESCRIPTION
Fixes #389.
