### PR TITLE
Do not automatically tag releases from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,24 +33,3 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./vendor/libgit2/script/install-deps-osx.sh; fi
 
 script: script/travisbuild
-
-before_deploy: |
-  echo "module Rugged" > lib/rugged/version.rb
-  if [ ! -z "$TRAVIS_TAG" ]; then
-   echo "  Version = VERSION = \"$(echo "$TRAVIS_TAG" | tail -c +2)\"" >> lib/rugged/version.rb
-  else
-   echo "  Version = VERSION = \"$(git describe --tags --first-parent | tail -c +2 | tr '-' '.').pre\"" >> lib/rugged/version.rb
-  fi;
-  echo "end" >> lib/rugged/version.rb
-
-deploy:
-  provider: rubygems
-  api_key:
-    secure: ffCPQ8RQ+0GTAeHmBUCBMKa2K0aegFd++BQ9m8kNSd2pC/PtWtrqeiG6ZkcEsaN/CbiJrNsetibqMq44IL+r5Eq2NyQC869VfOb0KRExI2ovVfan0NoE1U+pyFOwMy7V5OG6EZ1rCkFazJdEHiPbjO0xoEq4jZuygEIAhQJGvJo=
-  gem: rugged
-  on:
-    condition:
-      - '"$TRAVIS_OS_NAME" = "linux"'
-      - '"$TRAVIS_TAG" != "" || "$TRAVIS_BRANCH" = "master"'
-    repo: libgit2/rugged
-    ruby: 2.2.2

--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -1,4 +1,3 @@
 module Rugged
-  # This file is automatically overwritten during a deployment from Travis.
-  Version = VERSION = "#{`git describe --tags --first-parent | tail -c +2 | tr '-' '.'`.strip}.pre" rescue "0.0.0.dev"
+  Version = VERSION = '0.23.1'
 end


### PR DESCRIPTION
@arthurschreiber: I gotta roll this back because it's breaking GitHub's internal vendoring/packaging scripts. :(((((((

We'll have to continue tagging releases manually while I figure this out.