### PR TITLE
Gitignore rdoc/.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ lib/rugged/**/rugged.so
 vendor/gems
 bin/
 pkg/
+rdoc/


### PR DESCRIPTION
Generated on `rake rdoc`.
