### PR TITLE
test: make sure to set core.abbrev to 7

### DIFF
--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class TestCommit < Rugged::TestCase
   def setup
     @repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo.config['core.abbrev'] = 7
   end
 
   def test_lookup_raises_error_if_object_type_does_not_match
@@ -179,6 +180,7 @@ class CommitWriteTest < Rugged::TestCase
   def setup
     @source_repo = FixtureRepo.from_rugged("testrepo.git")
     @repo = FixtureRepo.clone(@source_repo)
+    @repo.config['core.abbrev'] = 7
   end
 
   def test_write_commit_with_time
@@ -266,6 +268,7 @@ end
 class CommitToMboxTest < Rugged::TestCase
   def setup
     @repo = FixtureRepo.from_libgit2 "diff_format_email"
+    @repo.config['core.abbrev'] = 7
   end
 
   def test_format_to_mbox

--- a/test/patch_test.rb
+++ b/test/patch_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class PatchTest < Rugged::TestCase
   def test_to_s
     repo = FixtureRepo.from_libgit2("diff")
+    repo.config['core.abbrev'] = 7
 
     a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
     b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")


### PR DESCRIPTION
our tests expect commit abbreviations to be done
with 7 characters, so instead of assuming current
machine doesn't have a global ~/.gitconfig, let's
make sure to set repository's core.abbrev to 7
on test runs.

Signed-off-by: Felipe Balbi <balbif@gmail.com>