### PR TITLE
Make `Rugged::Diff` reference their repository.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
     *Arthur Schreiber*
 
-*   Remove `Rugged::Diff#tree` and `Rugged::Diff#owner`.
+*   Remove `Rugged::Diff#tree` and change `Rugged::Diff#owner` to return the
+    repository that the `Rugged::Diff` object belongs to.
+
+    We need to keep a reference from the `Rugged::Diff` to the repository to
+    ensure that the underlying libgit2 data does not get freed accidentally.
 
     Fixes #389.
 

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -84,7 +84,7 @@ VALUE rugged_config_new(VALUE klass, VALUE owner, git_config *cfg);
 VALUE rugged_object_new(VALUE owner, git_object *object);
 VALUE rugged_object_rev_parse(VALUE rb_repo, VALUE rb_spec, int as_obj);
 VALUE rugged_ref_new(VALUE klass, VALUE owner, git_reference *ref);
-VALUE rugged_diff_new(VALUE klass, git_diff *diff);
+VALUE rugged_diff_new(VALUE klass, VALUE owner, git_diff *diff);
 VALUE rugged_patch_new(VALUE owner, git_patch *patch);
 VALUE rugged_diff_delta_new(VALUE owner, const git_diff_delta *delta);
 VALUE rugged_diff_hunk_new(VALUE owner, size_t hunk_idx, const git_diff_hunk *hunk, size_t lines_in_hunk);

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -27,9 +27,11 @@
 extern VALUE rb_mRugged;
 VALUE rb_cRuggedDiff;
 
-VALUE rugged_diff_new(VALUE klass, git_diff *diff)
+VALUE rugged_diff_new(VALUE klass, VALUE owner, git_diff *diff)
 {
-	return Data_Wrap_Struct(klass, NULL, git_diff_free, diff);
+	VALUE rb_diff = Data_Wrap_Struct(klass, NULL, git_diff_free, diff);
+	rugged_set_owner(rb_diff, owner);
+	return rb_diff;
 }
 
 /**

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -831,7 +831,7 @@ static VALUE rb_git_index_diff(int argc, VALUE *argv, VALUE self)
 	xfree(opts.pathspec.strings);
 	rugged_exception_check(error);
 
-	return rugged_diff_new(rb_cRuggedDiff, diff);
+	return rugged_diff_new(rb_cRuggedDiff, owner, diff);
 }
 
 /*

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -473,7 +473,7 @@ static VALUE rb_git_tree_diff_(int argc, VALUE *argv, VALUE self)
 	xfree(opts.pathspec.strings);
 	rugged_exception_check(error);
 
-	return rugged_diff_new(rb_cRuggedDiff, diff);
+	return rugged_diff_new(rb_cRuggedDiff, rb_repo, diff);
 }
 
 /*
@@ -508,7 +508,7 @@ static VALUE rb_git_tree_diff_workdir(int argc, VALUE *argv, VALUE self)
 	xfree(opts.pathspec.strings);
 	rugged_exception_check(error);
 
-	return rugged_diff_new(rb_cRuggedDiff, diff);
+	return rugged_diff_new(rb_cRuggedDiff, owner, diff);
 }
 
 void rugged_parse_merge_options(git_merge_options *opts, VALUE rb_options)

--- a/lib/rugged/diff.rb
+++ b/lib/rugged/diff.rb
@@ -7,6 +7,8 @@ module Rugged
     include Enumerable
     alias each each_patch
 
+    attr_reader :owner
+
     def patches
       each_patch.to_a
     end


### PR DESCRIPTION
We need to keep a reference from the diff objects to the repository to ensure that the underlying libgit2 data does not get freed accidentally.

Methods like `Rugged::Diff#find_similar!` (which wraps `git_diff_find_similar`) try to access the repository, and will fail if the data was freed.

//cc  @carlosmn @mmozuras
