### PR TITLE
Add tree_at similar to blob_at

### DIFF
--- a/lib/rugged/repository.rb
+++ b/lib/rugged/repository.rb
@@ -210,6 +210,17 @@ module Rugged
       remote_or_url.fetch(*args)
     end
 
+    # Get the tree at a path for a specific revision.
+    #
+    # revision - The String SHA1.
+    # path     - The String file path.
+    #
+    # Returns a String.
+    def tree_at(revision, path)
+      tree = Rugged::Commit.lookup(self, revision).tree
+      tree.path(path)[:oid]
+    end
+
     # Push a list of refspecs to the given remote.
     #
     # refspecs - A list of refspecs that should be pushed to the remote.


### PR DESCRIPTION
I was wondering if a `tree_at` method would be useful (similar to the `blob_at`? (I'm only recently exploring rugged's source, so I could be wrong). It's not a lot of effort doing that otherwise, but a method for that could keep things easy. 

There isn't much error handling atm.
