### PR TITLE
Win32 Builds on AppVeyor CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,11 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry (0.9.12.2-x86-mingw32)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+      win32console (~> 1.3)
     rake (10.1.0)
     rake-compiler (0.9.1)
       rake
@@ -220,9 +225,12 @@ GEM
     rubysl-yaml (2.0.4)
     rubysl-zlib (2.0.1)
     slop (3.4.5)
+    win32console (1.3.2-x86-mingw32)
 
 PLATFORMS
   ruby
+  x64-mingw32
+  x86-mingw32
 
 DEPENDENCIES
   minitest (~> 3.0.0)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+---
+version: "{build}"
+
+clone_depth: 10
+
+install:
+  - SET PATH=C:\Ruby%ruby_version%\DevKit\bin;C:\Ruby%ruby_version%\DevKit\mingw\bin;C:\Ruby%ruby_version%\bin;%PATH%
+  - ruby --version
+  - gem --version
+  - gem install bundler --quiet --no-ri --no-rdoc
+  - bundler --version
+  - bundle install --deployment
+  - choco install pkgconfiglite
+
+build_script:
+  - bundle exec rake
+
+on_success:
+  - bundle exec rake native gem
+
+artifacts:
+  - path: pkg\*.gem
+
+environment:
+  matrix:
+    - ruby_version: "193"
+    - ruby_version: "200"
+    - ruby_version: "200-x64"
+    - ruby_version: "21"
+    - ruby_version: "21-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - bundler --version
   - bundle install --deployment
   - choco install pkgconfiglite
-  - git config --global user.name 'The rugged tests are fragile'
+  - git config --global user.name Rugged
 
 build_script:
   - bundle exec rake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ install:
   - bundler --version
   - bundle install --deployment
   - choco install pkgconfiglite
+  - git config --global user.name 'The rugged tests are fragile'
 
 build_script:
   - bundle exec rake

--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -67,7 +67,7 @@ else
     sys(MAKE)
 
     pcfile = File.join(LIBGIT2_BUILD_DIR, "libgit2.pc")
-    $LDFLAGS << " " + `pkg-config --libs --static #{pcfile}`.strip
+    $LDFLAGS << " " + `pkg-config --libs-only-l --static #{pcfile}`.strip
   end
 
   # Prepend the vendored libgit2 build dir to the $DEFLIBPATH.

--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -20,7 +20,7 @@ if !(MAKE = find_executable('gmake') || find_executable('make'))
 end
 
 CWD = File.expand_path(File.dirname(__FILE__))
-LIBGIT2_DIR = File.join(CWD, '..', '..', 'vendor', 'libgit2')
+LIBGIT2_DIR = File.expand_path(File.join('..', '..', 'vendor', 'libgit2'), CWD)
 
 if arg_config("--use-system-libraries", !!ENV['RUGGED_USE_SYSTEM_LIBRARIES'])
   puts "Building Rugged using system libraries.\n"

--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -54,8 +54,6 @@ const char *RUGGED_ERROR_NAMES[] = {
 
 #define RUGGED_ERROR_COUNT (int)((sizeof(RUGGED_ERROR_NAMES)/sizeof(RUGGED_ERROR_NAMES[0])))
 
-VALUE rb_mRugged;
-VALUE rb_eRuggedError;
 VALUE rb_eRuggedErrors[RUGGED_ERROR_COUNT];
 
 static VALUE rb_mShutdownHook;
@@ -175,7 +173,7 @@ static VALUE rb_git_prettify_message(int argc, VALUE *argv, VALUE self)
 	rb_scan_args(argc, argv, "11", &rb_message, &rb_strip);
 
 	Check_Type(rb_message, T_STRING);
-	
+
 	switch (TYPE(rb_strip)) {
 	case T_FALSE:
 		strip_comments = 0;
@@ -495,4 +493,3 @@ void Init_rugged(void)
 	rb_mShutdownHook = Data_Wrap_Struct(rb_cObject, NULL, &cleanup_cb, NULL);
 	rb_global_variable(&rb_mShutdownHook);
 }
-

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -44,6 +44,25 @@
 #define rb_str_new_utf8(str) rb_enc_str_new(str, strlen(str), rb_utf8_encoding())
 #define CSTR2SYM(s) (ID2SYM(rb_intern((s))))
 
+VALUE rb_mRugged;
+VALUE rb_eRuggedError;
+
+#define RUGGED_GET_REPO(_obj, _target) \
+	{ \
+		struct rugged_repository * _rugged_repo; \
+		Data_Get_Struct(_obj, struct rugged_repository, _rugged_repo); \
+		if (_rugged_repo->closed) { \
+			rb_raise(rb_eRuggedError, "closed repository"); \
+		} \
+		_target = _rugged_repo->repo; \
+	} \
+
+struct rugged_repository
+{
+	git_repository * repo;
+	int closed;
+};
+
 /*
  * Initialization functions
  */

--- a/ext/rugged/rugged_blame.c
+++ b/ext/rugged/rugged_blame.c
@@ -152,7 +152,7 @@ static VALUE rb_git_blame_new(int argc, VALUE *argv, VALUE klass)
 	rb_scan_args(argc, argv, "20:", &rb_repo, &rb_path, &rb_options);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_path, T_STRING);
 

--- a/ext/rugged/rugged_blob.c
+++ b/ext/rugged/rugged_blob.c
@@ -158,7 +158,7 @@ static VALUE rb_git_blob_from_buffer(VALUE self, VALUE rb_repo, VALUE rb_buffer)
 	Check_Type(rb_buffer, T_STRING);
 	rugged_check_repo(rb_repo);
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_blob_create_frombuffer(&oid, repo, RSTRING_PTR(rb_buffer), RSTRING_LEN(rb_buffer));
 	rugged_exception_check(error);
@@ -185,7 +185,7 @@ static VALUE rb_git_blob_from_workdir(VALUE self, VALUE rb_repo, VALUE rb_path)
 	Check_Type(rb_path, T_STRING);
 	rugged_check_repo(rb_repo);
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_blob_create_fromworkdir(&oid, repo, StringValueCStr(rb_path));
 	rugged_exception_check(error);
@@ -213,7 +213,7 @@ static VALUE rb_git_blob_from_disk(VALUE self, VALUE rb_repo, VALUE rb_path)
 	Check_Type(rb_path, T_STRING);
 	rugged_check_repo(rb_repo);
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_blob_create_fromdisk(&oid, repo, StringValueCStr(rb_path));
 	rugged_exception_check(error);
@@ -293,7 +293,7 @@ static VALUE rb_git_blob_from_io(int argc, VALUE *argv, VALUE klass)
 	rb_scan_args(argc, argv, "21", &rb_repo, &rb_io, &rb_hint_path);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	if (!NIL_P(rb_hint_path)) {
 		Check_Type(rb_hint_path, T_STRING);
@@ -493,7 +493,7 @@ static VALUE rb_git_blob_to_buffer(int argc, VALUE *argv, VALUE self)
 	rb_scan_args(argc, argv, "21", &rb_repo, &rb_sha1, &rb_max_bytes);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	blob = (git_blob *)rugged_object_get(repo, rb_sha1, GIT_OBJ_BLOB);
 

--- a/ext/rugged/rugged_branch.c
+++ b/ext/rugged/rugged_branch.c
@@ -75,7 +75,7 @@ static VALUE rb_git_branch__remote_name(VALUE rb_repo, const char *canonical_nam
 	int error;
 	VALUE result = Qnil;
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	if ((error = git_branch_remote_name(&remote_name, repo, canonical_name)) == GIT_OK)
 		result = rb_enc_str_new(remote_name.ptr, remote_name.size, rb_utf8_encoding());

--- a/ext/rugged/rugged_branch_collection.c
+++ b/ext/rugged/rugged_branch_collection.c
@@ -144,7 +144,7 @@ static VALUE rb_git_branch_collection_create(int argc, VALUE *argv, VALUE self)
 	rb_scan_args(argc, argv, "20:", &rb_name, &rb_target, &rb_options);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_name, T_STRING);
 	Check_Type(rb_target, T_STRING);
@@ -200,7 +200,7 @@ static VALUE rb_git_branch_collection_aref(VALUE self, VALUE rb_name) {
 	int error;
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_name, T_STRING);
 
@@ -232,7 +232,7 @@ static VALUE each_branch(int argc, VALUE *argv, VALUE self, int branch_names_onl
 	if (!NIL_P(rb_filter))
 		filter = parse_branch_type(rb_filter);
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_branch_iterator_new(&iter, repo, filter);
 	rugged_exception_check(error);
@@ -312,7 +312,7 @@ static VALUE rb_git_branch_collection_delete(VALUE self, VALUE rb_name_or_branch
 	int error;
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = rugged_branch_lookup(&branch, repo, rb_name_or_branch);
 	rugged_exception_check(error);
@@ -367,7 +367,7 @@ static VALUE rb_git_branch_collection_move(int argc, VALUE *argv, VALUE self)
 	Check_Type(rb_new_branch_name, T_STRING);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 	
 	error = rugged_branch_lookup(&old_branch, repo, rb_name_or_branch);
 	rugged_exception_check(error);
@@ -411,7 +411,7 @@ static VALUE rb_git_branch_collection_exist_p(VALUE self, VALUE rb_name)
 	int error;
 
 	Check_Type(rb_name, T_STRING);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = rugged_branch_lookup(&branch, repo, rb_name);
 	git_reference_free(branch);

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -287,7 +287,7 @@ static VALUE rb_git_commit_amend(VALUE self, VALUE rb_data)
 	Data_Get_Struct(self, git_commit, commit_to_amend);
 
 	owner = rugged_owner(self);
-	Data_Get_Struct(owner, git_repository, repo);
+	RUGGED_GET_REPO(owner, repo);
 
 	rb_ref = rb_hash_aref(rb_data, CSTR2SYM("update_ref"));
 	if (!NIL_P(rb_ref)) {
@@ -384,7 +384,7 @@ static VALUE rb_git_commit_create(VALUE self, VALUE rb_repo, VALUE rb_data)
 	Check_Type(rb_data, T_HASH);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	rb_ref = rb_hash_aref(rb_data, CSTR2SYM("update_ref"));
 	if (!NIL_P(rb_ref)) {
@@ -513,7 +513,7 @@ static VALUE rb_git_commit_to_mbox(int argc, VALUE *argv, VALUE self)
 	rb_scan_args(argc, argv, ":", &rb_options);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Data_Get_Struct(self, git_commit, commit);
 

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -652,7 +652,7 @@ static VALUE rb_git_index_writetree(int argc, VALUE *argv, VALUE self)
 	if (rb_scan_args(argc, argv, "01", &rb_repo) == 1) {
 		git_repository *repo = NULL;
 		rugged_check_repo(rb_repo);
-		Data_Get_Struct(rb_repo, git_repository, repo);
+		RUGGED_GET_REPO(rb_repo, repo);
 		error = git_index_write_tree_to(&tree_oid, index, repo);
 	}
 	else {
@@ -805,7 +805,7 @@ static VALUE rb_git_index_diff(int argc, VALUE *argv, VALUE self)
 
 	Data_Get_Struct(self, git_index, index);
 	owner = rugged_owner(self);
-	Data_Get_Struct(owner, git_repository, repo);
+	RUGGED_GET_REPO(owner, repo);
 
 	if (NIL_P(rb_other)) {
 		error = git_diff_index_to_workdir(&diff, repo, index, &opts);
@@ -1084,7 +1084,7 @@ static VALUE rb_git_merge_file(int argc, VALUE *argv, VALUE self)
 	Data_Get_Struct(self, git_index, index);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_index_conflict_get(&ancestor, &ours, &theirs, index, StringValueCStr(rb_path));
 	if (error == GIT_ENOTFOUND)

--- a/ext/rugged/rugged_note.c
+++ b/ext/rugged/rugged_note.c
@@ -79,7 +79,7 @@ static VALUE rb_git_note_lookup(int argc, VALUE *argv, VALUE self)
 	Data_Get_Struct(self, git_object, object);
 
 	owner = rugged_owner(self);
-	Data_Get_Struct(owner, git_repository, repo);
+	RUGGED_GET_REPO(owner, repo);
 
 	error = git_note_read(&note, repo, notes_ref, git_object_id(object));
 
@@ -144,7 +144,7 @@ static VALUE rb_git_note_create(VALUE self, VALUE rb_data)
 	Data_Get_Struct(self, git_object, target);
 
 	owner = rugged_owner(self);
-	Data_Get_Struct(owner, git_repository, repo);
+	RUGGED_GET_REPO(owner, repo);
 
 	rb_ref = rb_hash_aref(rb_data, CSTR2SYM("ref"));
 
@@ -227,7 +227,7 @@ static VALUE rb_git_note_remove(int argc, VALUE *argv, VALUE self)
 	Data_Get_Struct(self, git_object, target);
 
 	owner = rugged_owner(self);
-	Data_Get_Struct(owner, git_repository, repo);
+	RUGGED_GET_REPO(owner, repo);
 
 	rb_scan_args(argc, argv, "01", &rb_data);
 
@@ -274,7 +274,7 @@ static int cb_note__each(const git_oid *blob_id, const git_oid *annotated_object
 
 	git_repository *repo;
 
-	Data_Get_Struct(payload->rb_data, git_repository, repo);
+	RUGGED_GET_REPO(payload->rb_data, repo);
 
 	rugged_exception_check(
 		git_object_lookup(&annotated_object, repo, annotated_object_id, GIT_OBJ_ANY)
@@ -314,6 +314,8 @@ static VALUE rb_git_note_each(int argc, VALUE *argv, VALUE self)
 	struct rugged_cb_payload payload = { self, 0 };
 	VALUE rb_notes_ref;
 
+	RUGGED_GET_REPO(self, repo);
+
 	rb_scan_args(argc, argv, "01", &rb_notes_ref);
 
 	if (!rb_block_given_p()) {
@@ -324,8 +326,6 @@ static VALUE rb_git_note_each(int argc, VALUE *argv, VALUE self)
 		Check_Type(rb_notes_ref, T_STRING);
 		notes_ref = StringValueCStr(rb_notes_ref);
 	}
-
-	Data_Get_Struct(self, git_repository, repo);
 
 	error = git_note_foreach(repo, notes_ref, &cb_note__each, &payload);
 
@@ -351,7 +351,7 @@ static VALUE rb_git_note_default_ref_GET(VALUE self)
 	git_repository *repo = NULL;
 	const char * ref_name;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	rugged_exception_check(
 		git_note_default_ref(&ref_name, repo)

--- a/ext/rugged/rugged_object.c
+++ b/ext/rugged/rugged_object.c
@@ -237,7 +237,7 @@ VALUE rb_git_object_lookup(VALUE klass, VALUE rb_repo, VALUE rb_hex)
 	if (oid_length > GIT_OID_HEXSZ)
 		rb_raise(rb_eTypeError, "The given OID is too long");
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_oid_fromstrn(&oid, RSTRING_PTR(rb_hex), oid_length);
 	rugged_exception_check(error);
@@ -265,7 +265,7 @@ VALUE rugged_object_rev_parse(VALUE rb_repo, VALUE rb_spec, int as_obj)
 
 	rugged_check_repo(rb_repo);
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_revparse_single(&object, repo, spec);
 	rugged_exception_check(error);

--- a/ext/rugged/rugged_reference_collection.c
+++ b/ext/rugged/rugged_reference_collection.c
@@ -84,7 +84,7 @@ static VALUE rb_git_reference_collection_create(int argc, VALUE *argv, VALUE sel
 	rb_scan_args(argc, argv, "20:", &rb_name, &rb_target, &rb_options);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 	Check_Type(rb_name, T_STRING);
 	Check_Type(rb_target, T_STRING);
 
@@ -130,7 +130,7 @@ static VALUE rb_git_reference_collection_aref(VALUE self, VALUE rb_name) {
 	git_reference *ref;
 	int error;
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_reference_lookup(&ref, repo, StringValueCStr(rb_name));
 
@@ -160,7 +160,7 @@ static VALUE rb_git_reference_collection__each(int argc, VALUE *argv, VALUE self
 
 	rugged_check_repo(rb_repo);
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	if (!NIL_P(rb_glob)) {
 		Check_Type(rb_glob, T_STRING);
@@ -251,7 +251,7 @@ static VALUE rb_git_reference_collection_exist_p(VALUE self, VALUE rb_name_or_re
 	if (TYPE(rb_name_or_ref) != T_STRING)
 		rb_raise(rb_eTypeError, "Expecting a String or Rugged::Reference instance");
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_reference_lookup(&ref, repo, StringValueCStr(rb_name_or_ref));
 	git_reference_free(ref);
@@ -317,7 +317,7 @@ static VALUE rb_git_reference_collection_rename(int argc, VALUE *argv, VALUE sel
 		rb_raise(rb_eTypeError, "Expecting a String or Rugged::Reference instance");
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	if (!NIL_P(rb_options)) {
 		VALUE rb_val;
@@ -403,7 +403,7 @@ static VALUE rb_git_reference_collection_update(int argc, VALUE *argv, VALUE sel
 	}
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_reference_lookup(&ref, repo, StringValueCStr(rb_name_or_ref));
 	rugged_exception_check(error);
@@ -455,7 +455,7 @@ static VALUE rb_git_reference_collection_delete(VALUE self, VALUE rb_name_or_ref
 		rb_raise(rb_eTypeError, "Expecting a String or Rugged::Reference instance");
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_reference_lookup(&ref, repo, StringValueCStr(rb_name_or_ref));
 	rugged_exception_check(error);

--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -640,7 +640,7 @@ static VALUE rb_git_remote_fetch(int argc, VALUE *argv, VALUE self)
 
 	Data_Get_Struct(self, git_remote, remote);
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &callbacks, &payload);
 
@@ -739,7 +739,7 @@ static VALUE rb_git_remote_push(int argc, VALUE *argv, VALUE self)
 	rugged_rb_ary_to_strarray(rb_refspecs, &refspecs);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 	Data_Get_Struct(self, git_remote, remote);
 
 	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &callbacks, &payload);

--- a/ext/rugged/rugged_remote_collection.c
+++ b/ext/rugged/rugged_remote_collection.c
@@ -62,7 +62,7 @@ static VALUE rb_git_remote_collection_create_anonymous(VALUE self, VALUE rb_url)
 	VALUE rb_repo = rugged_owner(self);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_url, T_STRING);
 
@@ -98,7 +98,7 @@ static VALUE rb_git_remote_collection_create(VALUE self, VALUE rb_name, VALUE rb
 	VALUE rb_repo = rugged_owner(self);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_name, T_STRING);
 	Check_Type(rb_url, T_STRING);
@@ -133,7 +133,7 @@ static VALUE rb_git_remote_collection_aref(VALUE self, VALUE rb_name)
 
 	VALUE rb_repo = rugged_owner(self);
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_name, T_STRING);
 
@@ -166,7 +166,7 @@ static VALUE rb_git_remote_collection__each(VALUE self, int only_names)
 
 	rb_repo = rugged_owner(self);
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_remote_list(&remotes, repo);
 	rugged_exception_check(error);
@@ -267,7 +267,7 @@ static VALUE rb_git_remote_collection_rename(VALUE self, VALUE rb_name_or_remote
 		rb_raise(rb_eTypeError, "Expecting a String or Rugged::Remote instance");
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_remote_rename(&problems, repo, StringValueCStr(rb_name_or_remote), StringValueCStr(rb_new_name));
 	rugged_exception_check(error);
@@ -307,7 +307,7 @@ static VALUE rb_git_remote_collection_delete(VALUE self, VALUE rb_name_or_remote
 		rb_raise(rb_eTypeError, "Expecting a String or Rugged::Remote instance");
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_remote_delete(repo, StringValueCStr(rb_name_or_remote));
 	rugged_exception_check(error);

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -146,12 +146,6 @@ VALUE rugged_repo_new(VALUE klass, git_repository *repo)
 {
 	VALUE rb_repo = Data_Wrap_Struct(klass, NULL, &rb_git_repo__free, repo);
 
-#ifdef HAVE_RUBY_ENCODING_H
-	/* TODO: set this properly */
-	rb_iv_set(rb_repo, "@encoding",
-		rb_enc_from_encoding(rb_filesystem_encoding()));
-#endif
-
 	rb_iv_set(rb_repo, "@config", Qnil);
 	rb_iv_set(rb_repo, "@index", Qnil);
 

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -137,14 +137,21 @@ VALUE rugged_raw_read(git_repository *repo, const git_oid *oid)
 	return Data_Wrap_Struct(rb_cRuggedOdbObject, NULL, rb_git__odbobj_free, obj);
 }
 
-void rb_git_repo__free(git_repository *repo)
+void rb_git_repo__free(struct rugged_repository * wrapper)
 {
-	git_repository_free(repo);
+	if (!wrapper->closed) {
+		git_repository_free(wrapper->repo);
+	}
+	xfree(wrapper);
 }
 
 VALUE rugged_repo_new(VALUE klass, git_repository *repo)
 {
-	VALUE rb_repo = Data_Wrap_Struct(klass, NULL, &rb_git_repo__free, repo);
+	struct rugged_repository * wrapper = malloc(sizeof(struct rugged_repository));
+	VALUE rb_repo = Data_Wrap_Struct(klass, NULL, &rb_git_repo__free, wrapper);
+
+	wrapper->repo = repo;
+	wrapper->closed = 0;
 
 	rb_iv_set(rb_repo, "@config", Qnil);
 	rb_iv_set(rb_repo, "@index", Qnil);
@@ -502,7 +509,7 @@ static VALUE rb_git_repo_clone_at(int argc, VALUE *argv, VALUE klass)
 		git_repository *repo; \
 		git_##_object *data; \
 		int error; \
-		Data_Get_Struct(self, git_repository, repo); \
+		RUGGED_GET_REPO(self, repo); \
 		error = git_repository_##_object(&data, repo); \
 		rugged_exception_check(error); \
 		rb_data = rugged_##_object##_new(_klass, self, data); \
@@ -520,7 +527,7 @@ static VALUE rb_git_repo_clone_at(int argc, VALUE *argv, VALUE klass)
 	if (!NIL_P(rugged_owner(rb_data))) \
 		rb_raise(rb_eRuntimeError, \
 			"The given object is already owned by another repository"); \
-	Data_Get_Struct(self, git_repository, repo); \
+	RUGGED_GET_REPO(self, repo); \
 	Data_Get_Struct(rb_data, git_##_object, data); \
 	git_repository_set_##_object(repo, data); \
 	rb_old_data = rb_iv_get(self, "@" #_object); \
@@ -603,10 +610,10 @@ static VALUE rb_git_repo_merge_base(VALUE self, VALUE rb_args)
 	git_oid base, *input_array = xmalloc(sizeof(git_oid) * RARRAY_LEN(rb_args));
 	int len = (int)RARRAY_LEN(rb_args);
 
+	RUGGED_GET_REPO(self, repo);
+
 	if (len < 2)
 		rb_raise(rb_eArgError, "wrong number of arguments (%d for 2+)", len);
-
-	Data_Get_Struct(self, git_repository, repo);
 
 	for (i = 0; !error && i < len; ++i) {
 		error = rugged_oid_get(&input_array[i], repo, rb_ary_entry(rb_args, i));
@@ -650,7 +657,7 @@ static VALUE rb_git_repo_merge_bases(VALUE self, VALUE rb_args)
 	if (len < 2)
 		rb_raise(rb_eArgError, "wrong number of arguments (%ld for 2+)", RARRAY_LEN(rb_args));
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	input_array = xmalloc(sizeof(git_oid) * len);
 
@@ -718,7 +725,7 @@ static VALUE rb_git_repo_merge_analysis(int argc, VALUE *argv, VALUE self)
 
 	rb_scan_args(argc, argv, "10", &rb_their_commit);
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	if (TYPE(rb_their_commit) == T_STRING) {
 		rb_their_commit = rugged_object_rev_parse(self, rb_their_commit, 1);
@@ -793,7 +800,7 @@ static VALUE rb_git_repo_merge_commits(int argc, VALUE *argv, VALUE self)
 		rugged_parse_merge_options(&opts, rb_options);
 	}
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	Data_Get_Struct(rb_our_commit, git_commit, our_commit);
 	Data_Get_Struct(rb_their_commit, git_commit, their_commit);
 
@@ -820,7 +827,7 @@ static VALUE rb_git_repo_exists(VALUE self, VALUE hex)
 	git_oid oid;
 	int error;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	Check_Type(hex, T_STRING);
 
 	error = git_oid_fromstrn(&oid, RSTRING_PTR(hex), RSTRING_LEN(hex));
@@ -850,7 +857,7 @@ static VALUE rb_git_repo_read(VALUE self, VALUE hex)
 	git_oid oid;
 	int error;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	Check_Type(hex, T_STRING);
 
 	error = git_oid_fromstr(&oid, StringValueCStr(hex));
@@ -884,7 +891,7 @@ static VALUE rb_git_repo_read_header(VALUE self, VALUE hex)
 	VALUE rb_hash;
 	int error;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	Check_Type(hex, T_STRING);
 
 	error = git_oid_fromstr(&oid, StringValueCStr(hex));
@@ -927,7 +934,7 @@ static VALUE rb_git_repo_expand_oids(int argc, VALUE *argv, VALUE self)
 	git_odb *odb;
 	int i, error;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	rb_scan_args(argc, argv, "11", &rb_oids, &rb_expected_type);
 
@@ -991,7 +998,7 @@ static VALUE rb_git_repo_descendant_of(VALUE self, VALUE rb_commit, VALUE rb_anc
 	git_repository *repo;
 	git_oid commit, ancestor;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	error = rugged_oid_get(&commit, repo, rb_commit);
 	rugged_exception_check(error);
@@ -1084,7 +1091,7 @@ static VALUE rb_git_repo_write(VALUE self, VALUE rb_buffer, VALUE rub_type)
 
 	git_otype type;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	Check_Type(rb_buffer, T_STRING);
 
 	error = git_repository_odb(&odb, repo);
@@ -1109,7 +1116,7 @@ static VALUE rb_git_repo_write(VALUE self, VALUE rb_buffer, VALUE rub_type)
 #define RB_GIT_REPO_GETTER(method) \
 	git_repository *repo; \
 	int error; \
-	Data_Get_Struct(self, git_repository, repo); \
+	RUGGED_GET_REPO(self, repo); \
 	error = git_repository_##method(repo); \
 	rugged_exception_check(error); \
 	return error ? Qtrue : Qfalse; \
@@ -1185,7 +1192,7 @@ static VALUE rb_git_repo_set_head(VALUE self, VALUE rb_head)
 	git_repository *repo;
 	int error;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	Check_Type(rb_head, T_STRING);
 	error = git_repository_set_head(repo, StringValueCStr(rb_head), NULL, NULL);
@@ -1208,7 +1215,7 @@ static VALUE rb_git_repo_get_head(VALUE self)
 	git_reference *head;
 	int error;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	error = git_repository_head(&head, repo);
 	if (error == GIT_ENOTFOUND)
@@ -1233,7 +1240,7 @@ static VALUE rb_git_repo_path(VALUE self)
 	git_repository *repo;
 	const char *path;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	path = git_repository_path(repo);
 
 	return path ? rb_str_new_utf8(path) : Qnil;
@@ -1257,7 +1264,7 @@ static VALUE rb_git_repo_workdir(VALUE self)
 	git_repository *repo;
 	const char *workdir;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	workdir = git_repository_workdir(repo);
 
 	return workdir ? rb_str_new_utf8(workdir) : Qnil;
@@ -1283,7 +1290,7 @@ static VALUE rb_git_repo_set_workdir(VALUE self, VALUE rb_workdir)
 {
 	git_repository *repo;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	Check_Type(rb_workdir, T_STRING);
 
 	rugged_exception_check(
@@ -1424,7 +1431,7 @@ static VALUE rb_git_repo_status(int argc, VALUE *argv, VALUE self)
 	VALUE rb_path;
 	git_repository *repo;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	if (rb_scan_args(argc, argv, "01", &rb_path) == 1) {
 		unsigned int flags;
@@ -1475,7 +1482,7 @@ static VALUE rb_git_repo_each_id(VALUE self)
 	if (!rb_block_given_p())
 		return rb_funcall(self, rb_intern("to_enum"), 1, CSTR2SYM("each_id"));
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	error = git_repository_odb(&odb, repo);
 	rugged_exception_check(error);
@@ -1552,7 +1559,7 @@ static VALUE rb_git_repo_reset(int argc, VALUE *argv, VALUE self)
 
 	rb_scan_args(argc, argv, "20:", &rb_target, &rb_reset_type, &rb_options);
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	reset_type = parse_reset_type(rb_reset_type);
 	target = rugged_object_get(repo, rb_target, GIT_OBJ_ANY);
@@ -1606,7 +1613,7 @@ static VALUE rb_git_repo_reset_path(int argc, VALUE *argv, VALUE self)
 	pathspecs.strings = NULL;
 	pathspecs.count = 0;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	rb_scan_args(argc, argv, "11", &rb_paths, &rb_target);
 
@@ -1637,10 +1644,15 @@ static VALUE rb_git_repo_reset_path(int argc, VALUE *argv, VALUE self)
  */
 static VALUE rb_git_repo_close(VALUE self)
 {
-	git_repository *repo;
-	Data_Get_Struct(self, git_repository, repo);
+	struct rugged_repository *wrapper;
 
-	git_repository__cleanup(repo);
+	Data_Get_Struct(self, struct rugged_repository, wrapper);
+	if (wrapper->closed) {
+		rb_raise(rb_eRuggedError, "closed repository");
+	}
+
+	git_repository_free(wrapper->repo);
+	wrapper->closed = 1;
 
 	return Qnil;
 }
@@ -1657,7 +1669,7 @@ static VALUE rb_git_repo_set_namespace(VALUE self, VALUE rb_namespace)
 	git_repository *repo;
 	int error;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	if (!NIL_P(rb_namespace)) {
 		Check_Type(rb_namespace, T_STRING);
@@ -1681,7 +1693,7 @@ static VALUE rb_git_repo_get_namespace(VALUE self)
 	git_repository *repo;
 	const char *namespace;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	namespace = git_repository_get_namespace(repo);
 	return namespace ? rb_str_new_utf8(namespace) : Qnil;
@@ -1704,7 +1716,7 @@ static VALUE rb_git_repo_ahead_behind(VALUE self, VALUE rb_local, VALUE rb_upstr
 	size_t ahead, behind;
 	VALUE rb_result;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	error = rugged_oid_get(&local, repo, rb_local);
 	rugged_exception_check(error);
@@ -1743,7 +1755,7 @@ static VALUE rb_git_repo_default_signature(VALUE self) {
 	git_signature *signature;
 	VALUE rb_signature;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	error = git_signature_default(&signature, repo);
 
@@ -2109,7 +2121,7 @@ static VALUE rb_git_checkout_tree(int argc, VALUE *argv, VALUE self)
 		rb_raise(rb_eTypeError, "Expected Rugged::Commit, Rugged::Tag or Rugged::Tree");
 	}
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	Data_Get_Struct(rb_treeish, git_object, treeish);
 
 	rugged_parse_checkout_options(&opts, rb_options);
@@ -2153,7 +2165,7 @@ static VALUE rb_git_checkout_head(int argc, VALUE *argv, VALUE self)
 
 	rb_scan_args(argc, argv, "00:", &rb_options);
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 
 	rugged_parse_checkout_options(&opts, rb_options);
 
@@ -2190,7 +2202,7 @@ static VALUE rb_git_repo_is_path_ignored(VALUE self, VALUE rb_path) {
 	int error;
 	int ignored;
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	path = StringValueCStr(rb_path);
 	error = git_ignore_path_is_ignored(&ignored, repo, path);
 	rugged_exception_check(error);
@@ -2246,7 +2258,7 @@ static VALUE rb_git_repo_attributes(int argc, VALUE *argv, VALUE self)
 
 	rb_scan_args(argc, argv, "12", &rb_path, &rb_names, &rb_options);
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	Check_Type(rb_path, T_STRING);
 
 	if (!NIL_P(rb_options)) {
@@ -2359,7 +2371,7 @@ static VALUE rb_git_repo_cherrypick(int argc, VALUE *argv, VALUE self)
 		rb_raise(rb_eArgError, "Expected a Rugged::Commit.");
 	}
 
-	Data_Get_Struct(self, git_repository, repo);
+	RUGGED_GET_REPO(self, repo);
 	Data_Get_Struct(rb_commit, git_commit, commit);
 
 	rugged_parse_cherrypick_options(&opts, rb_options);

--- a/ext/rugged/rugged_revwalk.c
+++ b/ext/rugged/rugged_revwalk.c
@@ -52,7 +52,7 @@ static VALUE rb_git_walker_new(VALUE klass, VALUE rb_repo)
 	git_revwalk *walk;
 	int error;
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_revwalk_new(&walk, repo);
 	rugged_exception_check(error);

--- a/ext/rugged/rugged_submodule_collection.c
+++ b/ext/rugged/rugged_submodule_collection.c
@@ -80,7 +80,7 @@ static VALUE rb_git_submodule_collection_aref(VALUE self, VALUE rb_name)
 	int error;
 
 	VALUE rb_repo = rugged_owner(self);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_name, T_STRING);
 
@@ -106,7 +106,7 @@ static int cb_submodule__each(git_submodule *submodule, const char *name, void *
 	VALUE rb_repo;
 
 	rb_repo = payload->rb_data;
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	/* The submodule passed here has it's refcount decreased just after
 	 * the foreach finishes. The only way to increase that refcount is
@@ -143,7 +143,7 @@ static VALUE rb_git_submodule_collection_each(VALUE self)
 	struct rugged_cb_payload payload;
 
 	VALUE rb_repo = rugged_owner(self);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	if (!rb_block_given_p())
 		return rb_funcall(self, rb_intern("to_enum"), 1, CSTR2SYM("each"));
@@ -202,7 +202,7 @@ static VALUE rb_git_submodule_setup_add(int argc, VALUE *argv, VALUE self)
 	Check_Type(rb_path, T_STRING);
 
 	rb_repo = rugged_owner(self);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	if (!NIL_P(rb_options)) {
 		VALUE rb_val;

--- a/ext/rugged/rugged_tag.c
+++ b/ext/rugged/rugged_tag.c
@@ -176,7 +176,7 @@ static VALUE rb_git_tag_annotation(VALUE self)
 
 	rugged_check_repo(rb_repo);
 	Data_Get_Struct(self, git_reference, ref);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_reference_resolve(&resolved_ref, ref);
 	rugged_exception_check(error);
@@ -204,7 +204,7 @@ static VALUE rb_git_tag_target(VALUE self)
 
 	rugged_check_repo(rb_repo);
 	Data_Get_Struct(self, git_reference, ref);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_reference_resolve(&resolved_ref, ref);
 	rugged_exception_check(error);

--- a/ext/rugged/rugged_tag_collection.c
+++ b/ext/rugged/rugged_tag_collection.c
@@ -59,7 +59,7 @@ static VALUE rb_git_tag_collection_aref(VALUE self, VALUE rb_name)
 	VALUE rb_repo = rugged_owner(self);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_name, T_STRING);
 
@@ -93,7 +93,7 @@ static VALUE rb_git_tag_collection_delete(VALUE self, VALUE rb_name)
 	int error;
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_name, T_STRING);
 
@@ -133,7 +133,7 @@ static VALUE rb_git_tag_collection_create(int argc, VALUE *argv, VALUE self)
 	rb_scan_args(argc, argv, "21:", &rb_name, &rb_target, &rb_force, &rb_annotation);
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_name, T_STRING);
 
@@ -211,7 +211,7 @@ static VALUE rb_git_tag_collection_create_annotation(VALUE self, VALUE rb_name, 
 
 	VALUE rb_repo = rugged_owner(self);
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	Check_Type(rb_name, T_STRING);
 
@@ -266,7 +266,7 @@ static VALUE each_tag(int argc, VALUE *argv, VALUE self, int tag_names_only)
 	}
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_tag_list_match(&tags, pattern ? pattern : "", repo);
 	rugged_exception_check(error);

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -423,7 +423,7 @@ static VALUE rb_git_tree_diff_(int argc, VALUE *argv, VALUE self)
 	rb_scan_args(argc, argv, "22", &rb_repo, &rb_self, &rb_other, &rb_options);
 	rugged_parse_diff_options(&opts, rb_options);
 
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	if (!NIL_P(rb_self)) {
 		if (!rb_obj_is_kind_of(rb_self, rb_cRuggedTree))
@@ -501,7 +501,7 @@ static VALUE rb_git_tree_diff_workdir(int argc, VALUE *argv, VALUE self)
 
 	Data_Get_Struct(self, git_tree, tree);
 	owner = rugged_owner(self);
-	Data_Get_Struct(owner, git_repository, repo);
+	RUGGED_GET_REPO(owner, repo);
 
 	error = git_diff_tree_to_workdir(&diff, repo, tree, &opts);
 
@@ -610,7 +610,7 @@ static VALUE rb_git_tree_merge(int argc, VALUE *argv, VALUE self)
 		rb_raise(rb_eTypeError, "Expecting a Rugged::Tree instance");
 
 	Data_Get_Struct(self, git_tree, tree);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 	Data_Get_Struct(rb_other_tree, git_tree, other_tree);
 
 	if (!NIL_P(rb_ancestor_tree))
@@ -656,7 +656,7 @@ static VALUE rb_git_treebuilder_new(int argc, VALUE *argv, VALUE klass)
 	}
 
 	rugged_check_repo(rb_repo);
-	Data_Get_Struct(rb_repo, git_repository, repo);
+	RUGGED_GET_REPO(rb_repo, repo);
 
 	error = git_treebuilder_new(&builder, repo, tree);
 	rugged_exception_check(error);

--- a/lib/rugged/submodule_collection.rb
+++ b/lib/rugged/submodule_collection.rb
@@ -22,8 +22,13 @@ module Rugged
     # Returns the newly created +submodule+
     def add(url, path, options = {})
       submodule = setup_add(url, path, options)
-      clone_submodule(submodule.repository, options)
-      submodule.finalize_add
+      repo = submodule.repository
+      begin
+        clone_submodule(repo, options)
+        submodule.finalize_add
+      ensure
+        repo.close
+      end
     end
 
     private

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -314,80 +314,88 @@ class TreeToWorkdirDiffTest < Rugged::SandboxedTestCase
 
   def test_diff_merge
     repo = sandbox_init("status")
-    index = repo.index
+    begin
+      index = repo.index
 
-    a = Rugged::Commit.lookup(repo, "26a125ee1bf").tree
+      a = Rugged::Commit.lookup(repo, "26a125ee1bf").tree
 
-    # merge diffs to simulate "git diff 26a125ee1bf"
+      # merge diffs to simulate "git diff 26a125ee1bf"
 
-    diff  = a.diff(index, :include_ignored => true, :include_untracked => true)
-    diff2 = index.diff(:include_ignored => true, :include_untracked => true)
-    diff.merge!(diff2)
+      diff  = a.diff(index, :include_ignored => true, :include_untracked => true)
+      diff2 = index.diff(:include_ignored => true, :include_untracked => true)
+      diff.merge!(diff2)
 
-    deltas = diff.deltas
-    patches = diff.patches
-    hunks = patches.map(&:hunks).flatten
-    lines = hunks.map(&:lines).flatten
+      deltas = diff.deltas
+      patches = diff.patches
+      hunks = patches.map(&:hunks).flatten
+      lines = hunks.map(&:lines).flatten
 
-    # expected values differ from "git diff --porcelain 26a125ee1bf"
-    # because that includes the file "staged_delete_modified_file" twice,
-    # once in the deleted list and again the untracked list and libgit2
-    # does not do that with a merged diff (though it would with status)
+      # expected values differ from "git diff --porcelain 26a125ee1bf"
+      # because that includes the file "staged_delete_modified_file" twice,
+      # once in the deleted list and again the untracked list and libgit2
+      # does not do that with a merged diff (though it would with status)
 
-    assert_equal 15, deltas.size
-    assert_equal 15, patches.size
+      assert_equal 15, deltas.size
+      assert_equal 15, patches.size
 
-    assert_equal 2, deltas.select(&:added?).size
-    assert_equal 5, deltas.select(&:deleted?).size
-    assert_equal 4, deltas.select(&:modified?).size
-    assert_equal 1, deltas.select(&:ignored?).size
-    assert_equal 3, deltas.select(&:untracked?).size
+      assert_equal 2, deltas.select(&:added?).size
+      assert_equal 5, deltas.select(&:deleted?).size
+      assert_equal 4, deltas.select(&:modified?).size
+      assert_equal 1, deltas.select(&:ignored?).size
+      assert_equal 3, deltas.select(&:untracked?).size
 
-    assert_equal 11, hunks.size
+      assert_equal 11, hunks.size
 
-    assert_equal 17, lines.size
-    assert_equal 4, lines.select(&:context?).size
-    assert_equal 8, lines.select(&:addition?).size
-    assert_equal 5, lines.select(&:deletion?).size
+      assert_equal 17, lines.size
+      assert_equal 4, lines.select(&:context?).size
+      assert_equal 8, lines.select(&:addition?).size
+      assert_equal 5, lines.select(&:deletion?).size
+    ensure
+      repo.close
+    end
   end
 
   def test_stats
     repo = sandbox_init("status")
-    index = repo.index
+    begin
+      index = repo.index
 
-    a = Rugged::Commit.lookup(repo, "26a125ee1bf").tree
+      a = Rugged::Commit.lookup(repo, "26a125ee1bf").tree
 
-    # merge diffs to simulate "git diff 26a125ee1bf"
+      # merge diffs to simulate "git diff 26a125ee1bf"
 
-    diff  = a.diff(index, :include_ignored => true, :include_untracked => true)
-    diff2 = index.diff(:include_ignored => true, :include_untracked => true)
-    diff.merge!(diff2)
+      diff  = a.diff(index, :include_ignored => true, :include_untracked => true)
+      diff2 = index.diff(:include_ignored => true, :include_untracked => true)
+      diff.merge!(diff2)
 
-    # expected values from: git diff --stat 26a125ee1bf
-    files, adds, dels = diff.stat
-    assert_equal 11, files
-    assert_equal 8, adds
-    assert_equal 5, dels
+      # expected values from: git diff --stat 26a125ee1bf
+      files, adds, dels = diff.stat
+      assert_equal 11, files
+      assert_equal 8, adds
+      assert_equal 5, dels
 
-    # expected per-file values from the diff --stat output plus total lines
-    expected_patch_stat = [
-      [ 0, 1, 1 ], [ 1, 0, 2 ], [ 1, 0, 2 ], [ 0, 1, 1 ], [ 2, 0, 3 ],
-      [ 0, 1, 1 ], [ 0, 1, 1 ], [ 1, 0, 1 ], [ 2, 0, 2 ], [ 0, 1, 1 ],
-      [ 1, 0, 2 ]
-    ]
+      # expected per-file values from the diff --stat output plus total lines
+      expected_patch_stat = [
+        [ 0, 1, 1 ], [ 1, 0, 2 ], [ 1, 0, 2 ], [ 0, 1, 1 ], [ 2, 0, 3 ],
+        [ 0, 1, 1 ], [ 0, 1, 1 ], [ 1, 0, 1 ], [ 2, 0, 2 ], [ 0, 1, 1 ],
+        [ 1, 0, 2 ]
+      ]
 
-    diff.each_patch do |patch|
-      next if [:unmodified, :ignored, :untracked].include? patch.delta.status
+      diff.each_patch do |patch|
+        next if [:unmodified, :ignored, :untracked].include? patch.delta.status
 
-      expected_adds, expected_dels, expected_lines = expected_patch_stat.shift
+        expected_adds, expected_dels, expected_lines = expected_patch_stat.shift
 
-      actual_adds, actual_dels = patch.stat
+        actual_adds, actual_dels = patch.stat
 
-      assert_equal expected_adds, actual_adds
-      assert_equal expected_dels, actual_dels
-      assert_equal expected_adds + expected_dels, patch.changes
+        assert_equal expected_adds, actual_adds
+        assert_equal expected_dels, actual_dels
+        assert_equal expected_adds + expected_dels, patch.changes
 
-      assert_equal expected_lines, patch.lines
+        assert_equal expected_lines, patch.lines
+      end
+    ensure
+      repo.close
     end
   end
 end

--- a/test/repo_test.rb
+++ b/test/repo_test.rb
@@ -495,7 +495,7 @@ end
 class RepositoryCloneTest < Rugged::TestCase
   def setup
     @tmppath = Dir.mktmpdir
-    @source_path = "file://" + File.join(Rugged::TestCase::TEST_DIR, 'fixtures', 'testrepo.git')
+    @source_path = "file://" + File.join("", Rugged::TestCase::TEST_DIR, 'fixtures', 'testrepo.git')
   end
 
   def teardown

--- a/test/submodule_test.rb
+++ b/test/submodule_test.rb
@@ -44,49 +44,53 @@ class SubmoduleTest < Rugged::SubmoduleTestCase
     submodule_repo = submodule.repository
     assert_instance_of Rugged::Repository, submodule_repo
 
-    assert :none, submodule.ignore_rule
-    assert submodule.path.end_with?('sm_unchanged')
-    assert submodule.url.end_with?('submod2_target')
-    assert_equal 'sm_unchanged', submodule.name
+    begin
+      assert :none, submodule.ignore_rule
+      assert submodule.path.end_with?('sm_unchanged')
+      assert submodule.url.end_with?('submod2_target')
+      assert_equal 'sm_unchanged', submodule.name
 
-    assert_equal oid, submodule.head_oid
-    assert_equal oid, submodule.index_oid
-    assert_equal oid, submodule.workdir_oid
+      assert_equal oid, submodule.head_oid
+      assert_equal oid, submodule.index_oid
+      assert_equal oid, submodule.workdir_oid
 
-    # changed head
-    submodule = @repo.submodules['sm_changed_head']
+      # changed head
+      submodule = @repo.submodules['sm_changed_head']
 
-    assert_equal 'sm_changed_head', submodule.name
-    assert_equal oid, submodule.head_oid
-    assert_equal oid, submodule.index_oid
-    assert_equal '3d9386c507f6b093471a3e324085657a3c2b4247', submodule.workdir_oid
+      assert_equal 'sm_changed_head', submodule.name
+      assert_equal oid, submodule.head_oid
+      assert_equal oid, submodule.index_oid
+      assert_equal '3d9386c507f6b093471a3e324085657a3c2b4247', submodule.workdir_oid
 
-    # added and uncommited
-    submodule = @repo.submodules['sm_added_and_uncommited']
+      # added and uncommited
+      submodule = @repo.submodules['sm_added_and_uncommited']
 
-    assert_equal 'sm_added_and_uncommited', submodule.name
-    assert_nil submodule.head_oid
-    assert_equal oid, submodule.index_oid
-    assert_equal oid, submodule.workdir_oid
+      assert_equal 'sm_added_and_uncommited', submodule.name
+      assert_nil submodule.head_oid
+      assert_equal oid, submodule.index_oid
+      assert_equal oid, submodule.workdir_oid
 
-    # missing commits
-    submodule = @repo.submodules['sm_missing_commits']
-    assert_equal 'sm_missing_commits', submodule.name
-    assert_equal oid, submodule.head_oid
-    assert_equal oid, submodule.index_oid
-    assert_equal '5e4963595a9774b90524d35a807169049de8ccad', submodule.workdir_oid
+      # missing commits
+      submodule = @repo.submodules['sm_missing_commits']
+      assert_equal 'sm_missing_commits', submodule.name
+      assert_equal oid, submodule.head_oid
+      assert_equal oid, submodule.index_oid
+      assert_equal '5e4963595a9774b90524d35a807169049de8ccad', submodule.workdir_oid
 
-    # status checks
-    submodule = @repo.submodules['sm_unchanged']
+      # status checks
+      submodule = @repo.submodules['sm_unchanged']
 
-    expected = [:in_head, :in_index, :in_config, :in_workdir]
-    assert_equal expected, submodule.status
-    assert submodule.in_head?
-    assert submodule.in_index?
-    assert submodule.in_config?
-    assert submodule.in_workdir?
-    assert submodule.unmodified?
-    refute submodule.dirty_workdir?
+      expected = [:in_head, :in_index, :in_config, :in_workdir]
+      assert_equal expected, submodule.status
+      assert submodule.in_head?
+      assert submodule.in_index?
+      assert submodule.in_config?
+      assert submodule.in_workdir?
+      assert submodule.unmodified?
+      refute submodule.dirty_workdir?
+    ensure
+      submodule_repo.close
+    end
   end
 
   def test_submodule_each
@@ -323,7 +327,14 @@ class SubmoduleTest < Rugged::SubmoduleTestCase
     assert File.file?(File.join(@repo.workdir, submod_path, 'README'))
 
     # sets up master as a remote tracking branch
-    assert submodule.repository.branches['master']
-    assert_equal 'origin/master', submodule.repository.branches['master'].upstream.name
+    submodule_repo = submodule.repository
+    assert_instance_of Rugged::Repository, submodule_repo
+
+    begin
+      assert submodule_repo.branches['master']
+      assert_equal 'origin/master', submodule_repo.branches['master'].upstream.name
+    ensure
+      submodule_repo.close
+    end
   end
 end

--- a/test/submodule_test.rb
+++ b/test/submodule_test.rb
@@ -6,6 +6,11 @@ class SubmoduleTest < Rugged::SubmoduleTestCase
     @repo = setup_submodule
   end
 
+  def teardown
+    @repo.close
+    super
+  end
+
   class TestException < StandardError
   end
 

--- a/test/tag_test.rb
+++ b/test/tag_test.rb
@@ -153,6 +153,11 @@ class AnnotatedTagObjectTest < Rugged::SandboxedTestCase
     })
   end
 
+  def teardown
+    @repo.close
+    super
+  end
+
   def test_annotation
     assert_kind_of Rugged::Tag::Annotation, @annotation
     assert_equal "test tag message\n", @annotation.message

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,23 +33,28 @@ module Rugged
       super
     end
 
-    def sandbox_fixture(repository)
-      FileUtils.cp_r(File.join(TestCase::LIBGIT2_FIXTURE_DIR, repository), @_sandbox_path)
+    def sandbox_fixture(repository_name)
+      FileUtils.cp_r(File.join(TestCase::LIBGIT2_FIXTURE_DIR, repository_name), @_sandbox_path)
     end
 
-    # Fills the current sandbox folder with the files
-    # found in the given repository
-    def sandbox_init(repository)
-      sandbox_fixture(repository)
-
-      fixture_repo_path = File.join(@_sandbox_path, repository)
-      Dir.chdir(fixture_repo_path) do
+    def prepare_fixture(repository_name)
+      Dir.chdir(File.join(@_sandbox_path, repository_name)) do
         File.rename(".gitted", ".git") if File.exist?(".gitted")
         File.rename("gitattributes", ".gitattributes") if File.exist?("gitattributes")
         File.rename("gitignore", ".gitignore") if File.exist?("gitignore")
       end
+    end
 
-      Rugged::Repository.new(fixture_repo_path)
+    def open_fixture(repository_name)
+      Rugged::Repository.new(File.join(@_sandbox_path, repository_name))
+    end
+
+    # Fills the current sandbox folder with the files
+    # found in the given repository name
+    def sandbox_init(repository_name)
+      sandbox_fixture(repository_name)
+      prepare_fixture(repository_name)
+      open_fixture(repository_name)
     end
 
     def sandbox_clone(repository, name)
@@ -104,32 +109,20 @@ module Rugged
     end
 
     def setup_submodule
-      repository = sandbox_init('submod2')
+      sandbox_fixture('submod2')
+      prepare_fixture('submod2')
+      prepare_fixture(File.join('submod2', 'not'))
+      prepare_fixture(File.join('submod2', 'not-submodule'))
+
       sandbox_fixture('submod2_target')
+      prepare_fixture('submod2_target')
 
-      Dir.chdir(@_sandbox_path) do
-        File.rename(
-          File.join('submod2_target', '.gitted'),
-          File.join('submod2_target', '.git')
-        )
-
-        rewrite_gitmodules(repository.workdir)
-
-        File.rename(
-          File.join('submod2', 'not-submodule', '.gitted'),
-          File.join('submod2', 'not-submodule', '.git')
-        )
-
-        File.rename(
-          File.join('submod2', 'not', '.gitted'),
-          File.join('submod2', 'not', '.git')
-        )
-      end
-
-      repository
+      rewrite_gitmodules('submod2')
+      open_fixture('submod2')
     end
 
-    def rewrite_gitmodules(workdir)
+    def rewrite_gitmodules(repository_name)
+      workdir = File.join(@_sandbox_path, repository_name)
       input_path = File.join(workdir, 'gitmodules')
       output_path = File.join(workdir, '.gitmodules')
       submodules = []

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -139,7 +139,6 @@ module Rugged
             output.write(line)
           end
         end
-        FileUtils.remove_entry_secure(input_path)
 
         # rename .gitted -> .git in submodule dirs
         submodules.each do |submodule|
@@ -151,6 +150,8 @@ module Rugged
           end
         end
       end
+
+      FileUtils.remove_entry_secure(input_path)
     end
   end
 


### PR DESCRIPTION
This adds an appveyor config that will build the `rugged` gem on win32.

The tests currently fail because of issues with the way files and folders get locked on windows.