### PR TITLE
Fix compiler warnings

### DIFF
--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -154,6 +154,7 @@ struct rugged_remote_cb_payload
 	VALUE transfer_progress;
 	VALUE update_tips;
 	VALUE credentials;
+	VALUE result;
 	int exception;
 };
 

--- a/ext/rugged/rugged_remote_collection.c
+++ b/ext/rugged/rugged_remote_collection.c
@@ -251,7 +251,8 @@ static VALUE rb_git_remote_collection_rename(VALUE self, VALUE rb_name_or_remote
 {
 	VALUE rb_repo = rugged_owner(self);
 	git_repository *repo;
-	int i, error, exception;
+	size_t i;
+	int error, exception;
 	git_strarray problems;
 
 	if (!rb_block_given_p())

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -645,18 +645,20 @@ static VALUE rb_git_repo_merge_base(VALUE self, VALUE rb_args)
  */
 static VALUE rb_git_repo_merge_bases(VALUE self, VALUE rb_args)
 {
-	int error = GIT_OK, i;
+	int error = GIT_OK;
+	size_t i, len = (size_t)RARRAY_LEN(rb_args);
 	git_repository *repo;
 	git_oidarray bases = {NULL, 0};
-	git_oid *input_array = xmalloc(sizeof(git_oid) * RARRAY_LEN(rb_args));
-	int len = (int)RARRAY_LEN(rb_args);
+	git_oid *input_array;
 
 	VALUE rb_bases;
 
 	if (len < 2)
-		rb_raise(rb_eArgError, "wrong number of arguments (%d for 2+)", len);
+		rb_raise(rb_eArgError, "wrong number of arguments (%ld for 2+)", RARRAY_LEN(rb_args));
 
 	Data_Get_Struct(self, git_repository, repo);
+
+	input_array = xmalloc(sizeof(git_oid) * len);
 
 	for (i = 0; !error && i < len; ++i) {
 		error = rugged_oid_get(&input_array[i], repo, rb_ary_entry(rb_args, i));

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -188,23 +188,25 @@ static void load_alternates(git_repository *repo, VALUE rb_alternates)
 
 static void rugged_repo_new_with_backend(git_repository **repo, VALUE rb_path, VALUE rb_backend)
 {
-	Check_Type(rb_path, T_STRING);
-	char *path = StringValuePtr(rb_path);
-
-	if(rb_obj_is_kind_of(rb_backend, rb_cRuggedBackend) == Qfalse) {
-		rb_raise(rb_eRuggedError, "Backend must be an instance of Rugged::Backend");
-	}
-
-	rugged_backend *backend;
-	Data_Get_Struct(rb_backend, rugged_backend, backend);
+	char *path;
 
 	git_odb *odb = NULL;
 	git_odb_backend *odb_backend = NULL;
 	git_refdb *refdb = NULL;
 	git_refdb_backend *refdb_backend = NULL;
 	git_reference *head = NULL;
+	rugged_backend *backend;
 
 	int error = 0;
+
+	Check_Type(rb_path, T_STRING);
+	path = StringValueCStr(rb_path);
+
+	if (rb_obj_is_kind_of(rb_backend, rb_cRuggedBackend) == Qfalse) {
+		rb_raise(rb_eRuggedError, "Backend must be an instance of Rugged::Backend");
+	}
+
+	Data_Get_Struct(rb_backend, rugged_backend, backend);
 
 	error = git_odb_new(&odb);
 	if (error) goto cleanup;
@@ -238,9 +240,8 @@ static void rugged_repo_new_with_backend(git_repository **repo, VALUE rb_path, V
 
 	if (!error) {
 		git_reference_free(head);
-	} else goto cleanup;
-
-	return;
+		return;
+	}
 
 cleanup:
 	git_repository_free(*repo);

--- a/ext/rugged/rugged_revwalk.c
+++ b/ext/rugged/rugged_revwalk.c
@@ -227,8 +227,7 @@ static VALUE rb_git_walker_push_range(VALUE self, VALUE range)
 {
 	git_revwalk *walk;
 	Data_Get_Struct(self, git_revwalk, walk);
-	int error = git_revwalk_push_range(walk, StringValuePtr(range));
-	rugged_exception_check(error);
+	rugged_exception_check(git_revwalk_push_range(walk, StringValueCStr(range)));
 	return Qnil;
 }
 


### PR DESCRIPTION
This fixes a bunch of warnings coming from gcc:

* `git_push` and related functions were made private in `libgit2`, we should be using the `git_remote_push` helper function instead.
* `rugged_repo_new_with_backend`, `rb_git_walker_push_range` were recently added and introduced some gcc warnings.
* `rb_git_repo_merge_bases` and `rb_git_remote_collection_each_name` caused some gcc warnings due to type mismatches on comparisons.

This fixes all these issues and brings us back to a clean build.