### PR TITLE
Update to the latest libgit2 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: rbx-2
+    - rvm: ruby-head
 
 install:
   - ./vendor/libgit2/script/install-deps-${TRAVIS_OS_NAME}.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 
     *Arthur Schreiber*
 
+*   `Rugged::Remote` instances are now immutable.
+
+    * `Remote#clear_refspecs` and `Remote#save` were removed without
+      replacement.
+
+    * `Remote#url=` and `Remote#push_url=` were removed and replaced by
+      `RemoteCollection#set_url` and `RemoteCollection#set_push_url`.
+
+    * `Remote#add_push` and `Remote#add_fetch` were removed and replaced by
+      `RemoteCollection#add_push_refspec` and
+      `RemoteCollection#add_fetch_refspec`.
+
+    *Arthur Schreiber*
+
 *   Update bundled libgit2 to 9042693e283f65d9afb4906ed693a862a250664b.
 
     *Arthur Schreiber*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-
 *   Add accessors for the Repository ident.
 
     Added `Repository#ident` and `Repository#ident=` to read and set the
     identity that is used when writing reflog entries.
+
+    *Arthur Schreiber*
+
+*   Update bundled libgit2 to 9042693e283f65d9afb4906ed693a862a250664b.
 
     *Arthur Schreiber*
 
@@ -26,10 +29,6 @@
 *   The `:safe_create` flag was removed from `Repository#checkout_tree`.
 
     You can use `:create` in combination with `:recreate_missing` instead.
-
-    *Arthur Schreiber*
-
-*   Update bundled libgit2 to 8311db0cf8ae15b46edd14358a8238862e0bac4d.
 
     *Arthur Schreiber*
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,3 +230,6 @@ DEPENDENCIES
   rake-compiler (>= 0.9.0)
   rubysl (~> 2.0)
   rugged!
+
+BUNDLED WITH
+   1.10.3

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -120,11 +120,15 @@ void rugged_parse_diff_options(git_diff_options *opts, VALUE rb_options)
 		}
 
 		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("show_untracked_content")))) {
-			opts->flags |= GIT_DIFF_SHOW_UNTRACKED_CONTENT ;
+			opts->flags |= GIT_DIFF_SHOW_UNTRACKED_CONTENT;
 		}
 
 		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("show_unmodified")))) {
-			opts->flags |= GIT_DIFF_SHOW_UNTRACKED_CONTENT ;
+			opts->flags |= GIT_DIFF_SHOW_UNMODIFIED;
+		}
+
+		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("show_binary")))) {
+			opts->flags |= GIT_DIFF_SHOW_BINARY;
 		}
 
 		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("patience")))) {

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -643,7 +643,7 @@ static VALUE rb_git_diff_stat(VALUE self)
 	Data_Get_Struct(self, git_diff, diff);
 
 	git_diff_foreach(
-		diff, diff_file_stats_cb, NULL, diff_line_stats_cb, &stats);
+		diff, diff_file_stats_cb, NULL, NULL, diff_line_stats_cb, &stats);
 
 	return rb_ary_new3(
 		3, INT2FIX(stats.files), INT2FIX(stats.adds), INT2FIX(stats.dels));

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -555,7 +555,7 @@ static VALUE rb_git_indexentry_fromC(const git_index_entry *entry)
 	return rb_entry;
 }
 
-static inline unsigned int
+static inline uint32_t
 default_entry_value(VALUE rb_entry, const char *key)
 {
 	VALUE val = rb_hash_aref(rb_entry, CSTR2SYM(key));
@@ -587,7 +587,7 @@ static void rb_git_indexentry_toC(git_index_entry *entry, VALUE rb_entry)
 	entry->mode = default_entry_value(rb_entry, "mode");
 	entry->gid = default_entry_value(rb_entry, "gid");
 	entry->uid = default_entry_value(rb_entry, "uid");
-	entry->file_size = (git_off_t)default_entry_value(rb_entry, "file_size");
+	entry->file_size = default_entry_value(rb_entry, "file_size");
 
 	if ((val = rb_hash_aref(rb_entry, CSTR2SYM("mtime"))) != Qnil) {
 		if (!rb_obj_is_kind_of(val, rb_cTime))

--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -264,8 +264,7 @@ static VALUE rb_git_remote_ls(int argc, VALUE *argv, VALUE self)
 
 	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &callbacks, &payload);
 
-	if ((error = git_remote_set_callbacks(remote, &callbacks)) ||
-	    (error = git_remote_connect(remote, GIT_DIRECTION_FETCH)) ||
+	if ((error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks)) ||
 	    (error = git_remote_ls(&heads, &heads_len, remote)))
 		goto cleanup;
 
@@ -321,28 +320,6 @@ static VALUE rb_git_remote_url(VALUE self)
 
 /*
  *  call-seq:
- *    remote.url = url -> url
- *
- *  Sets the remote's url without persisting it in the config.
- *  Existing connections will not be updated.
- *
- *    remote.url = 'git://github.com/libgit2/rugged.git' #=> "git://github.com/libgit2/rugged.git"
- */
-static VALUE rb_git_remote_set_url(VALUE self, VALUE rb_url)
-{
-	git_remote *remote;
-
-	Check_Type(rb_url, T_STRING);
-	Data_Get_Struct(self, git_remote, remote);
-
-	rugged_exception_check(
-		git_remote_set_url(remote, StringValueCStr(rb_url))
-	);
-	return rb_url;
-}
-
-/*
- *  call-seq:
  *    remote.push_url() -> string or nil
  *
  *  Returns the remote's url for pushing or nil if no special url for
@@ -372,13 +349,18 @@ static VALUE rb_git_remote_push_url(VALUE self)
  */
 static VALUE rb_git_remote_set_push_url(VALUE self, VALUE rb_url)
 {
+	VALUE rb_repo = rugged_owner(self);
 	git_remote *remote;
+	git_repository *repo;
+
+	rugged_check_repo(rb_repo);
+	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	Check_Type(rb_url, T_STRING);
 	Data_Get_Struct(self, git_remote, remote);
 
 	rugged_exception_check(
-		git_remote_set_pushurl(remote, StringValueCStr(rb_url))
+		git_remote_set_pushurl(repo, git_remote_name(remote), StringValueCStr(rb_url))
 	);
 
 	return rb_url;
@@ -425,86 +407,6 @@ static VALUE rb_git_remote_fetch_refspecs(VALUE self)
 static VALUE rb_git_remote_push_refspecs(VALUE self)
 {
 	return rb_git_remote_refspecs(self, GIT_DIRECTION_PUSH);
-}
-
-static VALUE rb_git_remote_add_refspec(VALUE self, VALUE rb_refspec, git_direction direction)
-{
-	git_remote *remote;
-	int error = 0;
-
-	Data_Get_Struct(self, git_remote, remote);
-
-	Check_Type(rb_refspec, T_STRING);
-
-	if (direction == GIT_DIRECTION_FETCH)
-		error = git_remote_add_fetch(remote, StringValueCStr(rb_refspec));
-	else
-		error = git_remote_add_push(remote, StringValueCStr(rb_refspec));
-
-	rugged_exception_check(error);
-
-	return Qnil;
-}
-
-/*
- *  call-seq:
- *    remote.add_fetch(refspec) -> nil
- *
- *  Add a fetch refspec to the remote.
- */
-static VALUE rb_git_remote_add_fetch(VALUE self, VALUE rb_refspec)
-{
-	return rb_git_remote_add_refspec(self, rb_refspec, GIT_DIRECTION_FETCH);
-}
-
-/*
- *  call-seq:
- *    remote.add_push(refspec) -> nil
- *
- *  Add a push refspec to the remote.
- */
-static VALUE rb_git_remote_add_push(VALUE self, VALUE rb_refspec)
-{
-	return rb_git_remote_add_refspec(self, rb_refspec, GIT_DIRECTION_PUSH);
-}
-
-/*
- *  call-seq:
- *    remote.clear_refspecs -> nil
- *
- *  Remove all configured fetch and push refspecs from the remote.
- */
-static VALUE rb_git_remote_clear_refspecs(VALUE self)
-{
-	git_remote *remote;
-
-	Data_Get_Struct(self, git_remote, remote);
-
-	git_remote_clear_refspecs(remote);
-
-	return Qnil;
-}
-
-/*
- *  call-seq:
- *    remote.save -> true
- *
- *  Saves the remote data (url, fetchspecs, ...) to the config.
- *
- *  Anonymous, in-memory remotes created through
- *  +ReferenceCollection#create_anonymous+ can not be saved.
- *  Doing so will result in an exception being raised.
- */
-static VALUE rb_git_remote_save(VALUE self)
-{
-	git_remote *remote;
-
-	Data_Get_Struct(self, git_remote, remote);
-
-	rugged_exception_check(
-		git_remote_save(remote)
-	);
-	return Qtrue;
 }
 
 /*
@@ -556,21 +458,13 @@ static VALUE rb_git_remote_check_connection(int argc, VALUE *argv, VALUE self)
 
 	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &callbacks, &payload);
 
-	if ((error = git_remote_set_callbacks(remote, &callbacks)) < 0)
-		goto cleanup;
+	error = git_remote_connect(remote, direction, &callbacks);
+	git_remote_disconnect(remote);
 
-	if (git_remote_connect(remote, direction))
-		return Qfalse;
-	else {
-		git_remote_disconnect(remote);
-		return Qtrue;
-	}
-
-cleanup:
 	if (payload.exception)
 		rb_jump_tag(payload.exception);
-	rugged_exception_check(error);
-	return Qfalse;
+
+	return error ? Qfalse : Qtrue;
 }
 
 /*
@@ -622,7 +516,8 @@ static VALUE rb_git_remote_fetch(int argc, VALUE *argv, VALUE self)
 	git_remote *remote;
 	git_repository *repo;
 	git_strarray refspecs;
-	git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
+	git_fetch_options opts = GIT_FETCH_OPTIONS_INIT;
+	const git_transfer_progress *stats;
 	struct rugged_remote_cb_payload payload = { Qnil, Qnil, Qnil, Qnil, Qnil, Qnil, 0 };
 
 	char *log_message = NULL;
@@ -638,7 +533,7 @@ static VALUE rb_git_remote_fetch(int argc, VALUE *argv, VALUE self)
 	rugged_check_repo(rb_repo);
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
-	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &callbacks, &payload);
+	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &opts.callbacks, &payload);
 
 	if (!NIL_P(rb_options)) {
 		VALUE rb_val = rb_hash_aref(rb_options, CSTR2SYM("message"));
@@ -646,23 +541,7 @@ static VALUE rb_git_remote_fetch(int argc, VALUE *argv, VALUE self)
 			log_message = StringValueCStr(rb_val);
 	}
 
-	if ((error = git_remote_set_callbacks(remote, &callbacks)))
-		goto cleanup;
-
-	if ((error = git_remote_fetch(remote, &refspecs, log_message)) == GIT_OK) {
-		const git_transfer_progress *stats = git_remote_stats(remote);
-
-		rb_result = rb_hash_new();
-		rb_hash_aset(rb_result, CSTR2SYM("total_objects"),    UINT2NUM(stats->total_objects));
-		rb_hash_aset(rb_result, CSTR2SYM("indexed_objects"),  UINT2NUM(stats->indexed_objects));
-		rb_hash_aset(rb_result, CSTR2SYM("received_objects"), UINT2NUM(stats->received_objects));
-		rb_hash_aset(rb_result, CSTR2SYM("local_objects"),    UINT2NUM(stats->local_objects));
-		rb_hash_aset(rb_result, CSTR2SYM("total_deltas"),     UINT2NUM(stats->total_deltas));
-		rb_hash_aset(rb_result, CSTR2SYM("indexed_deltas"),   UINT2NUM(stats->indexed_deltas));
-		rb_hash_aset(rb_result, CSTR2SYM("received_bytes"),   INT2FIX(stats->received_bytes));
-	}
-
-	cleanup:
+	error = git_remote_fetch(remote, &refspecs, &opts, log_message);
 
 	xfree(refspecs.strings);
 
@@ -670,6 +549,17 @@ static VALUE rb_git_remote_fetch(int argc, VALUE *argv, VALUE self)
 		rb_jump_tag(payload.exception);
 
 	rugged_exception_check(error);
+
+	stats = git_remote_stats(remote);
+
+	rb_result = rb_hash_new();
+	rb_hash_aset(rb_result, CSTR2SYM("total_objects"),    UINT2NUM(stats->total_objects));
+	rb_hash_aset(rb_result, CSTR2SYM("indexed_objects"),  UINT2NUM(stats->indexed_objects));
+	rb_hash_aset(rb_result, CSTR2SYM("received_objects"), UINT2NUM(stats->received_objects));
+	rb_hash_aset(rb_result, CSTR2SYM("local_objects"),    UINT2NUM(stats->local_objects));
+	rb_hash_aset(rb_result, CSTR2SYM("total_deltas"),     UINT2NUM(stats->total_deltas));
+	rb_hash_aset(rb_result, CSTR2SYM("indexed_deltas"),   UINT2NUM(stats->indexed_deltas));
+	rb_hash_aset(rb_result, CSTR2SYM("received_bytes"),   INT2FIX(stats->received_bytes));
 
 	return rb_result;
 }
@@ -708,7 +598,6 @@ static VALUE rb_git_remote_push(int argc, VALUE *argv, VALUE self)
 
 	git_repository *repo;
 	git_remote *remote;
-	git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
 	git_strarray refspecs;
 	git_push_options opts = GIT_PUSH_OPTIONS_INIT;
 
@@ -724,14 +613,10 @@ static VALUE rb_git_remote_push(int argc, VALUE *argv, VALUE self)
 	Data_Get_Struct(rb_repo, git_repository, repo);
 	Data_Get_Struct(self, git_remote, remote);
 
-	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &callbacks, &payload);
-
-	if ((error = git_remote_set_callbacks(remote, &callbacks)))
-	    goto cleanup;
+	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &opts.callbacks, &payload);
 
 	error = git_remote_push(remote, &refspecs, &opts);
 
-cleanup:
 	xfree(refspecs.strings);
 
 	if (payload.exception)
@@ -746,20 +631,13 @@ void Init_rugged_remote(void)
 {
 	rb_cRuggedRemote = rb_define_class_under(rb_mRugged, "Remote", rb_cObject);
 
-
 	rb_define_method(rb_cRuggedRemote, "name", rb_git_remote_name, 0);
 	rb_define_method(rb_cRuggedRemote, "url", rb_git_remote_url, 0);
-	rb_define_method(rb_cRuggedRemote, "url=", rb_git_remote_set_url, 1);
 	rb_define_method(rb_cRuggedRemote, "push_url", rb_git_remote_push_url, 0);
-	rb_define_method(rb_cRuggedRemote, "push_url=", rb_git_remote_set_push_url, 1);
 	rb_define_method(rb_cRuggedRemote, "fetch_refspecs", rb_git_remote_fetch_refspecs, 0);
 	rb_define_method(rb_cRuggedRemote, "push_refspecs", rb_git_remote_push_refspecs, 0);
-	rb_define_method(rb_cRuggedRemote, "add_fetch", rb_git_remote_add_fetch, 1);
-	rb_define_method(rb_cRuggedRemote, "add_push", rb_git_remote_add_push, 1);
 	rb_define_method(rb_cRuggedRemote, "ls", rb_git_remote_ls, -1);
 	rb_define_method(rb_cRuggedRemote, "check_connection", rb_git_remote_check_connection, -1);
 	rb_define_method(rb_cRuggedRemote, "fetch", rb_git_remote_fetch, -1);
 	rb_define_method(rb_cRuggedRemote, "push", rb_git_remote_push, -1);
-	rb_define_method(rb_cRuggedRemote, "clear_refspecs", rb_git_remote_clear_refspecs, 0);
-	rb_define_method(rb_cRuggedRemote, "save", rb_git_remote_save, 0);
 }

--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -634,6 +634,7 @@ void Init_rugged_remote(void)
 	rb_define_method(rb_cRuggedRemote, "name", rb_git_remote_name, 0);
 	rb_define_method(rb_cRuggedRemote, "url", rb_git_remote_url, 0);
 	rb_define_method(rb_cRuggedRemote, "push_url", rb_git_remote_push_url, 0);
+	rb_define_method(rb_cRuggedRemote, "push_url=", rb_git_remote_set_push_url, 1);
 	rb_define_method(rb_cRuggedRemote, "fetch_refspecs", rb_git_remote_fetch_refspecs, 0);
 	rb_define_method(rb_cRuggedRemote, "push_refspecs", rb_git_remote_push_refspecs, 0);
 	rb_define_method(rb_cRuggedRemote, "ls", rb_git_remote_ls, -1);

--- a/ext/rugged/rugged_remote_collection.c
+++ b/ext/rugged/rugged_remote_collection.c
@@ -69,8 +69,7 @@ static VALUE rb_git_remote_collection_create_anonymous(VALUE self, VALUE rb_url)
 	error = git_remote_create_anonymous(
 			&remote,
 			repo,
-			StringValueCStr(rb_url),
-			NULL);
+			StringValueCStr(rb_url));
 
 	rugged_exception_check(error);
 

--- a/ext/rugged/rugged_remote_collection.c
+++ b/ext/rugged/rugged_remote_collection.c
@@ -298,7 +298,6 @@ static VALUE rb_git_remote_collection_delete(VALUE self, VALUE rb_name_or_remote
 {
 	VALUE rb_repo = rugged_owner(self);
 	git_repository *repo;
-	int error;
 
 	if (rb_obj_is_kind_of(rb_name_or_remote, rb_cRuggedRemote))
 		rb_name_or_remote = rb_funcall(rb_name_or_remote, rb_intern("name"), 0);
@@ -309,10 +308,128 @@ static VALUE rb_git_remote_collection_delete(VALUE self, VALUE rb_name_or_remote
 	rugged_check_repo(rb_repo);
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
-	error = git_remote_delete(repo, StringValueCStr(rb_name_or_remote));
+	rugged_exception_check(
+		git_remote_delete(repo, StringValueCStr(rb_name_or_remote))
+	);
+
+	return Qnil;
+}
+
+/*
+ *  call-seq:
+ *    remotes.set_url(remote, url) -> nil
+ *    remotes.set_url(name, url) -> nil
+ *
+ *  Sets the remote's url in the configuration.
+ *  Rugged::Remote objects already in memory will not be affected.
+ *
+ *    repo.remotes.set_url("origin", 'git://github.com/libgit2/rugged.git')
+ */
+static VALUE rb_git_remote_collection_set_url(VALUE self, VALUE rb_name_or_remote, VALUE rb_url)
+{
+	VALUE rb_repo = rugged_owner(self);
+	git_repository *repo;
+
+	if (rb_obj_is_kind_of(rb_name_or_remote, rb_cRuggedRemote))
+		rb_name_or_remote = rb_funcall(rb_name_or_remote, rb_intern("name"), 0);
+
+	if (TYPE(rb_name_or_remote) != T_STRING)
+		rb_raise(rb_eTypeError, "Expecting a String or Rugged::Remote instance");
+
+	rugged_check_repo(rb_repo);
+	Data_Get_Struct(rb_repo, git_repository, repo);
+
+	Check_Type(rb_url, T_STRING);
+
+	rugged_exception_check(
+		git_remote_set_url(repo, StringValueCStr(rb_name_or_remote), StringValueCStr(rb_url))
+	);
+
+	return Qnil;
+}
+
+/*
+ *  call-seq:
+ *    remotes.set_push_url(remote, url) -> nil
+ *    remotes.set_push_url(name, url) -> nil
+ *
+ *  Sets the remote's url for pushing in the configuration.
+ *  Rugged::Remote objects already in memory will not be affected.
+ *
+ *    repo.remotes.set_push_url("origin", 'git://github.com/libgit2/rugged.git')
+ */
+static VALUE rb_git_remote_collection_set_push_url(VALUE self, VALUE rb_name_or_remote, VALUE rb_url)
+{
+	VALUE rb_repo = rugged_owner(self);
+	git_repository *repo;
+
+	if (rb_obj_is_kind_of(rb_name_or_remote, rb_cRuggedRemote))
+		rb_name_or_remote = rb_funcall(rb_name_or_remote, rb_intern("name"), 0);
+
+	if (TYPE(rb_name_or_remote) != T_STRING)
+		rb_raise(rb_eTypeError, "Expecting a String or Rugged::Remote instance");
+
+	rugged_check_repo(rb_repo);
+	Data_Get_Struct(rb_repo, git_repository, repo);
+
+	Check_Type(rb_url, T_STRING);
+
+	rugged_exception_check(
+		git_remote_set_pushurl(repo, StringValueCStr(rb_name_or_remote), StringValueCStr(rb_url))
+	);
+
+	return Qnil;
+}
+
+static VALUE rb_git_remote_collection_add_refspec(VALUE self, VALUE rb_name_or_remote, VALUE rb_refspec, git_direction direction)
+{
+	VALUE rb_repo = rugged_owner(self);
+	git_repository *repo;
+	int error = 0;
+
+	if (rb_obj_is_kind_of(rb_name_or_remote, rb_cRuggedRemote))
+		rb_name_or_remote = rb_funcall(rb_name_or_remote, rb_intern("name"), 0);
+
+	if (TYPE(rb_name_or_remote) != T_STRING)
+		rb_raise(rb_eTypeError, "Expecting a String or Rugged::Remote instance");
+
+	rugged_check_repo(rb_repo);
+	Data_Get_Struct(rb_repo, git_repository, repo);
+
+	Check_Type(rb_refspec, T_STRING);
+
+	if (direction == GIT_DIRECTION_FETCH)
+		error = git_remote_add_fetch(repo, StringValueCStr(rb_name_or_remote), StringValueCStr(rb_refspec));
+	else
+		error = git_remote_add_push(repo, StringValueCStr(rb_name_or_remote), StringValueCStr(rb_refspec));
+
 	rugged_exception_check(error);
 
 	return Qnil;
+}
+
+/*
+ *  call-seq:
+ *    remotes.add_fetch_refspec(remote, refspec) -> nil
+ *    remotes.add_fetch_refspec(name, refspec) -> nil
+ *
+ *  Add a fetch refspec to the remote.
+ */
+static VALUE rb_git_remote_collection_add_fetch_refspec(VALUE self, VALUE rb_name_or_remote, VALUE rb_refspec)
+{
+	return rb_git_remote_collection_add_refspec(self, rb_name_or_remote, rb_refspec, GIT_DIRECTION_FETCH);
+}
+
+/*
+ *  call-seq:
+ *    remotes.add_push_refspec(remote, refspec) -> nil
+ *    remotes.add_push_refspec(name, refspec) -> nil
+ *
+ *  Add a push refspec to the remote.
+ */
+static VALUE rb_git_remote_collection_add_push_refspec(VALUE self, VALUE rb_name_or_remote, VALUE rb_refspec)
+{
+	return rb_git_remote_collection_add_refspec(self, rb_name_or_remote, rb_refspec, GIT_DIRECTION_PUSH);
 }
 
 void Init_rugged_remote_collection(void)
@@ -320,16 +437,22 @@ void Init_rugged_remote_collection(void)
 	rb_cRuggedRemoteCollection = rb_define_class_under(rb_mRugged, "RemoteCollection", rb_cObject);
 	rb_include_module(rb_cRuggedRemoteCollection, rb_mEnumerable);
 
-	rb_define_method(rb_cRuggedRemoteCollection, "initialize",       rb_git_remote_collection_initialize, 1);
+	rb_define_method(rb_cRuggedRemoteCollection, "initialize",        rb_git_remote_collection_initialize, 1);
 
-	rb_define_method(rb_cRuggedRemoteCollection, "[]",               rb_git_remote_collection_aref, 1);
+	rb_define_method(rb_cRuggedRemoteCollection, "[]",                rb_git_remote_collection_aref, 1);
 
-	rb_define_method(rb_cRuggedRemoteCollection, "create",           rb_git_remote_collection_create, 2);
-	rb_define_method(rb_cRuggedRemoteCollection, "create_anonymous", rb_git_remote_collection_create_anonymous, 1);
+	rb_define_method(rb_cRuggedRemoteCollection, "create",            rb_git_remote_collection_create, 2);
+	rb_define_method(rb_cRuggedRemoteCollection, "create_anonymous",  rb_git_remote_collection_create_anonymous, 1);
 
-	rb_define_method(rb_cRuggedRemoteCollection, "each",             rb_git_remote_collection_each, 0);
-	rb_define_method(rb_cRuggedRemoteCollection, "each_name",        rb_git_remote_collection_each_name, 0);
+	rb_define_method(rb_cRuggedRemoteCollection, "each",              rb_git_remote_collection_each, 0);
+	rb_define_method(rb_cRuggedRemoteCollection, "each_name",         rb_git_remote_collection_each_name, 0);
 
-	rb_define_method(rb_cRuggedRemoteCollection, "rename",           rb_git_remote_collection_rename, 2);
-	rb_define_method(rb_cRuggedRemoteCollection, "delete",           rb_git_remote_collection_delete, 1);
+	rb_define_method(rb_cRuggedRemoteCollection, "set_url",           rb_git_remote_collection_set_url, 2);
+	rb_define_method(rb_cRuggedRemoteCollection, "set_push_url",      rb_git_remote_collection_set_push_url, 2);
+
+	rb_define_method(rb_cRuggedRemoteCollection, "add_push_refspec",  rb_git_remote_collection_add_push_refspec, 2);
+	rb_define_method(rb_cRuggedRemoteCollection, "add_fetch_refspec", rb_git_remote_collection_add_fetch_refspec, 2);
+
+	rb_define_method(rb_cRuggedRemoteCollection, "rename",            rb_git_remote_collection_rename, 2);
+	rb_define_method(rb_cRuggedRemoteCollection, "delete",            rb_git_remote_collection_delete, 1);
 }

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -2306,7 +2306,7 @@ static VALUE rb_git_repo_attributes(int argc, VALUE *argv, VALUE self)
 		VALUE rb_result;
 		const char **values;
 		const char **names;
-		int i, num_attr = RARRAY_LEN(rb_names);
+		long i, num_attr = RARRAY_LEN(rb_names);
 
 		if (num_attr > 32)
 			rb_raise(rb_eRuntimeError, "Too many attributes requested");

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -410,7 +410,6 @@ static VALUE rb_git_repo_init_at(int argc, VALUE *argv, VALUE klass)
 
 static void parse_clone_options(git_clone_options *ret, VALUE rb_options, struct rugged_remote_cb_payload *remote_payload)
 {
-	git_remote_callbacks remote_callbacks = GIT_REMOTE_CALLBACKS_INIT;
 	VALUE val;
 
 	if (NIL_P(rb_options))
@@ -426,9 +425,7 @@ static void parse_clone_options(git_clone_options *ret, VALUE rb_options, struct
 		ret->checkout_branch = StringValueCStr(val);
 	}
 
-	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &remote_callbacks, remote_payload);
-
-	ret->remote_callbacks = remote_callbacks;
+	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &ret->fetch_opts.callbacks, remote_payload);
 }
 
 /*

--- a/ext/rugged/rugged_submodule.c
+++ b/ext/rugged/rugged_submodule.c
@@ -164,13 +164,18 @@ static VALUE submodule_status_flags_to_rb(unsigned int flags)
  */
 static VALUE rb_git_submodule_status(VALUE self)
 {
+	VALUE rb_repo = rugged_owner(self);
 	git_submodule *submodule;
+	git_repository *repo;
 	unsigned int flags;
 
+	rugged_check_repo(rb_repo);
+	Data_Get_Struct(rb_repo, git_repository, repo);
 	Data_Get_Struct(self, git_submodule, submodule);
 
 	rugged_exception_check(
-		git_submodule_status(&flags, submodule)
+		git_submodule_status(&flags, repo, git_submodule_name(submodule),
+			GIT_SUBMODULE_IGNORE_FALLBACK)
 	);
 
 	return submodule_status_flags_to_rb(flags);
@@ -231,11 +236,16 @@ static VALUE rb_git_submodule_status_in_workdir(VALUE self)
 }
 
 #define RB_GIT_SUBMODULE_STATUS_FLAG_CHECK(flag) \
+	VALUE rb_repo = rugged_owner(self); \
+	git_repository *repo; \
 	git_submodule *submodule; \
 	unsigned int flags; \
+	rugged_check_repo(rb_repo); \
+	Data_Get_Struct(rb_repo, git_repository, repo); \
 	Data_Get_Struct(self, git_submodule, submodule); \
 	rugged_exception_check( \
-		git_submodule_status(&flags, submodule) \
+		git_submodule_status(&flags, repo, git_submodule_name(submodule), \
+			GIT_SUBMODULE_IGNORE_FALLBACK) \
 	); \
 	return (flags & flag) ? Qtrue : Qfalse; \
 
@@ -350,11 +360,16 @@ static VALUE rb_git_submodule_status_untracked_files_in_workdir(VALUE self)
 }
 
 #define RB_GIT_SUBMODULE_STATUS_CHECK(check) \
+	VALUE rb_repo = rugged_owner(self); \
+	git_repository *repo; \
 	git_submodule *submodule; \
 	unsigned int flags; \
+	rugged_check_repo(rb_repo); \
+	Data_Get_Struct(rb_repo, git_repository, repo); \
 	Data_Get_Struct(self, git_submodule, submodule); \
 	rugged_exception_check( \
-		git_submodule_status(&flags, submodule) \
+		git_submodule_status(&flags, repo, git_submodule_name(submodule), \
+			GIT_SUBMODULE_IGNORE_FALLBACK) \
 	); \
 	return check(flags) ? Qtrue : Qfalse; \
 
@@ -437,27 +452,6 @@ static VALUE rb_git_submodule_reload(VALUE self)
 
 	rugged_exception_check(
 		git_submodule_reload(submodule, 1)
-	);
-
-	return self;
-}
-
-/*
- *  call-seq:
- *    submodule.save -> submodule
- *
- *  Write submodule settings to +.gitmodules+ file.
- *
- *  This commits any in-memory changes to the submodule to the +.gitmodules+
- *  file on disk.
- */
-static VALUE rb_git_submodule_save(VALUE self)
-{
-	git_submodule *submodule;
-	Data_Get_Struct(self, git_submodule, submodule);
-
-	rugged_exception_check(
-		git_submodule_save(submodule)
 	);
 
 	return self;
@@ -567,25 +561,26 @@ static VALUE rb_git_submodule_url(VALUE self)
  *  call-seq:
  *    submodule.url = url -> url
  *
- *  Set the URL in memory for the submodule.
+ *  Set the URL in the config for the submodule.
  *
- *  This will be used for any following submodule actions while this submodule
- *  data is in memory.
- *
- *  After calling this, #save can be called to write the changes back to
- *  the +.gitmodules+ file and #sync to write the changes to the checked out
+ *  After calling this, #reload can be called to load the new url for
+ *  the submodule and #sync to write the changes to the checked out
  *  submodule repository.
  */
 static VALUE rb_git_submodule_set_url(VALUE self, VALUE rb_url)
 {
+	VALUE rb_repo = rugged_owner(self);
+	git_repository *repo;
 	git_submodule *submodule;
 
+	rugged_check_repo(rb_repo);
 	Check_Type(rb_url, T_STRING);
 
+	Data_Get_Struct(rb_repo, git_repository, repo);
 	Data_Get_Struct(self, git_submodule, submodule);
 
 	rugged_exception_check(
-		git_submodule_set_url(submodule, StringValueCStr(rb_url))
+		git_submodule_set_url(repo, git_submodule_name(submodule), StringValueCStr(rb_url))
 	);
 	return rb_url;
 }
@@ -684,19 +679,24 @@ static VALUE rb_git_submodule_fetch_recurse_submodules(VALUE self)
  *  call-seq:
  *    submodule.fetch_recurse_submodules= bool -> bool
  *
- *  Set the +fetchRecurseSubmodules+ rule in memory for a submodule.
+ *  Set the +fetchRecurseSubmodules+ rule in the configuration for a submodule.
  *
  *  This sets the <tt>submodule.<name>.fetchRecurseSubmodules</tt> value for
- *  the submodule. #save can be called to persist the new value.
+ *  the submodule. #reload can be called to load the new value.
  */
 static VALUE rb_git_submodule_set_fetch_recurse_submodules(VALUE self, VALUE rb_fetch_recursive)
 {
+	VALUE rb_repo = rugged_owner(self);
+	git_repository *repo;
 	git_submodule *submodule;
+
+	rugged_check_repo(rb_repo);
+
+	Data_Get_Struct(rb_repo, git_repository, repo);
 	Data_Get_Struct(self, git_submodule, submodule);
 
-	git_submodule_set_fetch_recurse_submodules(
-			submodule,
-			rugged_parse_bool(rb_fetch_recursive)
+	git_submodule_set_fetch_recurse_submodules(repo,
+		git_submodule_name(submodule), rugged_parse_bool(rb_fetch_recursive)
 	);
 
 	return rb_fetch_recursive;
@@ -778,46 +778,27 @@ static git_submodule_ignore_t rb_git_subm_ignore_rule_toC(VALUE rb_ignore_rule)
  *  call-seq:
  *    submodule.ignore_rule = rule -> rule
  *
- *  Set the ignore_rule to +rule+ in memory for a submodule.
+ *  Set the ignore_rule to +rule+ in the submodule configuration.
  *  See #ignore for a list of accepted rules.
  *
- *  This will be used for any following actions (such as
- *  #status) while the submodule is in memory. The ignore
- *  rule can be persisted to the config with #save.
- *
- *  Calling #reset_ignore_rule or #reload will
- *  revert the rule to the value that was in the config.
+ *  Calling #reload will update the submodule to the updated configuration.
  */
 static VALUE rb_git_submodule_set_ignore_rule(VALUE self, VALUE rb_ignore_rule)
 {
+	VALUE rb_repo = rugged_owner(self);
+	git_repository *repo;
 	git_submodule *submodule;
 
+	rugged_check_repo(rb_repo);
+
+	Data_Get_Struct(rb_repo, git_repository, repo);
 	Data_Get_Struct(self, git_submodule, submodule);
 
-	git_submodule_set_ignore(
-		submodule,
+	git_submodule_set_ignore(repo, git_submodule_name(submodule),
 		rb_git_subm_ignore_rule_toC(rb_ignore_rule)
 	);
 
 	return rb_ignore_rule;
-}
-
-/*
- *  call-seq:
- *    submodule.reset_ignore_rule -> submodule
- *
- *  Revert the ignore rule set by #ignore_rule= to the value that
- *  was in the config.
- */
-static VALUE rb_git_submodule_reset_ignore_rule(VALUE self)
-{
-	git_submodule *submodule;
-
-	Data_Get_Struct(self, git_submodule, submodule);
-
-	git_submodule_set_ignore(submodule, GIT_SUBMODULE_IGNORE_RESET);
-
-	return self;
 }
 
 static VALUE rb_git_subm_update_rule_fromC(git_submodule_update_t rule)
@@ -891,42 +872,27 @@ static git_submodule_update_t rb_git_subm_update_rule_toC(VALUE rb_update_rule)
  *  call-seq:
  *    submodule.update_rule = rule -> rule
  *
- *  Set the update_rule to +rule+ in memory for a submodule.
+ *  Set the update_rule to +rule+ in the configuration for a submodule.
  *  See #update_rule for a list of accepted rules.
  *
- *  Calling #reset_update_rule or #reload will
- *  revert the +rule+ to the value that was in the config.
+ *  Changing this setting won't affect the loaded submodule
  */
 static VALUE rb_git_submodule_set_update_rule(VALUE self, VALUE rb_update_rule)
 {
+	VALUE rb_repo = rugged_owner(self);
+	git_repository *repo;
 	git_submodule *submodule;
 
+	rugged_check_repo(rb_repo);
+
+	Data_Get_Struct(rb_repo, git_repository, repo);
 	Data_Get_Struct(self, git_submodule, submodule);
 
-	git_submodule_set_update(
-		submodule,
+	git_submodule_set_update(repo, git_submodule_name(submodule),
 		rb_git_subm_update_rule_toC(rb_update_rule)
 	);
 
 	return rb_update_rule;
-}
-
-/*
- *  call-seq:
- *    submodule.reset_update_rule -> submodule
- *
- *  Revert the update rule set by #update_rule= to the value that
- *  was in the config.
- */
-static VALUE rb_git_submodule_reset_update_rule(VALUE self)
-{
-	git_submodule *submodule;
-
-	Data_Get_Struct(self, git_submodule, submodule);
-
-	git_submodule_set_update(submodule, GIT_SUBMODULE_UPDATE_RESET);
-
-	return self;
 }
 
 /*
@@ -1004,10 +970,8 @@ void Init_rugged_submodule(void)
 
 	rb_define_method(rb_cRuggedSubmodule, "ignore_rule", rb_git_submodule_ignore_rule, 0);
 	rb_define_method(rb_cRuggedSubmodule, "ignore_rule=", rb_git_submodule_set_ignore_rule, 1);
-	rb_define_method(rb_cRuggedSubmodule, "reset_ignore_rule", rb_git_submodule_reset_ignore_rule, 0);
 	rb_define_method(rb_cRuggedSubmodule, "update_rule", rb_git_submodule_update_rule, 0);
 	rb_define_method(rb_cRuggedSubmodule, "update_rule=", rb_git_submodule_set_update_rule, 1);
-	rb_define_method(rb_cRuggedSubmodule, "reset_update_rule", rb_git_submodule_reset_update_rule, 0);
 
 	rb_define_method(rb_cRuggedSubmodule, "head_oid", rb_git_submodule_head_id, 0);
 	rb_define_method(rb_cRuggedSubmodule, "index_oid", rb_git_submodule_index_id, 0);
@@ -1036,7 +1000,6 @@ void Init_rugged_submodule(void)
 
 	rb_define_method(rb_cRuggedSubmodule, "add_to_index", rb_git_submodule_add_to_index, -1);
 	rb_define_method(rb_cRuggedSubmodule, "reload", rb_git_submodule_reload, 0);
-	rb_define_method(rb_cRuggedSubmodule, "save", rb_git_submodule_save, 0);
 	rb_define_method(rb_cRuggedSubmodule, "sync", rb_git_submodule_sync, 0);
 	rb_define_method(rb_cRuggedSubmodule, "init", rb_git_submodule_init, -1);
 }

--- a/ext/rugged/rugged_submodule.c
+++ b/ext/rugged/rugged_submodule.c
@@ -175,7 +175,7 @@ static VALUE rb_git_submodule_status(VALUE self)
 
 	rugged_exception_check(
 		git_submodule_status(&flags, repo, git_submodule_name(submodule),
-			GIT_SUBMODULE_IGNORE_FALLBACK)
+			GIT_SUBMODULE_IGNORE_UNSPECIFIED)
 	);
 
 	return submodule_status_flags_to_rb(flags);
@@ -245,7 +245,7 @@ static VALUE rb_git_submodule_status_in_workdir(VALUE self)
 	Data_Get_Struct(self, git_submodule, submodule); \
 	rugged_exception_check( \
 		git_submodule_status(&flags, repo, git_submodule_name(submodule), \
-			GIT_SUBMODULE_IGNORE_FALLBACK) \
+			GIT_SUBMODULE_IGNORE_UNSPECIFIED) \
 	); \
 	return (flags & flag) ? Qtrue : Qfalse; \
 
@@ -369,7 +369,7 @@ static VALUE rb_git_submodule_status_untracked_files_in_workdir(VALUE self)
 	Data_Get_Struct(self, git_submodule, submodule); \
 	rugged_exception_check( \
 		git_submodule_status(&flags, repo, git_submodule_name(submodule), \
-			GIT_SUBMODULE_IGNORE_FALLBACK) \
+			GIT_SUBMODULE_IGNORE_UNSPECIFIED) \
 	); \
 	return check(flags) ? Qtrue : Qfalse; \
 

--- a/test/submodule_test.rb
+++ b/test/submodule_test.rb
@@ -171,36 +171,26 @@ class SubmoduleTest < Rugged::SubmoduleTestCase
     submodule = @repo.submodules['sm_changed_untracked_file']
 
     submodule.ignore_rule = :untracked
+    submodule.reload
 
     assert submodule.unmodified?
     refute submodule.untracked_files_in_workdir?
 
-    submodule.reset_ignore_rule
-
-    refute submodule.unmodified?
-    assert submodule.untracked_files_in_workdir?
-
     #dirty
     submodule = @repo.submodules['sm_changed_file']
     submodule.ignore_rule = :dirty
+    submodule.reload
 
     refute submodule.modified_files_in_workdir?
-
-    submodule.reset_ignore_rule
-
-    assert submodule.modified_files_in_workdir?
 
     #all
     submodule = @repo.submodules['sm_added_and_uncommited']
     submodule.ignore_rule = :all
+    submodule.reload
 
     assert submodule.unmodified?
     refute submodule.added_to_index?
 
-    submodule.reset_ignore_rule
-
-    assert submodule.added_to_index?
-    refute submodule.unmodified?
   end
 
   def test_submodule_modify
@@ -212,7 +202,6 @@ class SubmoduleTest < Rugged::SubmoduleTestCase
     refute submodule.fetch_recurse_submodules?
     submodule.fetch_recurse_submodules = true
 
-    submodule.save
     submodule.reload
 
     assert_equal :untracked, submodule.ignore_rule
@@ -225,17 +214,16 @@ class SubmoduleTest < Rugged::SubmoduleTestCase
     assert_equal :checkout, submodule.update_rule
 
     submodule.update_rule = :rebase
+    submodule.reload
     assert_equal :rebase, submodule.update_rule
 
     submodule.update_rule = :merge
+    submodule.reload
     assert_equal :merge, submodule.update_rule
 
     submodule.update_rule = :none
+    submodule.reload
     assert_equal :none, submodule.update_rule
-
-    # reset
-    submodule.reset_update_rule
-    assert_equal :checkout, submodule.update_rule
   end
 
   def test_submodule_sync


### PR DESCRIPTION
This mainly contains changes necessary to support the API changes in the `git_remote_*` API that were recently introduced.