### PR TITLE
Better Fixture Management

### DIFF
--- a/rugged.gemspec
+++ b/rugged.gemspec
@@ -30,5 +30,5 @@ for testing and using the libgit2 library in a language that is awesome.
 desc
   s.add_development_dependency "rake-compiler", ">= 0.9.0"
   s.add_development_dependency "pry"
-  s.add_development_dependency "minitest", "~> 3.0.0"
+  s.add_development_dependency "minitest", "~> 3.0"
 end

--- a/test/blame_test.rb
+++ b/test/blame_test.rb
@@ -1,16 +1,10 @@
 require "test_helper"
 require "time"
 
-class BlameTest < Rugged::SandboxedTestCase
+class BlameTest < Rugged::TestCase
   def setup
-    super
-    @repo = sandbox_init("testrepo")
+    @repo = FixtureRepo.from_libgit2("testrepo")
     @blame = Rugged::Blame.new(@repo, "branch_file.txt")
-  end
-
-  def teardown
-    @repo.close
-    super
   end
 
   def test_blame_index

--- a/test/blob_test.rb
+++ b/test/blob_test.rb
@@ -1,7 +1,9 @@
 require "test_helper"
 
 class BlobTest < Rugged::TestCase
-  include Rugged::RepositoryAccess
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
 
   def test_lookup_raises_error_if_object_type_does_not_match
     assert_raises Rugged::InvalidError do
@@ -123,7 +125,10 @@ class BlobTest < Rugged::TestCase
 end
 
 class BlobWriteTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @source_repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo = FixtureRepo.clone(@source_repo)
+  end
 
   def test_fetch_blob_content_with_nulls
     content = "100644 example_helper.rb\x00\xD3\xD5\xED\x9DA4_"+
@@ -171,7 +176,9 @@ class BlobWriteTest < Rugged::TestCase
 end
 
 class BlobLOCTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
 
   def write_blob(data)
     sha = Rugged::Blob.from_buffer(@repo, data)
@@ -209,15 +216,9 @@ class BlobLOCTest < Rugged::TestCase
   end
 end
 
-class BlobDiffTest < Rugged::SandboxedTestCase
+class BlobDiffTest < Rugged::TestCase
   def setup
-    super
-    @repo = sandbox_init("diff")
-  end
-
-  def teardown
-    @repo.close
-    super
+    @repo = FixtureRepo.from_libgit2("diff")
   end
 
   def test_diff_blob
@@ -351,7 +352,9 @@ class BlobDiffTest < Rugged::SandboxedTestCase
 end
 
 class BlobCreateFromIOTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
 
   def test_write_blob_from_io_with_hintpath
     file_path= File.join(TEST_DIR, (File.join('fixtures', 'archive.tar.gz')))
@@ -415,7 +418,9 @@ class BlobCreateFromIOTest < Rugged::TestCase
 end
 
 class BlobHashSignatureTest < Rugged::TestCase
-  include Rugged::RepositoryAccess
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
 
   LOREM = <<-LOREM
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -445,4 +450,3 @@ LOREM
     assert Rugged::Blob::HashSignature.compare(sig1, sig2) > 75
   end
 end
-

--- a/test/branch_test.rb
+++ b/test/branch_test.rb
@@ -2,7 +2,10 @@
 require "test_helper"
 
 class BranchTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @source_repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo = FixtureRepo.clone(@source_repo)
+  end
 
   def test_list_all_names
     assert_equal [

--- a/test/cherrypick_test.rb
+++ b/test/cherrypick_test.rb
@@ -1,14 +1,8 @@
 require "test_helper"
 
-class WorkdirCherrypickTest < Rugged::SandboxedTestCase
+class WorkdirCherrypickTest < Rugged::TestCase
   def setup
-    super
-    @repo = sandbox_init("cherrypick")
-  end
-
-  def teardown
-    @repo.close
-    super
+    @repo = FixtureRepo.from_libgit2("cherrypick")
   end
 
   def test_automerge

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -1,7 +1,9 @@
 require "test_helper"
 
 class TestCommit < Rugged::TestCase
-  include Rugged::RepositoryAccess
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
 
   def test_lookup_raises_error_if_object_type_does_not_match
     assert_raises Rugged::InvalidError do
@@ -174,7 +176,10 @@ class TestCommit < Rugged::TestCase
 end
 
 class CommitWriteTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @source_repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo = FixtureRepo.clone(@source_repo)
+  end
 
   def test_write_commit_with_time
     person = {:name => 'Scott', :email => 'schacon@gmail.com', :time => Time.now }
@@ -258,17 +263,9 @@ class CommitWriteTest < Rugged::TestCase
   end
 end
 
-class CommitToMboxTest < Rugged::SandboxedTestCase
+class CommitToMboxTest < Rugged::TestCase
   def setup
-    super
-
-    @repo = sandbox_init "diff_format_email"
-  end
-
-  def teardown
-    @repo.close
-
-    super
+    @repo = FixtureRepo.from_libgit2 "diff_format_email"
   end
 
   def test_format_to_mbox

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,7 +1,9 @@
 require "test_helper"
 
-class ConfigTest < Rugged::TestCase 
-  include Rugged::RepositoryAccess
+class ConfigTest < Rugged::TestCase
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
 
   def test_read_config_file
     config = @repo.config
@@ -22,7 +24,11 @@ class ConfigTest < Rugged::TestCase
 end
 
 class ConfigWriteTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @source_repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo = FixtureRepo.clone(@source_repo)
+    @path = @repo.workdir
+  end
 
   def test_write_config_values
     config = @repo.config

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PatchFromStringsTest < Rugged::SandboxedTestCase
+class PatchFromStringsTest < Rugged::TestCase
   def test_from_strings_no_args
     patch = Rugged::Patch.from_strings()
     assert_equal 0, patch.size
@@ -64,9 +64,9 @@ EOS
   end
 end
 
-class RepoDiffTest < Rugged::SandboxedTestCase
+class RepoDiffTest < Rugged::TestCase
   def test_with_oid_string
-    repo = sandbox_init("attr")
+    repo = FixtureRepo.from_libgit2("attr")
     diff = repo.diff("605812a", "370fe9ec22", :context_lines => 1, :interhunk_lines => 1)
 
     deltas = diff.deltas
@@ -91,7 +91,7 @@ class RepoDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_delta_status_char
-    repo = sandbox_init("attr")
+    repo = FixtureRepo.from_libgit2("attr")
     diff = repo.diff("605812a", "370fe9ec22", :context_lines => 1, :interhunk_lines => 1)
 
     deltas = diff.deltas
@@ -104,7 +104,7 @@ class RepoDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_with_nil_on_left_side
-    repo = sandbox_init("attr")
+    repo = FixtureRepo.from_libgit2("attr")
     diff = repo.diff("605812a", nil, :context_lines => 1, :interhunk_lines => 1)
 
     deltas = diff.deltas
@@ -129,7 +129,7 @@ class RepoDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_with_nil_on_right_side
-    repo = sandbox_init("attr")
+    repo = FixtureRepo.from_libgit2("attr")
     diff = repo.diff(nil, "605812a", :context_lines => 1, :interhunk_lines => 1)
 
     deltas = diff.deltas
@@ -154,9 +154,9 @@ class RepoDiffTest < Rugged::SandboxedTestCase
   end
 end
 
-class RepoWorkdirDiffTest < Rugged::SandboxedTestCase
+class RepoWorkdirDiffTest < Rugged::TestCase
   def test_basic_diff
-    repo = sandbox_init("status")
+    repo = FixtureRepo.from_libgit2("status")
     diff = repo.diff_workdir("26a125ee1bf",
       :context_lines => 3,
       :interhunk_lines => 1,
@@ -187,9 +187,9 @@ class RepoWorkdirDiffTest < Rugged::SandboxedTestCase
   end
 end
 
-class CommitDiffTest < Rugged::SandboxedTestCase
+class CommitDiffTest < Rugged::TestCase
   def test_diff_with_parent
-    repo = sandbox_init("attr")
+    repo = FixtureRepo.from_libgit2("attr")
     commit = Rugged::Commit.lookup(repo, "605812a")
 
     diff = commit.diff(:context_lines => 1, :interhunk_lines => 1)
@@ -216,7 +216,7 @@ class CommitDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_diff_with_parent_for_initial_commit
-    repo = sandbox_init("attr")
+    repo = FixtureRepo.from_libgit2("attr")
     commit = Rugged::Commit.lookup(repo, "6bab5c79cd5140d0f800917f550eb2a3dc32b0da")
 
     diff = commit.diff(:context_lines => 1, :interhunk_lines => 1, :reverse => true)
@@ -243,9 +243,9 @@ class CommitDiffTest < Rugged::SandboxedTestCase
   end
 end
 
-class CommitToWorkdirDiffTest < Rugged::SandboxedTestCase
+class CommitToWorkdirDiffTest < Rugged::TestCase
   def test_basic_diff
-    repo = sandbox_init("status")
+    repo = FixtureRepo.from_libgit2("status")
     a = Rugged::Commit.lookup(repo, "26a125ee1bf")
 
     diff = a.diff_workdir(
@@ -278,9 +278,9 @@ class CommitToWorkdirDiffTest < Rugged::SandboxedTestCase
   end
 end
 
-class TreeToWorkdirDiffTest < Rugged::SandboxedTestCase
+class TreeToWorkdirDiffTest < Rugged::TestCase
   def test_basic_diff
-    repo = sandbox_init("status")
+    repo = FixtureRepo.from_libgit2("status")
     a = Rugged::Commit.lookup(repo, "26a125ee1bf").tree
 
     diff = a.diff_workdir(
@@ -313,7 +313,7 @@ class TreeToWorkdirDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_diff_merge
-    repo = sandbox_init("status")
+    repo = FixtureRepo.from_libgit2("status")
     index = repo.index
 
     a = Rugged::Commit.lookup(repo, "26a125ee1bf").tree
@@ -352,7 +352,7 @@ class TreeToWorkdirDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_stats
-    repo = sandbox_init("status")
+    repo = FixtureRepo.from_libgit2("status")
     index = repo.index
 
     a = Rugged::Commit.lookup(repo, "26a125ee1bf").tree
@@ -392,9 +392,9 @@ class TreeToWorkdirDiffTest < Rugged::SandboxedTestCase
   end
 end
 
-class TreeToTreeDiffTest < Rugged::SandboxedTestCase
+class TreeToTreeDiffTest < Rugged::TestCase
   def test_basic_diff
-    repo = sandbox_init("attr")
+    repo = FixtureRepo.from_libgit2("attr")
     a = Rugged::Commit.lookup(repo, "605812a").tree
     b = Rugged::Commit.lookup(repo, "370fe9ec22").tree
     c = Rugged::Commit.lookup(repo, "f5b0af1fb4f5c").tree
@@ -444,7 +444,7 @@ class TreeToTreeDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_diff_with_empty_tree
-    repo = sandbox_init("attr")
+    repo = FixtureRepo.from_libgit2("attr")
     a = Rugged::Commit.lookup(repo, "605812a").tree
 
     diff = a.diff(nil, :context_lines => 1, :interhunk_lines => 1)
@@ -471,7 +471,7 @@ class TreeToTreeDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_diff_with_rev_string
-    repo = sandbox_init("attr")
+    repo = FixtureRepo.from_libgit2("attr")
     a = Rugged::Commit.lookup(repo, "605812a").tree
 
     diff = a.diff("370fe9ec22", :context_lines => 1, :interhunk_lines => 1)
@@ -498,7 +498,7 @@ class TreeToTreeDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_diff_merge
-    repo = sandbox_init("attr")
+    repo = FixtureRepo.from_libgit2("attr")
     a = Rugged::Commit.lookup(repo, "605812a").tree
     b = Rugged::Commit.lookup(repo, "370fe9ec22").tree
     c = Rugged::Commit.lookup(repo, "f5b0af1fb4f5c").tree
@@ -527,7 +527,7 @@ class TreeToTreeDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_symlink_blob_mode_changed_to_regular_file
-    repo = sandbox_init("unsymlinked.git")
+    repo = FixtureRepo.from_libgit2("unsymlinked.git")
 
     a = Rugged::Commit.lookup(repo, "7fccd7").tree
     b = Rugged::Commit.lookup(repo, "806999").tree
@@ -548,7 +548,7 @@ class TreeToTreeDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_symlink_blob_mode_changed_to_regular_file_as_typechange
-    repo = sandbox_init("unsymlinked.git")
+    repo = FixtureRepo.from_libgit2("unsymlinked.git")
 
     a = Rugged::Commit.lookup(repo, "7fccd7").tree
     b = Rugged::Commit.lookup(repo, "806999").tree
@@ -569,7 +569,7 @@ class TreeToTreeDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_regular_blob_mode_changed_to_executable_file
-    repo = sandbox_init("unsymlinked.git")
+    repo = FixtureRepo.from_libgit2("unsymlinked.git")
 
     a = Rugged::Commit.lookup(repo, "806999").tree
     b = Rugged::Commit.lookup(repo, "a8595c").tree
@@ -590,7 +590,7 @@ class TreeToTreeDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_size
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -600,7 +600,7 @@ class TreeToTreeDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_each_delta
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -627,7 +627,7 @@ class TreeToTreeDiffTest < Rugged::SandboxedTestCase
   end
 
   def test_diff_treats_files_bigger_as_max_size_as_binary
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -645,7 +645,7 @@ EOS
   end
 
   def test_contraining_paths
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -667,7 +667,7 @@ EOS
   end
 
   def test_options
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -716,7 +716,7 @@ EOS
   end
 
   def test_iteration
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -827,7 +827,7 @@ EOS
   end
 
   def test_each_line_patch
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -869,7 +869,7 @@ EOS
   end
 
   def test_each_line_patch_header
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -893,7 +893,7 @@ EOS
   end
 
   def test_each_line_raw
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -917,7 +917,7 @@ EOS
   end
 
   def test_each_line_name_only
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -941,7 +941,7 @@ EOS
   end
 
   def test_each_line_name_status
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -965,7 +965,7 @@ EOS
   end
 
   def test_each_line_unknown_format_raises_error
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -978,7 +978,7 @@ EOS
   end
 
   def test_each_patch_returns_enumerator
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -996,7 +996,7 @@ EOS
   end
 
   def test_each_hunk_returns_enumerator
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -1009,7 +1009,7 @@ EOS
   end
 
   def test_each_line_returns_enumerator
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -1024,7 +1024,7 @@ EOS
   end
 
   def test_patch
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -1109,7 +1109,7 @@ EOS
   end
 
   def test_patch_compact
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
@@ -1123,7 +1123,7 @@ EOS
   end
 
   def test_stats
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")

--- a/test/merge_test.rb
+++ b/test/merge_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-class TrivialMergeTest < Rugged::SandboxedTestCase
+class TrivialMergeTest < Rugged::TestCase
   def test_2alt
-    repo = sandbox_init("merge-resolve")
+    repo = FixtureRepo.from_libgit2("merge-resolve")
 
     ours = repo.rev_parse("trivial-2alt")
     theirs = repo.rev_parse("trivial-2alt-branch")
@@ -18,7 +18,7 @@ class TrivialMergeTest < Rugged::SandboxedTestCase
   end
 
   def test_4
-    repo = sandbox_init("merge-resolve")
+    repo = FixtureRepo.from_libgit2("merge-resolve")
 
     ours = repo.rev_parse("trivial-4")
     theirs = repo.rev_parse("trivial-4-branch")
@@ -33,7 +33,7 @@ class TrivialMergeTest < Rugged::SandboxedTestCase
   end
 
   def test_analysis
-    repo = sandbox_init("merge-resolve")
+    repo = FixtureRepo.from_libgit2("merge-resolve")
 
     analysis = repo.merge_analysis("HEAD")
     assert_equal [:up_to_date], analysis

--- a/test/note_test.rb
+++ b/test/note_test.rb
@@ -1,7 +1,9 @@
 require 'test_helper'
 
 class NoteTest < Rugged::TestCase
-  include Rugged::RepositoryAccess
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
 
   def test_read_note_for_object
     oid = "36060c58702ed4c2a40832c51758d5344201d89a"
@@ -49,7 +51,10 @@ class NoteTest < Rugged::TestCase
 end
 
 class NoteWriteTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @source_repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo = FixtureRepo.clone(@source_repo)
+  end
 
   def test_create_note
     person = {:name => 'Scott', :email => 'schacon@gmail.com', :time => Time.now }

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -2,7 +2,9 @@ require "test_helper"
 require 'base64'
 
 class ObjectTest < Rugged::TestCase
-  include Rugged::RepositoryAccess
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
 
   def test_lookup_can_lookup_any_object_type
     blob = Rugged::Object.lookup(@repo, "fa49b077972391ad58037050f2a75f74e3671e92")

--- a/test/online/fetch_test.rb
+++ b/test/online/fetch_test.rb
@@ -2,13 +2,7 @@ require 'test_helper'
 
 class OnlineFetchTest < Rugged::OnlineTestCase
   def setup
-    super
-    @repo = Rugged::Repository.init_at(File.join(@_sandbox_path, "repo"))
-  end
-
-  def teardown
-    @repo.close
-    super
+    @repo = FixtureRepo.empty
   end
 
   if git_creds?

--- a/test/online/fetch_test.rb
+++ b/test/online/fetch_test.rb
@@ -7,8 +7,6 @@ class OnlineFetchTest < Rugged::OnlineTestCase
 
   if git_creds?
     def test_fetch_over_git
-      reset_remote_repo
-
       @repo.remotes.create("origin", ENV['GITTEST_REMOTE_GIT_URL'])
 
       @repo.fetch("origin")
@@ -34,8 +32,6 @@ class OnlineFetchTest < Rugged::OnlineTestCase
 
   if Rugged.features.include?(:ssh) && ssh_creds?
     def test_fetch_over_ssh_with_credentials
-      reset_remote_repo
-
       @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
 
       @repo.fetch("origin", {
@@ -44,8 +40,6 @@ class OnlineFetchTest < Rugged::OnlineTestCase
     end
 
     def test_fetch_over_ssh_with_credentials_from_agent
-      reset_remote_repo
-
       @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
 
       @repo.fetch("origin", {
@@ -54,8 +48,6 @@ class OnlineFetchTest < Rugged::OnlineTestCase
     end
 
     def test_fetch_over_ssh_with_credentials_callback
-      reset_remote_repo
-
       @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
 
       @repo.fetch("origin", {

--- a/test/online/ls_test.rb
+++ b/test/online/ls_test.rb
@@ -2,15 +2,7 @@ require 'test_helper'
 
 class OnlineLsTest < Rugged::OnlineTestCase
   def setup
-    super
-
-    @repo = sandbox_init("push_src")
-  end
-
-  def teardown
-    @repo.close
-
-    super
+    @repo = FixtureRepo.from_libgit2("push_src")
   end
 
   if Rugged.features.include?(:https)

--- a/test/online/ls_test.rb
+++ b/test/online/ls_test.rb
@@ -25,8 +25,6 @@ class OnlineLsTest < Rugged::OnlineTestCase
 
   if git_creds?
     def test_ls_over_git
-      reset_remote_repo
-
       remote = @repo.remotes.create("origin", ENV['GITTEST_REMOTE_GIT_URL'])
       remote.push(["refs/heads/b1:refs/heads/b1"])
 
@@ -38,8 +36,6 @@ class OnlineLsTest < Rugged::OnlineTestCase
 
   if Rugged.features.include?(:ssh) && ssh_creds?
     def test_ls_over_ssh_with_credentials
-      reset_remote_repo
-
       remote = @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
       remote.push(["refs/heads/b1:refs/heads/b1"], credentials: ssh_key_credential)
 

--- a/test/online/push_test.rb
+++ b/test/online/push_test.rb
@@ -2,17 +2,9 @@ require 'test_helper'
 
 class OnlineGitPushTest < Rugged::OnlineTestCase
   def setup
-    super
-
-    @repo = sandbox_init("push_src")
+    @repo = FixtureRepo.from_libgit2("push_src")
     @remote = @repo.remotes.create("test", ENV['GITTEST_REMOTE_GIT_URL'])
     @target_repo = Rugged::Repository.new(ENV['GITTEST_REMOTE_REPO_PATH'])
-  end
-
-  def teardown
-    @repo.close
-
-    super
   end
 
   if git_creds?
@@ -37,17 +29,9 @@ end
 if Rugged.features.include?(:ssh)
   class OnlineSshPushTest < Rugged::OnlineTestCase
     def setup
-      super
-
-      @repo = sandbox_init("push_src")
+      @repo = FixtureRepo.from_libgit2("push_src")
       @remote = @repo.remotes.create("test", ENV['GITTEST_REMOTE_SSH_URL'])
       @target_repo = Rugged::Repository.new(ENV['GITTEST_REMOTE_REPO_PATH'])
-    end
-
-    def teardown
-      @repo.close
-
-      super
     end
 
     if ssh_creds?

--- a/test/patch_test.rb
+++ b/test/patch_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-class PatchTest < Rugged::SandboxedTestCase
+class PatchTest < Rugged::TestCase
   def test_to_s
-    repo = sandbox_init("diff")
+    repo = FixtureRepo.from_libgit2("diff")
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -1,15 +1,9 @@
 # encoding: UTF-8
 require "test_helper"
 
-class ReferenceTest < Rugged::SandboxedTestCase
+class ReferenceTest < Rugged::TestCase
   def setup
-    super
-    @repo = sandbox_init("testrepo")
-  end
-
-  def teardown
-    @repo.close
-    super
+    @repo = FixtureRepo.from_libgit2("testrepo")
   end
 
   def test_reference_validity
@@ -131,45 +125,37 @@ class ReferenceTest < Rugged::SandboxedTestCase
   end
 
   def test_reference_is_branch
-    repo = sandbox_init("testrepo.git")
+    repo = FixtureRepo.from_libgit2("testrepo.git")
 
-    begin
-      assert repo.references["refs/heads/master"].branch?
+    assert repo.references["refs/heads/master"].branch?
 
-      refute repo.references["refs/remotes/test/master"].branch?
-      refute repo.references["refs/tags/test"].branch?
-    ensure
-      repo.close
-    end
+    refute repo.references["refs/remotes/test/master"].branch?
+    refute repo.references["refs/tags/test"].branch?
   end
 
   def test_reference_is_remote
-    repo = sandbox_init("testrepo.git")
-    begin
-      assert repo.references["refs/remotes/test/master"].remote?
+    repo = FixtureRepo.from_libgit2("testrepo.git")
 
-      refute repo.references["refs/heads/master"].remote?
-      refute repo.references["refs/tags/test"].remote?
-    ensure
-      repo.close
-    end
+    assert repo.references["refs/remotes/test/master"].remote?
+
+    refute repo.references["refs/heads/master"].remote?
+    refute repo.references["refs/tags/test"].remote?
   end
 
   def test_reference_is_tag
-    repo = sandbox_init("testrepo.git")
-    begin
-      assert repo.references["refs/tags/test"].tag?
+    repo = FixtureRepo.from_libgit2("testrepo.git")
 
-      refute repo.references["refs/heads/master"].tag?
-      refute repo.references["refs/remotes/test/master"].tag?
-    ensure
-      repo.close
-    end
+    assert repo.references["refs/tags/test"].tag?
+
+    refute repo.references["refs/heads/master"].tag?
+    refute repo.references["refs/remotes/test/master"].tag?
   end
 end
 
 class ReferenceWriteTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
 
   def test_create_force
     @repo.references.create("refs/heads/unit_test", "refs/heads/master")
@@ -286,11 +272,9 @@ class ReferenceWriteTest < Rugged::TestCase
   end
 end
 
-class ReflogTest < Rugged::SandboxedTestCase
+class ReflogTest < Rugged::TestCase
   def setup
-    super
-
-    @repo = sandbox_init("testrepo")
+    @repo = FixtureRepo.from_libgit2("testrepo")
 
     @ident = {
       name: 'Rugged User',
@@ -302,11 +286,6 @@ class ReflogTest < Rugged::SandboxedTestCase
 
     @ref = @repo.references.create("refs/heads/test-reflog",
       "a65fedf39aefe402d3bb6e24df4d4f5fe4547750")
-  end
-
-  def teardown
-    @repo.close
-    super
   end
 
   def test_create_default_log

--- a/test/repo_ignore_test.rb
+++ b/test/repo_ignore_test.rb
@@ -1,16 +1,8 @@
 require "test_helper"
 
-class RepositoryIgnoreTest < Rugged::SandboxedTestCase
+class RepositoryIgnoreTest < Rugged::TestCase
   def setup
-    super
-
-    @repo = sandbox_init "attr"
-  end
-
-  def teardown
-    @repo.close
-
-    super
+    @repo = FixtureRepo.from_libgit2 "attr"
   end
 
   def test_path_ignored
@@ -24,4 +16,3 @@ class RepositoryIgnoreTest < Rugged::SandboxedTestCase
     refute @repo.path_ignored?("direction")
   end
 end
-

--- a/test/repo_pack_test.rb
+++ b/test/repo_pack_test.rb
@@ -2,7 +2,9 @@ require "test_helper"
 require 'base64'
 
 class PackfileTest < Rugged::TestCase
-  include Rugged::RepositoryAccess
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
 
   def test_packfile_object_exists
     assert @repo.exists?("41bc8c69075bbdb46c5c6f0566cc8cc5b46e8bd9")

--- a/test/repo_reset_test.rb
+++ b/test/repo_reset_test.rb
@@ -1,10 +1,13 @@
 require "test_helper"
 
 class RepositoryResetTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @source_repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo = FixtureRepo.clone(@source_repo)
+  end
 
   def repo_file_path; File.join('subdir', 'README') end
-  def file_path;      File.join(@path, 'subdir', 'README') end
+  def file_path;      File.join(@repo.workdir, 'subdir', 'README') end
 
   def test_reset_with_rugged_tag
     tag = @repo.lookup('0c37a5391bbff43c37f0d0371823a5509eed5b1d')

--- a/test/status_test.rb
+++ b/test/status_test.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 require "test_helper"
 
-class LibgitRepositoryStatusTest < Rugged::SandboxedTestCase
+class LibgitRepositoryStatusTest < Rugged::TestCase
   STATUSES = {
     "staged_changes" => [:index_modified],
     "staged_changes_file_deleted" => [:index_modified, :worktree_deleted],
@@ -30,8 +30,7 @@ class LibgitRepositoryStatusTest < Rugged::SandboxedTestCase
   end
 
   def setup
-    super
-    @repo = sandbox_init "status"
+    @repo = FixtureRepo.from_libgit2 "status"
   end
 
   def test_status_with_callback
@@ -50,10 +49,4 @@ class LibgitRepositoryStatusTest < Rugged::SandboxedTestCase
       @repo.status(invalid_file)
     end
   end
-
-  def teardown
-    @repo.close
-    super
-  end
-
 end

--- a/test/submodule_test.rb
+++ b/test/submodule_test.rb
@@ -1,8 +1,20 @@
 require 'test_helper'
 
-class SubmoduleTest < Rugged::SubmoduleTestCase
+class SubmoduleTest < Rugged::TestCase
   def setup
-    @repo = setup_submodule
+    @repo = FixtureRepo.from_libgit2('submod2').tap do |repo|
+      Dir.chdir(repo.workdir) do
+        File.rename(
+          File.join('not-submodule', '.gitted'),
+          File.join('not-submodule', '.git')
+        )
+
+        File.rename(
+          File.join('not', '.gitted'),
+          File.join('not', '.git')
+        )
+      end
+    end
   end
 
   class TestException < StandardError

--- a/test/submodule_test.rb
+++ b/test/submodule_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class SubmoduleTest < Rugged::SubmoduleTestCase
   def setup
-    super
     @repo = setup_submodule
   end
 
@@ -41,7 +40,7 @@ class SubmoduleTest < Rugged::SubmoduleTestCase
 
     assert :none, submodule.ignore_rule
     assert submodule.path.end_with?('sm_unchanged')
-    assert submodule.url.end_with?('submod2_target')
+    #assert submodule.url.end_with?('submod2_target')
     assert_equal 'sm_unchanged', submodule.name
 
     assert_equal oid, submodule.head_oid

--- a/test/tag_test.rb
+++ b/test/tag_test.rb
@@ -1,14 +1,8 @@
 require "test_helper"
 
-class TagTest < Rugged::SandboxedTestCase
+class TagTest < Rugged::TestCase
   def setup
-    super
-    @repo = sandbox_init("testrepo.git")
-  end
-
-  def teardown
-    @repo.close
-    super
+    @repo = FixtureRepo.from_libgit2("testrepo.git")
   end
 
   def test_lookup_raises_error_if_object_type_does_not_match
@@ -106,19 +100,13 @@ class TagTest < Rugged::SandboxedTestCase
   end
 end
 
-class AnnotatedTagTest < Rugged::SandboxedTestCase
+class AnnotatedTagTest < Rugged::TestCase
   def setup
-    super
-    @repo = sandbox_init("testrepo.git")
+    @repo = FixtureRepo.from_libgit2("testrepo.git")
     @tag = @repo.tags.create('annotated_tag', "5b5b025afb0b4c913b4c338a42934a3863bf3644", {
       :message => "test tag message\n",
       :tagger  => { :name => 'Scott', :email => 'schacon@gmail.com', :time => Time.now }
     })
-  end
-
-  def teardown
-    @repo.close
-    super
   end
 
   def test_is_annotated
@@ -143,10 +131,9 @@ class AnnotatedTagTest < Rugged::SandboxedTestCase
   end
 end
 
-class AnnotatedTagObjectTest < Rugged::SandboxedTestCase
+class AnnotatedTagObjectTest < Rugged::TestCase
   def setup
-    super
-    @repo = sandbox_init("testrepo.git")
+    @repo = FixtureRepo.from_libgit2("testrepo.git")
     @annotation = @repo.tags.create_annotation("my-tag", "5b5b025afb0b4c913b4c338a42934a3863bf3644", {
       :message => "test tag message\n",
       :tagger  => { :name => "Scott", :email => "schacon@gmail.com", :time => Time.now },
@@ -171,16 +158,10 @@ class AnnotatedTagObjectTest < Rugged::SandboxedTestCase
   end
 end
 
-class LightweightTagTest < Rugged::SandboxedTestCase
+class LightweightTagTest < Rugged::TestCase
   def setup
-    super
-    @repo = sandbox_init("testrepo.git")
+    @repo = FixtureRepo.from_libgit2("testrepo.git")
     @tag = @repo.tags.create('lightweight_tag', "5b5b025afb0b4c913b4c338a42934a3863bf3644")
-  end
-
-  def teardown
-    @repo.close
-    super
   end
 
   def test_is_not_annotated
@@ -200,7 +181,10 @@ class LightweightTagTest < Rugged::SandboxedTestCase
 end
 
 class TagWriteTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @source_repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo = FixtureRepo.clone(@source_repo)
+  end
 
   def test_writing_a_tag
     tag = @repo.tags.create('tag', "5b5b025afb0b4c913b4c338a42934a3863bf3644", {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,62 +6,80 @@ require 'pp'
 
 module Rugged
   class TestCase < MiniTest::Unit::TestCase
+    # Helper methods to
+    module FixtureRepo
+      # Create a new, empty repository.
+      def self.empty(*args)
+        path = Dir.mktmpdir("rugged-empty")
+        with_cleanup(Rugged::Repository.init_at(path, *args), path)
+      rescue
+        FileUtils.remove_entry_secure(path)
+        raise
+      end
+
+      # Create a repository based on a rugged fixture repo.
+      def self.from_rugged(name, *args)
+        path = Dir.mktmpdir("rugged-#{name}")
+
+        FileUtils.cp_r(File.join(TestCase::TEST_DIR, "fixtures", name, "."), path)
+
+        prepare(path)
+
+        with_cleanup(Rugged::Repository.new(path, *args), path)
+      rescue
+        FileUtils.remove_entry_secure(path)
+        raise
+      end
+
+      # Create a repository based on a libgit2 fixture repo.
+      def self.from_libgit2(name, *args)
+        path = Dir.mktmpdir("rugged-libgit2-#{name}")
+
+        FileUtils.cp_r(File.join(TestCase::LIBGIT2_FIXTURE_DIR, name, "."), path)
+
+        prepare(path)
+
+        with_cleanup(Rugged::Repository.new(path, *args), path)
+      rescue
+        FileUtils.remove_entry_secure(path)
+        raise
+      end
+
+      # Create a repository cloned from another Rugged::Repository instance.
+      def self.clone(repository)
+        path = Dir.mktmpdir("rugged")
+
+        `git clone --quiet -- #{repository.path} #{path}`
+
+        with_cleanup(Rugged::Repository.new(path), path)
+      rescue
+        FileUtils.remove_entry_secure(path)
+        raise
+      end
+
+      def self.prepare(path)
+        Dir.chdir(path) do
+          File.rename(".gitted", ".git") if File.exist?(".gitted")
+          File.rename("gitattributes", ".gitattributes") if File.exist?("gitattributes")
+          File.rename("gitignore", ".gitignore") if File.exist?("gitignore")
+        end
+      end
+
+      def self.finalize_cleanup(path)
+        proc { FileUtils.remove_entry_secure(path) }
+      end
+
+      def self.with_cleanup(repo, path)
+        ObjectSpace.define_finalizer(repo, finalize_cleanup(path))
+        repo
+      end
+    end
+
     TEST_DIR = File.dirname(File.expand_path(__FILE__))
     LIBGIT2_FIXTURE_DIR = File.expand_path("../../vendor/libgit2/tests/resources", __FILE__)
-
-    protected
-    def with_default_encoding(encoding, &block)
-      old_encoding = Encoding.default_internal
-
-      new_encoding = Encoding.find(encoding)
-      Encoding.default_internal = new_encoding
-
-      yield new_encoding
-
-      Encoding.default_internal = old_encoding
-    end
   end
 
-  class SandboxedTestCase < TestCase
-    def setup
-      super
-      @_sandbox_path = Dir.mktmpdir("rugged_sandbox")
-    end
-
-    def teardown
-      FileUtils.remove_entry_secure @_sandbox_path
-      super
-    end
-
-    def sandbox_fixture(repository)
-      FileUtils.cp_r(File.join(TestCase::LIBGIT2_FIXTURE_DIR, repository), @_sandbox_path)
-    end
-
-    # Fills the current sandbox folder with the files
-    # found in the given repository
-    def sandbox_init(repository)
-      sandbox_fixture(repository)
-
-      fixture_repo_path = File.join(@_sandbox_path, repository)
-      Dir.chdir(fixture_repo_path) do
-        File.rename(".gitted", ".git") if File.exist?(".gitted")
-        File.rename("gitattributes", ".gitattributes") if File.exist?("gitattributes")
-        File.rename("gitignore", ".gitignore") if File.exist?("gitignore")
-      end
-
-      Rugged::Repository.new(fixture_repo_path)
-    end
-
-    def sandbox_clone(repository, name)
-      Dir.chdir(@_sandbox_path) do
-        `git clone --quiet -- #{repository} #{name}`
-      end
-
-      Rugged::Repository.new(File.join(@_sandbox_path, name))
-    end
-  end
-
-  class OnlineTestCase < SandboxedTestCase
+  class OnlineTestCase < TestCase
     def reset_remote_repo
       remote_repo = Rugged::Repository.new(ENV['GITTEST_REMOTE_REPO_PATH'])
       remote_repo.references.each do |ref|
@@ -98,38 +116,30 @@ module Rugged
   #
   # This should be the same as the libgit2 fixture
   # setup in vendor/libgit2/tests/submodule/submodule_helpers.c
-  class SubmoduleTestCase < Rugged::SandboxedTestCase
-    def setup
-      super
-    end
-
+  class SubmoduleTestCase < Rugged::TestCase
     def setup_submodule
-      repository = sandbox_init('submod2')
-      sandbox_fixture('submod2_target')
+      repository = FixtureRepo.from_libgit2('submod2')
 
-      Dir.chdir(@_sandbox_path) do
+      rewrite_gitmodules(repository)
+
+      Dir.chdir(repository.workdir) do
         File.rename(
-          File.join('submod2_target', '.gitted'),
-          File.join('submod2_target', '.git')
-        )
-
-        rewrite_gitmodules(repository.workdir)
-
-        File.rename(
-          File.join('submod2', 'not-submodule', '.gitted'),
-          File.join('submod2', 'not-submodule', '.git')
+          File.join('not-submodule', '.gitted'),
+          File.join('not-submodule', '.git')
         )
 
         File.rename(
-          File.join('submod2', 'not', '.gitted'),
-          File.join('submod2', 'not', '.git')
+          File.join('not', '.gitted'),
+          File.join('not', '.git')
         )
       end
 
       repository
     end
 
-    def rewrite_gitmodules(workdir)
+    def rewrite_gitmodules(repo)
+      workdir = repo.workdir
+
       input_path = File.join(workdir, 'gitmodules')
       output_path = File.join(workdir, '.gitmodules')
       submodules = []
@@ -139,57 +149,31 @@ module Rugged
           input.each_line do |line|
             if %r{path = (?<submodule>.+$)} =~ line
               submodules << submodule.strip
-            # convert relative URLs in "url =" lines
-            elsif %r{url = (?<url>.+$)} =~ line
-              line = "url = #{File.expand_path(File.join(workdir, url))}\n"
+            elsif %r{url = \.\.\/(?<url>.+$)} =~ line
+              # Copy repositories pointed to by relative urls
+              # and replace the relative url by the absolute path to the
+              # copied repo.
+              path = Dir.mktmpdir(url)
+              FileUtils.cp_r(File.join(TestCase::LIBGIT2_FIXTURE_DIR, url, "."), path)
+              ObjectSpace.define_finalizer(repo, FixtureRepo.finalize_cleanup(path) )
+              line = "url = #{path}\n"
             end
             output.write(line)
           end
         end
-        FileUtils.remove_entry_secure(input_path)
+      end
 
-        # rename .gitted -> .git in submodule dirs
-        submodules.each do |submodule|
-          submodule_path = File.join(workdir, submodule)
-          if File.exist?(File.join(submodule_path, '.gitted'))
-            Dir.chdir(submodule_path) do
-              File.rename('.gitted', '.git')
-            end
+      FileUtils.remove_entry_secure(input_path)
+
+      # rename .gitted -> .git in submodule dirs
+      submodules.each do |submodule|
+        submodule_path = File.join(workdir, submodule)
+        if File.exist?(File.join(submodule_path, '.gitted'))
+          Dir.chdir(submodule_path) do
+            File.rename('.gitted', '.git')
           end
         end
       end
-    end
-  end
-
-  module RepositoryAccess
-    def setup
-      @path = File.dirname(__FILE__) + '/fixtures/testrepo.git/'
-      @repo = Rugged::Repository.new(@path)
-    end
-  end
-
-  module TempRepositoryAccess
-    def setup
-      @path = temp_repo("testrepo.git")
-      @repo = Rugged::Repository.new(@path)
-    end
-
-    def teardown
-      @repo.close
-      GC.start
-      destroy_temp_repo(@path)
-    end
-
-    protected
-    def temp_repo(repo)
-      dir = Dir.mktmpdir 'dir'
-      repo_dir = File.join(TestCase::TEST_DIR, (File.join('fixtures', repo, '.')))
-      `git clone --quiet -- #{repo_dir} #{dir}`
-      dir
-    end
-
-    def destroy_temp_repo(path)
-      FileUtils.remove_entry_secure(path)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -100,12 +100,15 @@ module Rugged
   end
 
   class OnlineTestCase < TestCase
-    def reset_remote_repo
-      remote_repo = Rugged::Repository.new(ENV['GITTEST_REMOTE_REPO_PATH'])
-      remote_repo.references.each do |ref|
-        remote_repo.references.delete(ref)
+    if ENV['GITTEST_REMOTE_REPO_PATH']
+      def before_setup
+        remote_repo = Rugged::Repository.new(ENV['GITTEST_REMOTE_REPO_PATH'])
+        remote_repo.references.each do |ref|
+          remote_repo.references.delete(ref)
+        end
+
+        super
       end
-      remote_repo.close
     end
 
     def self.ssh_creds?

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -1,7 +1,11 @@
 require "test_helper"
 
 class TreeTest < Rugged::TestCase
-  include Rugged::RepositoryAccess
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+    @oid = "c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b"
+    @tree = @repo.lookup(@oid)
+  end
 
   def test_lookup_raises_error_if_object_type_does_not_match
     assert_raises Rugged::InvalidError do
@@ -35,12 +39,6 @@ class TreeTest < Rugged::TestCase
       # tag
       subclass.lookup(@repo, "0c37a5391bbff43c37f0d0371823a5509eed5b1d")
     end
-  end
-
-  def setup
-    super
-    @oid = "c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b"
-    @tree = @repo.lookup(@oid)
   end
 
   def test_read_tree_data
@@ -114,7 +112,10 @@ class TreeTest < Rugged::TestCase
 end
 
 class TreeWriteTest < Rugged::TestCase
-  include Rugged::TempRepositoryAccess
+  def setup
+    @source_repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo = FixtureRepo.clone(@source_repo)
+  end
 
   def test_write_tree_data
     entry = {:type => :blob,

--- a/test/walker_test.rb
+++ b/test/walker_test.rb
@@ -2,10 +2,8 @@ require "test_helper"
 require 'base64'
 
 class WalkerTest < Rugged::TestCase
-  include Rugged::RepositoryAccess
-
   def setup
-    super
+    @repo = FixtureRepo.from_rugged("testrepo.git")
     @walker = Rugged::Walker.new(@repo)
   end
 
@@ -150,9 +148,9 @@ end
 # testrepo (the non-bare repo) is the one with non-linear history,
 # which we need in order to make sure that we are activating the
 # first-parent simplification
-class WalkerTest2 < Rugged::SandboxedTestCase
+class WalkerTest2 < Rugged::TestCase
   def test_simplify_first_parent
-    repo = sandbox_init("testrepo")
+    repo = FixtureRepo.from_libgit2("testrepo")
     walker = Rugged::Walker.new(repo)
     walker.push("099fabac3a9ea935598528c27f866e34089c2eff")
     walker.simplify_first_parent


### PR DESCRIPTION
Fixture Management in Rugged has gone a bit out of hand. There's multiple different ways how fixtures are handled and managed, and it's not obvious when to use what.

* `Rugged::RepositoryAccess`: Including this module opens the bare repository at `test/fixtures/testrepo.git` and assigns it to `@repo`. Any modification to `@repo` will cause other test cases to fail, so this is only used for test cases that are read-only.
* `Rugged::TempRepositoryAccess`: This creates a clone of the repository at `test/fixtures/testrepo.git` and assigns it to `@repo`. This is used by test cases that modify the repo or that need a repo with a workdir.
* `Rugged::SandboxedTestCase`: This is a test class that provides the methods `sandbox_init` and `sandbox_clone`. `sandbox_init` copies test fixtures from libgit2 and returns a `Repository` for this copy, while `sandbox_clone` creates a clone for a repository that was previously copied via `sandbox_init`.
* `Rugged::SubmoduleTestCase`: This inherits from `Rugged::SandboxedTestCase` and provides another method to initialize a repository containing submodules.

---

This Pull Request tries to normalize and simplify the fixture repo handling. It replaces all the existing methods of creating test repositories with a single module containing a bunch of module methods:

* `FixtureRepo.empty`: Returns a new, empty repository.
* `FixtureRepo.from_rugged`: Returns a copy of a repository from the set of fixtures included in rugged.
* `FixtureRepo.from_libgit2`: Returns a copy of a repository from the set of fixtures included in libgit2.
* `FixtureRepo.clone`: Returns a clone of a `Rugged::Repository` instance.

All these methods operate on copies that are stored in temporary directories and that are cleaned up automatically through finalizers on the respective `Rugged::Repository` instances. This greatly simplifies test setup and teardown basically happens in a fully automated fashion.

---

TODO:

* [x] Fold `Rugged::SubmoduleTestCase` functionality into the methods provided by `FixtureRepo`.
* [x] ~~Check whether test cases fully pass on windows.~~ I couldn't get the latest rugged versions to compile and run on Windows.