### PR TITLE
fix SEGV in rugged_branch_collection.c

### DIFF
--- a/ext/rugged_branch_collection.c
+++ b/ext/rugged_branch_collection.c
@@ -235,6 +235,7 @@ static VALUE each_branch(int argc, VALUE *argv, VALUE self, int branch_names_onl
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	error = git_branch_iterator_new(&iter, repo, filter);
+	rugged_exception_check(error);
 
 	if (branch_names_only) {
 		git_reference *branch;


### PR DESCRIPTION
Check if git_branch_iterator_new returned error when initializing iter

Error might be returned if for some reason the iter could not be initialized,
but currently that error is not being checked.