### PR TITLE
Expose core dump on index.diff from merge.

### DIFF
--- a/test/merge_test.rb
+++ b/test/merge_test.rb
@@ -25,6 +25,7 @@ class TrivialMergeTest < Rugged::SandboxedTestCase
     base = repo.rev_parse(repo.merge_base(ours, theirs))
 
     index = ours.tree.merge(theirs.tree, base.tree)
+    index.diff
 
     assert index.conflicts?
     assert 2, index.count { |entry| entry[:stage] > 0 }


### PR DESCRIPTION
I was trying to get the conflicts, when I tried this.

Now I think this should not do what I want: in theory the diff should be empty.

But I think it is not acceptable to get core dumps on Ruby library? Exceptions should be thrown instead?

Let's see if Travis reproduces.