### PR TITLE
Add Rugged.valid_full_oid? helper method

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -111,6 +111,28 @@ static VALUE rb_git_features(VALUE self)
 
 /*
  *  call-seq:
+ *    Rugged.valid_full_oid?(oid) -> true or false
+ *
+ *  Checks to see if a string contains a full 40-character sha1.
+ *
+ *    Rugged.valid_full_oid?('d8786bfc97485e8d7b19b21fb88c8ef1f199fc3f')
+ *    #=> true
+ */
+static VALUE rb_git_valid_full_oid(VALUE self, VALUE hex)
+{
+	git_oid oid;
+
+	Check_Type(hex, T_STRING);
+	int errorcode = git_oid_fromstr(&oid, StringValueCStr(hex));
+	if (errorcode < 0) {
+		return Qfalse;
+	} else {
+		return Qtrue;
+	}
+}
+
+/*
+ *  call-seq:
  *    Rugged.hex_to_raw(oid) -> raw_buffer
  *
  *  Turn a string of 40 hexadecimal characters into the buffer of
@@ -421,6 +443,7 @@ void Init_rugged(void)
 
 	rb_define_module_function(rb_mRugged, "libgit2_version", rb_git_libgit2_version, 0);
 	rb_define_module_function(rb_mRugged, "features", rb_git_features, 0);
+	rb_define_module_function(rb_mRugged, "valid_full_oid?", rb_git_valid_full_oid, 1);
 	rb_define_module_function(rb_mRugged, "hex_to_raw", rb_git_hex_to_raw, 1);
 	rb_define_module_function(rb_mRugged, "raw_to_hex", rb_git_raw_to_hex, 1);
 	rb_define_module_function(rb_mRugged, "minimize_oid", rb_git_minimize_oid, -1);

--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -121,9 +121,10 @@ static VALUE rb_git_features(VALUE self)
 static VALUE rb_git_valid_full_oid(VALUE self, VALUE hex)
 {
 	git_oid oid;
+	int errorcode;
 
 	Check_Type(hex, T_STRING);
-	int errorcode = git_oid_fromstr(&oid, StringValueCStr(hex));
+	errorcode = git_oid_fromstr(&oid, StringValueCStr(hex));
 	if (errorcode < 0) {
 		return Qfalse;
 	} else {

--- a/test/lib_test.rb
+++ b/test/lib_test.rb
@@ -44,6 +44,12 @@ class RuggedTest < Rugged::TestCase
     assert features.is_a? Array
   end
 
+  def test_valid_full_oid
+    assert Rugged.valid_full_oid?("ce08fe4884650f067bd5703b6a59a8b3b3c99a09")
+    refute Rugged.valid_full_oid?("nope")
+    refute Rugged.valid_full_oid?("ce08fe4884650f067bd5703b6a59a8b3b3c99a0")
+  end
+
   def test_hex_to_raw_oid
     raw = Rugged::hex_to_raw("ce08fe4884650f067bd5703b6a59a8b3b3c99a09")
     b64raw = Base64.encode64(raw).strip


### PR DESCRIPTION
Previously I've been using regex to check the validity of a string as a full 40-character sha1, but decided to benchmark that against the `Rugged.hex_to_raw` method and found it to be ~6x faster. Only bummer was that `hex_to_raw` will raise if the input string was invalid, and in that case ended up only being about 1.5x faster.

So this extracts just the validity check and returns a boolean value. Meaning we can skip the raise/rescue slowdown as well as creating the output string that `hex_to_raw` would have made.