### PR TITLE
Remove the tilde from the Repository documentation

### DIFF
--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -336,7 +336,7 @@ static VALUE rb_git_repo_open_bare(int argc, VALUE *argv, VALUE klass)
  *
  *  Examples:
  *
- *    Rugged::Repository.new('~/test/.git') #=> #<Rugged::Repository:0x108849488>
+ *    Rugged::Repository.new('test/.git') #=> #<Rugged::Repository:0x108849488>
  *    Rugged::Repository.new(path, :alternates => ['./other/repo/.git/objects'])
  */
 static VALUE rb_git_repo_new(int argc, VALUE *argv, VALUE klass)
@@ -379,7 +379,7 @@ static VALUE rb_git_repo_new(int argc, VALUE *argv, VALUE klass)
  *    A Rugged::Backend instance
  *
  *
- *    Rugged::Repository.init_at('~/repository', :bare) #=> #<Rugged::Repository:0x108849488>
+ *    Rugged::Repository.init_at('repository', :bare) #=> #<Rugged::Repository:0x108849488>
  */
 static VALUE rb_git_repo_init_at(int argc, VALUE *argv, VALUE klass)
 {


### PR DESCRIPTION
Using the tilde in the documentation for repository initialization
suggests that we perform tilde expansion in the path provided. We do no
such thing, so remove it as it's quite unlikely someone does want a
directory called '~' to have their git repos.

---

Maybe we want to have `File.expand_path('~/test/.git')` instead? The current way should go either way, this is likely the cause for #438.