### PR TITLE
tell CMake to generate UNIX makefiles to avoid issues building on Window...

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -47,7 +47,7 @@ else
     Dir.mkdir("build") if !Dir.exists?("build")
 
     Dir.chdir("build") do
-      sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo")
+      sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Unix Makefiles\"")
       sys(MAKE)
 
       pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")


### PR DESCRIPTION
Building rugged on Windows when Visual Studio is installed causes CMake to default to Visual Studio project files, which are not understood by the DevKit environment and cause the installation to fail.

Passing -G "Unix Makefiles" to cmake causes it to create the expected Makefile and allows gem installation to succeed on Windows.  It has no side effects on other platforms, where that is the default generator.

CMake's default generator behavior: http://stackoverflow.com/questions/6430251/what-is-the-default-generator-for-cmake-in-windows  And relevant source: https://github.com/Kitware/CMake/blob/0f2defba7d89aced3b667c6afe031abdfd152540/Source/cmake.cxx#L1384
