### PR TITLE
Fix SIGSEGV: check if there was an exception when initializing iterator

### DIFF
--- a/ext/rugged/rugged_branch_collection.c
+++ b/ext/rugged/rugged_branch_collection.c
@@ -235,6 +235,7 @@ static VALUE each_branch(int argc, VALUE *argv, VALUE self, int branch_names_onl
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	error = git_branch_iterator_new(&iter, repo, filter);
+	rugged_exception_check(error);
 
 	if (branch_names_only) {
 		git_reference *branch;


### PR DESCRIPTION
Currently there is no check if an exception was raised when initializing the iterator at each_branch function.