### PR TITLE
Change the Submodule API.

### DIFF
--- a/ext/rugged/rugged_submodule_collection.c
+++ b/ext/rugged/rugged_submodule_collection.c
@@ -224,6 +224,151 @@ static VALUE rb_git_submodule_setup_add(int argc, VALUE *argv, VALUE self)
 	return rugged_submodule_new(rb_repo, submodule);
 }
 
+static git_submodule_ignore_t rb_git_subm_ignore_rule_toC(VALUE rb_ignore_rule)
+{
+	ID id_ignore_rule;
+
+	Check_Type(rb_ignore_rule, T_SYMBOL);
+	id_ignore_rule = SYM2ID(rb_ignore_rule);
+
+	if (id_ignore_rule == rb_intern("none")) {
+		return GIT_SUBMODULE_IGNORE_NONE;
+	} else if (id_ignore_rule == rb_intern("untracked")) {
+		return GIT_SUBMODULE_IGNORE_UNTRACKED;
+	} else if (id_ignore_rule == rb_intern("dirty")) {
+		return GIT_SUBMODULE_IGNORE_DIRTY;
+	} else if (id_ignore_rule == rb_intern("all")) {
+		return GIT_SUBMODULE_IGNORE_ALL;
+	} else {
+		rb_raise(rb_eArgError, "Invalid submodule ignore rule type.");
+	}
+}
+
+static git_submodule_update_t rb_git_subm_update_rule_toC(VALUE rb_update_rule)
+{
+	ID id_update_rule;
+
+	Check_Type(rb_update_rule, T_SYMBOL);
+	id_update_rule = SYM2ID(rb_update_rule);
+
+	if (id_update_rule == rb_intern("checkout")) {
+		return GIT_SUBMODULE_UPDATE_CHECKOUT;
+	} else if (id_update_rule == rb_intern("rebase")) {
+		return GIT_SUBMODULE_UPDATE_REBASE;
+	} else if (id_update_rule == rb_intern("merge")) {
+		return GIT_SUBMODULE_UPDATE_MERGE;
+	} else if (id_update_rule == rb_intern("none")) {
+		return GIT_SUBMODULE_UPDATE_NONE;
+	} else {
+		rb_raise(rb_eArgError, "Invalid submodule update rule type.");
+	}
+}
+
+/*
+ *  call-seq:
+ *    submodules.update(submodule, settings) -> nil
+ *    submodules.update(name, settings) -> nil
+ *
+ *  Update settings for the given submodule in the submodule config.
+ *
+ *  Existing `Rugged::Submodule` instances are not updated, but can be
+ *  reloaded by calling `#reload`.
+ *
+ *  The following options can be passed in the +settings+ Hash:
+ *
+ *  :url ::
+ *    Updates the URL for the submodule.
+ *
+ *  :ignore_rule ::
+ *    See `Rugged::Submodule#ignore_rule` for a list of accepted rules.
+ *
+ *  :update_rule ::
+ *    See `Rugged::Submodule#update_rule` for a list of accepted rules.
+ *
+ *  :fetch_recurse_submodules ::
+ *    Updates the +fetchRecurseSubmodules+ rule.
+ */
+static VALUE rb_git_submodule_update(VALUE self, VALUE rb_name_or_submodule, VALUE rb_settings)
+{
+	git_repository *repo;
+	git_submodule_ignore_t ignore_rule;
+	git_submodule_update_t update_rule;
+	const char *submodule_name;
+	int fetch_recurse_submodules;
+	VALUE rb_repo = rugged_owner(self);
+	VALUE rb_url, rb_fetch_recurse_submodules, rb_ignore_rule, rb_update_rule;
+
+	rugged_check_repo(rb_repo);
+	Data_Get_Struct(rb_repo, git_repository, repo);
+
+	if (rb_obj_is_kind_of(rb_name_or_submodule, rb_cRuggedSubmodule))
+		rb_name_or_submodule = rb_funcall(rb_name_or_submodule, rb_intern("name"), 0);
+
+	if (TYPE(rb_name_or_submodule) != T_STRING)
+		rb_raise(rb_eTypeError, "Expecting a String or Rugged::Submodule instance");
+
+	rb_url = rb_hash_aref(rb_settings, CSTR2SYM("url"));
+	rb_fetch_recurse_submodules = rb_hash_aref(rb_settings, CSTR2SYM("fetch_recurse_submodules"));
+	rb_ignore_rule = rb_hash_aref(rb_settings, CSTR2SYM("ignore_rule"));
+	rb_update_rule = rb_hash_aref(rb_settings, CSTR2SYM("update_rule"));
+
+	if (!NIL_P(rb_url)) {
+		Check_Type(rb_url, T_STRING);
+	}
+
+	if (!NIL_P(rb_fetch_recurse_submodules)) {
+		fetch_recurse_submodules = rugged_parse_bool(rb_fetch_recurse_submodules);
+	}
+
+	if (!NIL_P(rb_ignore_rule)) {
+		ignore_rule = rb_git_subm_ignore_rule_toC(rb_ignore_rule);
+	}
+
+	if (!NIL_P(rb_update_rule)) {
+		update_rule = rb_git_subm_update_rule_toC(rb_update_rule);
+	}
+
+	submodule_name = StringValueCStr(rb_name_or_submodule);
+
+	if (!NIL_P(rb_url)) {
+		rugged_exception_check(
+			git_submodule_set_url(repo,
+				submodule_name,
+				StringValueCStr(rb_url)
+			)
+		);
+	}
+
+	if (!NIL_P(rb_fetch_recurse_submodules)) {
+		rugged_exception_check(
+			git_submodule_set_fetch_recurse_submodules(repo,
+				submodule_name,
+				fetch_recurse_submodules
+			)
+		);
+	}
+
+	if (!NIL_P(rb_ignore_rule)) {
+		rugged_exception_check(
+			git_submodule_set_ignore(repo,
+				submodule_name,
+				ignore_rule
+			)
+		);
+	}
+
+	if (!NIL_P(rb_update_rule)) {
+		rugged_exception_check(
+			git_submodule_set_update(repo,
+				submodule_name,
+				update_rule
+			)
+		);
+	}
+
+	return Qnil;
+}
+
 void Init_rugged_submodule_collection(void)
 {
 	rb_cRuggedSubmoduleCollection = rb_define_class_under(rb_mRugged, "SubmoduleCollection", rb_cObject);
@@ -232,5 +377,8 @@ void Init_rugged_submodule_collection(void)
 	rb_define_method(rb_cRuggedSubmoduleCollection, "initialize", rb_git_submodule_collection_initialize, 1);
 	rb_define_method(rb_cRuggedSubmoduleCollection, "[]",         rb_git_submodule_collection_aref, 1);
 	rb_define_method(rb_cRuggedSubmoduleCollection, "each",       rb_git_submodule_collection_each, 0);
+
+	rb_define_method(rb_cRuggedSubmoduleCollection, "update",     rb_git_submodule_update, 2);
+
 	rb_define_method(rb_cRuggedSubmoduleCollection, "setup_add",  rb_git_submodule_setup_add, -1);
 }


### PR DESCRIPTION
This PR aligns the Submodule API with the new libgit2 submodule API.

I pulled out all setter methods that were available on `Rugged::Submodule` into a common `#update` method on the `SubmoduleCollection` class.