### PR TITLE
Update to libgit2 v0.22.1

### DIFF
--- a/ext/rugged/rugged_submodule.c
+++ b/ext/rugged/rugged_submodule.c
@@ -862,7 +862,7 @@ static VALUE rb_git_submodule_update_rule(VALUE self)
 	git_submodule_update_t update;
 
 	Data_Get_Struct(self, git_submodule, submodule);
-	update = git_submodule_update(submodule);
+	update = git_submodule_update_strategy(submodule);
 
 	return rb_git_subm_update_rule_fromC(update);
 }

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -658,7 +658,7 @@ static VALUE rb_git_treebuilder_new(int argc, VALUE *argv, VALUE klass)
 	rugged_check_repo(rb_repo);
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
-	error = git_treebuilder_create(&builder, repo, tree);
+	error = git_treebuilder_new(&builder, repo, tree);
 	rugged_exception_check(error);
 
 	rb_builder = Data_Wrap_Struct(klass, NULL, &rb_git_treebuilder_free, builder);


### PR DESCRIPTION
Update bundled libgit2 to v0.22.0 in preparation for a new rugged release. :tada: 