### PR TITLE
Use travis defaults for bundler installation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ matrix:
     - rvm: rbx-2
     - rvm: ruby-head
 
-install:
+before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./vendor/libgit2/script/install-deps-osx.sh; fi
-  - bundle install --path vendor/local
 
 script: script/travisbuild


### PR DESCRIPTION
Let's use whatever travis thinks are the appropriate bundler args for installation.

(At the moment, that's: `bundle install --jobs=3 --retry=3`)