### PR TITLE
Remove defunct `Rugged::Diff::Line#hunk` and `Rugged::Diff::Line#owner`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Remove defunct `Rugged::Diff::Line#hunk` and `Rugged::Diff::Line#owner`.
+
+    Fixes #390.
+
+    *Arthur Schreiber*
+
 *   Remove `Rugged::Diff#tree` and `Rugged::Diff#owner`.
 
     Fixes #389.

--- a/lib/rugged/diff/line.rb
+++ b/lib/rugged/diff/line.rb
@@ -1,9 +1,7 @@
 module Rugged
   class Diff
     class Line
-      attr_reader :line_origin, :content, :owner, :old_lineno, :new_lineno, :content_offset
-
-      alias hunk owner
+      attr_reader :line_origin, :content, :old_lineno, :new_lineno, :content_offset
 
       def context?
         @line_origin == :context


### PR DESCRIPTION
Fixes #390.
