### PR TITLE
Releases and pre-releases via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
-# Travis-CI Build for rugged
-# see travis-ci.org for details
-
 language: ruby
 
 os:
   - linux
   - osx
 
-# Ruby versions to test against
 rvm:
   - 1.9.3
   - 2.0.0
@@ -36,3 +32,24 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./vendor/libgit2/script/install-deps-osx.sh; fi
 
 script: script/travisbuild
+
+before_deploy:
+  - echo "module Rugged" > lib/rugged/version.rb
+  - if [ ! -z "$TRAVIS_TAG" ]; then
+  -   echo "  Version = VERSION = \"$(echo "$TRAVIS_TAG" | tail -c +2)\"" >> lib/rugged/version.rb
+  - else
+  -   echo "  Version = VERSION = \"$(git describe --tags --first-parent | tail -c +2 | tr '-' '.').pre\"" >> lib/rugged/version.rb
+  - fi;
+  - echo "end" >> lib/rugged/version.rb
+
+deploy:
+  provider: rubygems
+  api_key:
+    secure: ffCPQ8RQ+0GTAeHmBUCBMKa2K0aegFd++BQ9m8kNSd2pC/PtWtrqeiG6ZkcEsaN/CbiJrNsetibqMq44IL+r5Eq2NyQC869VfOb0KRExI2ovVfan0NoE1U+pyFOwMy7V5OG6EZ1rCkFazJdEHiPbjO0xoEq4jZuygEIAhQJGvJo=
+  gem: rugged
+  on:
+    condition: "$TRAVIS_OS_NAME = linux"
+    branch: master
+    tags: true
+    repo: libgit2/rugged
+    ruby: 2.2.2

--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -1,3 +1,4 @@
 module Rugged
-  Version = VERSION = '0.23.1'
+  # This file is automatically overwritten during a deployment from Travis.
+  Version = VERSION = "#{`git describe --tags --first-parent | tail -c +2 | tr '-' '.'`.strip}.pre" rescue "0.0.0.dev"
 end


### PR DESCRIPTION
This enables automatic releases and pre-releases via Travis.

### Releases

Releases get cut when a new tag gets pushed to the repo and the build succeeds for the Ruby `2.2.2` build on travis. I'm thinking about automatically generating the `lib/rugged/version.rb` file based on the tag name, which would basically allow us to do release without having to bump this version identifier for each release.

### Pre-releases

Each commit that happens on the master branch will trigger the push of a pre-release gem to rubygems if the build on Ruby `2.2.2` passses. These gems will be versioned as `$version.$build_number.pre`. Using the build number is not perfect as it's not per-actual-version, but it's an increasing sequence, so if two pre-releases share the same "actual" release version, the one with the higher build number will be never, and gem version specifiers in `Gemfiles` or `*.gemspec` files will be handled correctly.

//cc @vmg You like?