### PR TITLE
Memory-safe Walker API

### DIFF
--- a/ext/rugged/rugged_revwalk.c
+++ b/ext/rugged/rugged_revwalk.c
@@ -206,7 +206,7 @@ static VALUE rb_git_walker_reset(VALUE self)
 }
 
 struct walk_options {
-	VALUE rb_self;
+	VALUE rb_owner;
 	VALUE rb_options;
 
 	git_repository *repo;
@@ -288,7 +288,7 @@ static VALUE do_walk(VALUE _payload)
 			rugged_exception_check(error);
 
 			rb_yield(
-				rugged_object_new(rugged_owner(w->rb_self), (git_object *)commit)
+				rugged_object_new(w->rb_owner, (git_object *)commit)
 			);
 		}
 
@@ -366,7 +366,7 @@ static VALUE rb_git_walk(int argc, VALUE *argv, VALUE self)
 	Data_Get_Struct(rb_repo, git_repository, w.repo);
 	rugged_exception_check(git_revwalk_new(&w.walk, w.repo));
 
-	w.rb_self = self;
+	w.rb_owner = rb_repo;
 	w.rb_options = rb_options;
 
 	w.oid_only = 0;
@@ -392,7 +392,7 @@ static VALUE rb_git_walk_with_opts(int argc, VALUE *argv, VALUE self, int oid_on
 	Data_Get_Struct(self, git_revwalk, w.walk);
 	w.repo = git_revwalk_repository(w.walk);
 
-	w.rb_self = self;
+	w.rb_owner = rugged_owner(self);
 	w.rb_options = Qnil;
 
 	w.oid_only = oid_only;

--- a/ext/rugged/rugged_revwalk.c
+++ b/ext/rugged/rugged_revwalk.c
@@ -25,6 +25,7 @@
 #include "rugged.h"
 
 extern VALUE rb_mRugged;
+extern VALUE rb_cRuggedObject;
 VALUE rb_cRuggedWalker;
 
 static void rb_git_walk__free(git_revwalk *walk)
@@ -37,6 +38,58 @@ VALUE rugged_walker_new(VALUE klass, VALUE owner, git_revwalk *walk)
 	VALUE rb_walk = Data_Wrap_Struct(klass, NULL, &rb_git_walk__free, walk);
 	rugged_set_owner(rb_walk, owner);
 	return rb_walk;
+}
+
+static void push_commit_oid(git_revwalk *walk, const git_oid *oid, int hide)
+{
+	int error;
+	if (hide) error = git_revwalk_hide(walk, oid);
+	else error = git_revwalk_push(walk, oid);
+	rugged_exception_check(error);
+}
+
+static void push_commit_ref(git_revwalk *walk, const char *ref, int hide)
+{
+	int error;
+	if (hide) error = git_revwalk_hide_ref(walk, ref);
+	else error = git_revwalk_push_ref(walk, ref);
+	rugged_exception_check(error);
+}
+
+static void push_commit_1(git_revwalk *walk, VALUE rb_commit, int hide)
+{
+	if (rb_obj_is_kind_of(rb_commit, rb_cRuggedObject)) {
+		git_object *object;
+		Data_Get_Struct(rb_commit, git_object, object);
+
+		push_commit_oid(walk, git_object_id(object), hide);
+		return;
+	}
+
+	Check_Type(rb_commit, T_STRING);
+
+	if (RSTRING_LEN(rb_commit) == 40) {
+		git_oid commit_oid;
+		if (git_oid_fromstr(&commit_oid, RSTRING_PTR(rb_commit)) == 0) {
+			push_commit_oid(walk, &commit_oid, hide);
+			return;
+		}
+	}
+
+	push_commit_ref(walk, StringValueCStr(rb_commit), hide);
+}
+
+static void push_commit(git_revwalk *walk, VALUE rb_commit, int hide)
+{
+	if (rb_type(rb_commit) == T_ARRAY) {
+		long i;
+		for (i = 0; i < RARRAY_LEN(rb_commit); ++i)
+			push_commit_1(walk, rb_ary_entry(rb_commit, i), hide);
+
+		return;
+	}
+
+	push_commit_1(walk, rb_commit, hide);
 }
 
 /*
@@ -60,134 +113,6 @@ static VALUE rb_git_walker_new(VALUE klass, VALUE rb_repo)
 	return rugged_walker_new(klass, rb_repo, walk);;
 }
 
-static VALUE rb_git_walker_each_with_opts(int argc, VALUE *argv, VALUE self, int oid_only)
-{
-	git_revwalk *walk;
-	git_commit *commit;
-	git_repository *repo;
-	git_oid commit_oid;
-
-	int error, exception = 0;
-	uint64_t offset = 0, limit = UINT64_MAX;
-
-	VALUE rb_options;
-
-	rb_scan_args(argc, argv, "01", &rb_options);
-
-	if (!rb_block_given_p()) {
-		ID iter_method = ID2SYM(rb_intern(oid_only ? "each_oid" : "each"));
-		return rb_funcall(self, rb_intern("to_enum"), 2, iter_method, rb_options);
-	}
-
-	if (!NIL_P(rb_options)) {
-		VALUE rb_value = rb_hash_aref(rb_options, CSTR2SYM("offset"));
-		if (!NIL_P(rb_value)) {
-			Check_Type(rb_value, T_FIXNUM);
-			offset = FIX2ULONG(rb_value);
-		}
-
-		rb_value = rb_hash_aref(rb_options, CSTR2SYM("limit"));
-		if (!NIL_P(rb_value)) {
-			Check_Type(rb_value, T_FIXNUM);
-			limit = FIX2ULONG(rb_value);
-		}
-	}
-
-	Data_Get_Struct(self, git_revwalk, walk);
-	repo = git_revwalk_repository(walk);
-
-	while ((error = git_revwalk_next(&commit_oid, walk)) == 0) {
-		if (offset > 0) {
-			offset--;
-			continue;
-		}
-
-		if (oid_only) {
-			rb_protect(rb_yield,
-				rugged_create_oid(&commit_oid),
-				&exception);
-		} else {
-			error = git_commit_lookup(&commit, repo, &commit_oid);
-			rugged_exception_check(error);
-
-			rb_protect(rb_yield,
-				rugged_object_new(rugged_owner(self), (git_object *)commit),
-				&exception);
-		}
-
-		if (exception || --limit == 0)
-			break;
-	}
-
-	if (exception)
-		rb_jump_tag(exception);
-
-	if (error != GIT_ITEROVER)
-		rugged_exception_check(error);
-
-	return Qnil;
-}
-
-/*
- *  call-seq:
- *    walker.each { |commit| block }
- *    walker.each -> Iterator
- *
- *  Perform the walk through the repository, yielding each
- *  one of the commits found as a <tt>Rugged::Commit</tt> instance
- *  to +block+.
- *
- *  If no +block+ is given, an +Iterator+ will be returned.
- *
- *  The walker must have been previously set-up before a walk can be performed
- *  (i.e. at least one commit must have been pushed).
- *
- *    walker.push("92b22bbcb37caf4f6f53d30292169e84f5e4283b")
- *    walker.each { |commit| puts commit.oid }
- *
- *  generates:
- *
- *    92b22bbcb37caf4f6f53d30292169e84f5e4283b
- *    6b750d5800439b502de669465b385e5f469c78b6
- *    ef9207141549f4ffcd3c4597e270d32e10d0a6bc
- *    cb75e05f0f8ac3407fb3bd0ebd5ff07573b16c9f
- *    ...
- */
-static VALUE rb_git_walker_each(int argc, VALUE *argv, VALUE self)
-{
-	return rb_git_walker_each_with_opts(argc, argv, self, 0);
-}
-
-/*
- *  call-seq:
- *    walker.each_oid { |commit| block }
- *    walker.each_oid -> Iterator
- *
- *  Perform the walk through the repository, yielding each
- *  one of the commit oids found as a <tt>String</tt>
- *  to +block+.
- *
- *  If no +block+ is given, an +Iterator+ will be returned.
- *
- *  The walker must have been previously set-up before a walk can be performed
- *  (i.e. at least one commit must have been pushed).
- *
- *    walker.push("92b22bbcb37caf4f6f53d30292169e84f5e4283b")
- *    walker.each { |commit_oid| puts commit_oid }
- *
- *  generates:
- *
- *    92b22bbcb37caf4f6f53d30292169e84f5e4283b
- *    6b750d5800439b502de669465b385e5f469c78b6
- *    ef9207141549f4ffcd3c4597e270d32e10d0a6bc
- *    cb75e05f0f8ac3407fb3bd0ebd5ff07573b16c9f
- *    ...
- */
-static VALUE rb_git_walker_each_oid(int argc, VALUE *argv, VALUE self)
-{
-	return rb_git_walker_each_with_opts(argc, argv, self, 1);
-}
-
 /*
  *  call-seq:
  *    walker.push(commit) -> nil
@@ -207,19 +132,8 @@ static VALUE rb_git_walker_each_oid(int argc, VALUE *argv, VALUE self)
 static VALUE rb_git_walker_push(VALUE self, VALUE rb_commit)
 {
 	git_revwalk *walk;
-	git_commit *commit;
-	int error;
-
 	Data_Get_Struct(self, git_revwalk, walk);
-
-	commit = (git_commit *)rugged_object_get(
-		git_revwalk_repository(walk), rb_commit, GIT_OBJ_COMMIT);
-
-	error = git_revwalk_push(walk, git_object_id((git_object *)commit));
-
-	git_commit_free(commit);
-	rugged_exception_check(error);
-
+	push_commit(walk, rb_commit, 0);
 	return Qnil;
 }
 
@@ -241,19 +155,8 @@ static VALUE rb_git_walker_push_range(VALUE self, VALUE range)
 static VALUE rb_git_walker_hide(VALUE self, VALUE rb_commit)
 {
 	git_revwalk *walk;
-	git_commit *commit;
-	int error;
-
 	Data_Get_Struct(self, git_revwalk, walk);
-
-	commit = (git_commit *)rugged_object_get(
-		git_revwalk_repository(walk), rb_commit, GIT_OBJ_COMMIT);
-
-	error = git_revwalk_hide(walk, git_object_id((git_object *)commit));
-
-	git_commit_free(commit);
-	rugged_exception_check(error);
-
+	push_commit(walk, rb_commit, 1);
 	return Qnil;
 }
 
@@ -302,10 +205,280 @@ static VALUE rb_git_walker_reset(VALUE self)
 	return Qnil;
 }
 
+struct walk_options {
+	VALUE rb_self;
+	VALUE rb_options;
+
+	git_repository *repo;
+	git_revwalk *walk;
+	int oid_only;
+	uint64_t offset, limit;
+};
+
+static void load_walk_limits(struct walk_options *w, VALUE rb_options)
+{
+	VALUE rb_value = rb_hash_lookup(rb_options, CSTR2SYM("offset"));
+	if (!NIL_P(rb_value)) {
+		Check_Type(rb_value, T_FIXNUM);
+		w->offset = FIX2ULONG(rb_value);
+	}
+
+	rb_value = rb_hash_lookup(rb_options, CSTR2SYM("limit"));
+	if (!NIL_P(rb_value)) {
+		Check_Type(rb_value, T_FIXNUM);
+		w->limit = FIX2ULONG(rb_value);
+	}
+}
+
+static VALUE load_all_options(VALUE _payload)
+{
+	struct walk_options *w = (struct walk_options *)_payload;
+	VALUE rb_options = w->rb_options;
+	VALUE rb_show, rb_hide, rb_sort, rb_simp, rb_oid_only;
+
+	load_walk_limits(w, rb_options);
+
+	rb_sort = rb_hash_lookup(rb_options, CSTR2SYM("sort"));
+	if (!NIL_P(rb_sort)) {
+		Check_Type(rb_sort, T_FIXNUM);
+		git_revwalk_sorting(w->walk, FIX2INT(rb_sort));
+	}
+
+	rb_show = rb_hash_lookup(rb_options, CSTR2SYM("show"));
+	if (!NIL_P(rb_show)) {
+		push_commit(w->walk, rb_show, 0);
+	}
+
+	rb_hide = rb_hash_lookup(rb_options, CSTR2SYM("hide"));
+	if (!NIL_P(rb_hide)) {
+		push_commit(w->walk, rb_hide, 1);
+	}
+
+	rb_simp = rb_hash_lookup(rb_options, CSTR2SYM("simplify"));
+	if (RTEST(rb_simp)) {
+		git_revwalk_simplify_first_parent(w->walk);
+	}
+
+	rb_oid_only = rb_hash_lookup(rb_options, CSTR2SYM("oid_only"));
+	if (RTEST(rb_oid_only)) {
+		w->oid_only = 1;
+	}
+
+	return Qnil;
+}
+
+static VALUE do_walk(VALUE _payload)
+{
+	struct walk_options *w = (struct walk_options *)_payload;
+	int error;
+	git_oid commit_oid;
+
+	while ((error = git_revwalk_next(&commit_oid, w->walk)) == 0) {
+		if (w->offset > 0) {
+			w->offset--;
+			continue;
+		}
+
+		if (w->oid_only) {
+			rb_yield(rugged_create_oid(&commit_oid));
+		} else {
+			git_commit *commit;
+
+			error = git_commit_lookup(&commit, w->repo, &commit_oid);
+			rugged_exception_check(error);
+
+			rb_yield(
+				rugged_object_new(rugged_owner(w->rb_self), (git_object *)commit)
+			);
+		}
+
+		if (--w->limit == 0)
+			break;
+	}
+
+	if (error != GIT_ITEROVER)
+		rugged_exception_check(error);
+
+	return Qnil;
+}
+
+static VALUE do_walk_cleanup(VALUE _payload)
+{
+	struct walk_options *w = (struct walk_options *)_payload;
+	git_revwalk_free(w->walk);
+	return Qnil;
+}
+
+/*
+ *  call-seq:
+ *    Rugged::Walker.walk(repo, options={}) { |commit| block }
+ *
+ *	Create a Walker object, initialize it with the given options
+ *	and perform a walk on the repository; the lifetime of the
+ *	walker is bound to the call and it is immediately cleaned
+ *	up after the walk is over.
+ *
+ *	The following options are available:
+ *
+ *	- +sort+: Sorting mode for the walk (or an OR combination
+ *	of several sorting modes).
+ *
+ *	- +show+: Tips of the repository that will be walked;
+ *	this is necessary for the walk to yield any results.
+ *	A tip can be a 40-char object ID, an existing +Rugged::Commit+
+ *	object, a reference, or an +Array+ of several of these
+ *	(if you'd like to walk several tips in parallel).
+ *
+ *	- +hide+: Same as +show+, but hides the given tips instead
+ *	so they don't appear on the walk.
+ *
+ *	- +oid_only+: if +true+, the walker will yield 40-char OIDs
+ *	for each commit, instead of real +Rugged::Commit+ objects.
+ *	Defaults to +false+.
+ *
+ *	- +simplify+: if +true+, the walk will be simplified
+ *	to the first parent of each commit.
+ *
+ *	Example:
+ *
+ *    Rugged::Walker.walk(repo,
+ *		show: "92b22bbcb37caf4f6f53d30292169e84f5e4283b",
+ *		sort: Rugged::SORT_DATE|Rugged::SORT_TOPO,
+ *		oid_only: true) do |commit_oid|
+ *			puts commit_oid
+ *		end
+ *
+ *  generates:
+ *
+ *    92b22bbcb37caf4f6f53d30292169e84f5e4283b
+ *    6b750d5800439b502de669465b385e5f469c78b6
+ *    ef9207141549f4ffcd3c4597e270d32e10d0a6bc
+ *    cb75e05f0f8ac3407fb3bd0ebd5ff07573b16c9f
+ *    ...
+ */
+static VALUE rb_git_walk(int argc, VALUE *argv, VALUE self)
+{
+	VALUE rb_repo, rb_options;
+	struct walk_options w;
+
+	rb_scan_args(argc, argv, "10:", &rb_repo, &rb_options);
+
+	Data_Get_Struct(rb_repo, git_repository, w.repo);
+	rugged_exception_check(git_revwalk_new(&w.walk, w.repo));
+
+	w.rb_self = self;
+	w.rb_options = rb_options;
+
+	w.oid_only = 0;
+	w.offset = 0;
+	w.limit = UINT64_MAX;
+
+	if (!NIL_P(w.rb_options)) {
+		rb_ensure(
+			load_all_options, (VALUE)&w,
+			do_walk_cleanup, (VALUE)&w);
+	}
+
+	return rb_ensure(
+			do_walk, (VALUE)&w,
+			do_walk_cleanup, (VALUE)&w);
+}
+
+static VALUE rb_git_walk_with_opts(int argc, VALUE *argv, VALUE self, int oid_only)
+{
+	VALUE rb_options;
+	struct walk_options w;
+
+	Data_Get_Struct(self, git_revwalk, w.walk);
+	w.repo = git_revwalk_repository(w.walk);
+
+	w.rb_self = self;
+	w.rb_options = Qnil;
+
+	w.oid_only = oid_only;
+	w.offset = 0;
+	w.limit = UINT64_MAX;
+
+	rb_scan_args(argc, argv, "01", &rb_options);
+
+	if (!rb_block_given_p()) {
+		ID iter_method = ID2SYM(rb_intern(oid_only ? "each_oid" : "each"));
+		return rb_funcall(self, rb_intern("to_enum"), 2, iter_method, rb_options);
+	}
+
+	if (!NIL_P(rb_options))
+		load_walk_limits(&w, rb_options);
+
+	return do_walk((VALUE)&w);
+}
+
+/*
+ *  call-seq:
+ *    walker.each { |commit| block }
+ *    walker.each -> Iterator
+ *
+ *  Perform the walk through the repository, yielding each
+ *  one of the commits found as a <tt>Rugged::Commit</tt> instance
+ *  to +block+.
+ *
+ *  If no +block+ is given, an +Iterator+ will be returned.
+ *
+ *  The walker must have been previously set-up before a walk can be performed
+ *  (i.e. at least one commit must have been pushed).
+ *
+ *    walker.push("92b22bbcb37caf4f6f53d30292169e84f5e4283b")
+ *    walker.each { |commit| puts commit.oid }
+ *
+ *  generates:
+ *
+ *    92b22bbcb37caf4f6f53d30292169e84f5e4283b
+ *    6b750d5800439b502de669465b385e5f469c78b6
+ *    ef9207141549f4ffcd3c4597e270d32e10d0a6bc
+ *    cb75e05f0f8ac3407fb3bd0ebd5ff07573b16c9f
+ *    ...
+ */
+static VALUE rb_git_walker_each(int argc, VALUE *argv, VALUE self)
+{
+	return rb_git_walk_with_opts(argc, argv, self, 0);
+}
+
+/*
+ *  call-seq:
+ *    walker.each_oid { |commit| block }
+ *    walker.each_oid -> Iterator
+ *
+ *  Perform the walk through the repository, yielding each
+ *  one of the commit oids found as a <tt>String</tt>
+ *  to +block+.
+ *
+ *  If no +block+ is given, an +Iterator+ will be returned.
+ *
+ *  The walker must have been previously set-up before a walk can be performed
+ *  (i.e. at least one commit must have been pushed).
+ *
+ *    walker.push("92b22bbcb37caf4f6f53d30292169e84f5e4283b")
+ *    walker.each { |commit_oid| puts commit_oid }
+ *
+ *  generates:
+ *
+ *    92b22bbcb37caf4f6f53d30292169e84f5e4283b
+ *    6b750d5800439b502de669465b385e5f469c78b6
+ *    ef9207141549f4ffcd3c4597e270d32e10d0a6bc
+ *    cb75e05f0f8ac3407fb3bd0ebd5ff07573b16c9f
+ *    ...
+ */
+static VALUE rb_git_walker_each_oid(int argc, VALUE *argv, VALUE self)
+{
+	return rb_git_walk_with_opts(argc, argv, self, 1);
+}
+
+
+
 void Init_rugged_revwalk(void)
 {
 	rb_cRuggedWalker = rb_define_class_under(rb_mRugged, "Walker", rb_cObject);
 	rb_define_singleton_method(rb_cRuggedWalker, "new", rb_git_walker_new, 1);
+	rb_define_singleton_method(rb_cRuggedWalker, "walk", rb_git_walk, -1);
 
 	rb_define_method(rb_cRuggedWalker, "push", rb_git_walker_push, 1);
 	rb_define_method(rb_cRuggedWalker, "push_range", rb_git_walker_push_range, 1);

--- a/test/walker_test.rb
+++ b/test/walker_test.rb
@@ -138,6 +138,13 @@ class WalkerTest < Rugged::TestCase
     sort_list = do_sort(Rugged::SORT_TOPO | Rugged::SORT_REVERSE).reverse
     assert_equal is_toposorted(sort_list), true
   end
+
+  def test_walk_api
+    sha = "9fd738e8f7967c078dceed8190330fc8648ee56a"
+    data = Rugged::Walker.walk(@repo, show: sha).to_a
+    oids = data.sort { |a, b| a.oid <=> b.oid }.map {|a| a.oid[0,5]}.join('.')
+    assert_equal "4a202.5b5b0.84960.9fd73", oids
+  end
 end
 
 # testrepo (the non-bare repo) is the one with non-linear history,


### PR DESCRIPTION
Here's a new APi for `Walker` which is memory safe (i.e. frees the walker immediately and prevents used packfiles from lingering around). The walker code has been refactored to reduce duplication; old APIs should be 100% backwards-compatible.

@arthurschreiber can you fit this on the release? Thanks :)

cc @spraints who is already using this on production