### PR TITLE
Add Tree#count_recursive

### DIFF
--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -149,8 +149,8 @@ struct rugged_cb_payload
 
 struct rugged_treecount_cb_payload
 {
-	unsigned int count;
-	unsigned int limit;
+	int count;
+	int limit;
 };
 
 struct rugged_remote_cb_payload

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -150,7 +150,7 @@ struct rugged_cb_payload
 struct rugged_treecount_cb_payload
 {
 	unsigned int count;
-	int limit;
+	unsigned int limit;
 };
 
 struct rugged_remote_cb_payload

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -147,12 +147,6 @@ struct rugged_cb_payload
     int exception;
 };
 
-struct rugged_treecount_cb_payload
-{
-	int count;
-	int limit;
-};
-
 struct rugged_remote_cb_payload
 {
 	VALUE progress;

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -147,6 +147,12 @@ struct rugged_cb_payload
     int exception;
 };
 
+struct rugged_treecount_cb_payload
+{
+	unsigned int count;
+	int limit;
+};
+
 struct rugged_remote_cb_payload
 {
 	VALUE progress;

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -96,7 +96,6 @@ static VALUE rb_git_tree_entrycount(VALUE self)
 static int rugged__treecount_cb(const char *root, const git_tree_entry *entry, void *payload)
 {
 	int *count = (int *)payload;
-  printf("%s: %d\n", git_tree_entry_name(entry), git_tree_entry_type(entry));
 
   if(git_tree_entry_type(entry) == GIT_OBJ_TREE) {
     return 0;

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -109,10 +109,14 @@ static int rugged__treecount_cb(const char *root, const git_tree_entry *entry, v
 
 /*
  *  call-seq:
- *    tree.count_recursive -> count
- *    tree.length_recursive -> count
+ *    tree.count_recursive(limit=nil) -> count
  *
- *  Return the number of blobs contained in the tree and all subtrees.
+ *  `limit` - The maximum number of blobs to the count in the repository.
+ *  Rugged will stop walking the tree after `limit` items to avoid long
+ *  execution times.
+ *
+ *  Return the number of blobs (up to the limit) contained in the tree and
+ *  all subtrees.
  */
 static VALUE rb_git_tree_entrycount_recursive(int argc, VALUE* argv, VALUE self)
 {

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -124,17 +124,17 @@ static VALUE rb_git_tree_entrycount_recursive(int argc, VALUE* argv, VALUE self)
 	Data_Get_Struct(self, git_tree, tree);
 	int error;
 	struct rugged_treecount_cb_payload payload;
-	VALUE rbLimit;
+	VALUE rb_limit;
 
-	if (rb_scan_args(argc, argv, "01", &rbLimit) == 0)
-		rbLimit = Qnil;
+	if (rb_scan_args(argc, argv, "01", &rb_limit) == 0)
+		rb_limit = Qnil;
 
 	payload.limit = -1;
 	payload.count = 0;
 
-	if (!NIL_P(rbLimit)) {
-		Check_Type(rbLimit, T_FIXNUM);
-		payload.limit = FIX2INT(rbLimit);
+	if (!NIL_P(rb_limit)) {
+		Check_Type(rb_limit, T_FIXNUM);
+		payload.limit = FIX2INT(rb_limit);
 	}
 
 

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -95,7 +95,7 @@ static VALUE rb_git_tree_entrycount(VALUE self)
 
 static int rugged__treecount_cb(const char *root, const git_tree_entry *entry, void *payload)
 {
-	unsigned int *count = (int *)payload;
+	unsigned int *count = (unsigned int *)payload;
 
 	if(git_tree_entry_type(entry) == GIT_OBJ_TREE) {
 		return 0;

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -93,6 +93,12 @@ static VALUE rb_git_tree_entrycount(VALUE self)
 	return INT2FIX(git_tree_entrycount(tree));
 }
 
+struct rugged_treecount_cb_payload
+{
+	int count;
+	int limit;
+};
+
 static int rugged__treecount_cb(const char *root, const git_tree_entry *entry, void *data)
 {
 	struct rugged_treecount_cb_payload *payload = data;

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -95,7 +95,7 @@ static VALUE rb_git_tree_entrycount(VALUE self)
 
 static int rugged__treecount_cb(const char *root, const git_tree_entry *entry, void *payload)
 {
-	int *count = (int *)payload;
+	unsigned int *count = (int *)payload;
 
 	if(git_tree_entry_type(entry) == GIT_OBJ_TREE) {
 		return 0;
@@ -116,7 +116,7 @@ static VALUE rb_git_tree_entrycount_recursive(VALUE self)
 {
 	git_tree *tree;
 	Data_Get_Struct(self, git_tree, tree);
-	volatile int count = 0;
+	volatile unsigned int count = 0;
 	int error;
 
 	error = git_tree_walk(tree, GIT_TREEWALK_PRE, &rugged__treecount_cb, (void *)&count);

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -126,8 +126,7 @@ static VALUE rb_git_tree_entrycount_recursive(int argc, VALUE* argv, VALUE self)
 	struct rugged_treecount_cb_payload payload;
 	VALUE rb_limit;
 
-	if (rb_scan_args(argc, argv, "01", &rb_limit) == 0)
-		rb_limit = Qnil;
+	rb_scan_args(argc, argv, "01", &rb_limit);
 
 	payload.limit = -1;
 	payload.count = 0;

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -127,10 +127,11 @@ static int rugged__treecount_cb(const char *root, const git_tree_entry *entry, v
 static VALUE rb_git_tree_entrycount_recursive(int argc, VALUE* argv, VALUE self)
 {
 	git_tree *tree;
-	Data_Get_Struct(self, git_tree, tree);
 	int error;
 	struct rugged_treecount_cb_payload payload;
 	VALUE rb_limit;
+
+	Data_Get_Struct(self, git_tree, tree);
 
 	rb_scan_args(argc, argv, "01", &rb_limit);
 

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -145,7 +145,7 @@ static VALUE rb_git_tree_entrycount_recursive(int argc, VALUE* argv, VALUE self)
 
 	error = git_tree_walk(tree, GIT_TREEWALK_PRE, &rugged__treecount_cb, (void *)&payload);
 
-	if(error && giterr_last()->klass == GITERR_CALLBACK) {
+	if (error && giterr_last()->klass == GITERR_CALLBACK) {
 		giterr_clear();
 		error = 0;
 	}

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -129,14 +129,14 @@ static VALUE rb_git_tree_entrycount_recursive(int argc, VALUE* argv, VALUE self)
 	if (rb_scan_args(argc, argv, "01", &rbLimit) == 0)
 		rbLimit = Qnil;
 
-	if (NIL_P(rbLimit))
-		payload.limit = -1;
-	else if (TYPE(rbLimit) != T_FIXNUM)
-		rb_raise(rb_eTypeError, "limit must be a Fixnum");
-	else
-		payload.limit = FIX2INT(rbLimit);
-
+	payload.limit = -1;
 	payload.count = 0;
+
+	if (!NIL_P(rbLimit)) {
+		Check_Type(rbLimit, T_FIXNUM);
+		payload.limit = FIX2INT(rbLimit);
+	}
+
 
 	error = git_tree_walk(tree, GIT_TREEWALK_PRE, &rugged__treecount_cb, (void *)&payload);
 

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -97,12 +97,12 @@ static int rugged__treecount_cb(const char *root, const git_tree_entry *entry, v
 {
 	int *count = (int *)payload;
 
-  if(git_tree_entry_type(entry) == GIT_OBJ_TREE) {
-    return 0;
-  } else {
-    ++(*count);
-    return 1;
-  }
+	if(git_tree_entry_type(entry) == GIT_OBJ_TREE) {
+		return 0;
+	} else {
+		++(*count);
+		return 1;
+	}
 }
 
 /*
@@ -116,8 +116,8 @@ static VALUE rb_git_tree_entrycount_recursive(VALUE self)
 {
 	git_tree *tree;
 	Data_Get_Struct(self, git_tree, tree);
-  volatile int count = 0;
-  int error;
+	volatile int count = 0;
+	int error;
 
 	error = git_tree_walk(tree, GIT_TREEWALK_PRE, &rugged__treecount_cb, (void *)&count);
 

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -103,11 +103,11 @@ static int rugged__treecount_cb(const char *root, const git_tree_entry *entry, v
 {
 	struct rugged_treecount_cb_payload *payload = data;
 
-	if (payload->limit >= 0 && payload->count >= payload->limit)
+	if (payload->limit >= 0 && payload->count >= payload->limit) {
 		return -1;
-	else if(git_tree_entry_type(entry) == GIT_OBJ_TREE)
+	} else if(git_tree_entry_type(entry) == GIT_OBJ_TREE) {
 		return 0;
-	else {
+	} else {
 		++(payload->count);
 		return 1;
 	}

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -50,6 +50,9 @@ class TreeTest < Rugged::TestCase
     assert_equal 6, @tree.count_recursive
     assert_equal 5, @tree.count_recursive(5)
     assert_equal 6, @tree.count_recursive(10)
+    assert_raises(TypeError) do
+      @tree.count_recursive("NaN")
+    end
     assert_equal "1385f264afb75a56a5bec74243be9b367ba4ca08", @tree[0][:oid]
     assert_equal "fa49b077972391ad58037050f2a75f74e3671e92", @tree[1][:oid]
   end

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -47,6 +47,9 @@ class TreeTest < Rugged::TestCase
     assert_equal @oid, @tree.oid
     assert_equal :tree, @tree.type
     assert_equal 3, @tree.count
+    assert_equal 6, @tree.count_recursive
+    assert_equal 5, @tree.count_recursive(5)
+    assert_equal 6, @tree.count_recursive(10)
     assert_equal "1385f264afb75a56a5bec74243be9b367ba4ca08", @tree[0][:oid]
     assert_equal "fa49b077972391ad58037050f2a75f74e3671e92", @tree[1][:oid]
   end


### PR DESCRIPTION
This adds a new `count_recursive` method to Rugged tree objects. This counts all blobs in the tree recursively, with an optional limit to bail early. This allows asking things like "Are there more than 1 million files in this repo?" without a roundtrip into ruby for each file. 