### PR TITLE
Update Repository Section of README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ ref = repo.head
 ref.name
 # => "refs/heads/master"
 ref.target
-# => #<Rugged::Commit:2228467250 {message: "helpful message", tree: #<Rugged::Tree:2228467260 {oid: 5d6f29220a0783b8085134df14ec4d960b6c3bf2}>
+# => #<Rugged::Commit:2228467250 {message: "helpful message", tree: #<Rugged::Tree:2228467260 {oid: 5d6f29220a0783b8085134df14ec4d960b6c3bf2}>}>
 ref.target_id
 # => "2bc6a70483369f33f641ca44873497f13a15cde5"
 


### PR DESCRIPTION
I found the README to be slightly confusing so I thought I might propose a few changes. 

As the README is currently written it seems like the target of  the `repo.head` object is a SHA. In reality, the target of  the `repo.head` object is a `Commit` object instead of a SHA. I've updated the documentation to attempt to clarify this. 

I've also added instructions for the case where someone _does_ want the SHA instead of just the `Commit` object.
