### PR TITLE
Treebuilder remove return

### DIFF
--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -815,8 +815,11 @@ static VALUE rb_git_treebuilder_remove(VALUE self, VALUE path)
 	Check_Type(path, T_STRING);
 
 	error = git_treebuilder_remove(builder, StringValueCStr(path));
-	if (error == GIT_ENOTFOUND)
+	if (error == GIT_ENOTFOUND) {
 		return Qfalse;
+	} else if (error == GIT_ERROR && giterr_last()->klass == GITERR_TREE) {
+		return Qfalse;
+	}
 
 	rugged_exception_check(error);
 	return Qtrue;

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -130,3 +130,17 @@ class TreeWriteTest < Rugged::TestCase
     assert_equal 38, obj.read_raw.len
   end
 end
+
+class TreeUpdateTest < Rugged::TestCase
+  def setup
+    @source_repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo = FixtureRepo.clone(@source_repo)
+  end
+
+  def test_treebuilder_remove
+    builder = Rugged::Tree::Builder.new(@repo, @repo.head.target.tree)
+    assert_equal builder.remove("new.txt"), true
+    assert_equal builder.remove("nonexistent file"), false
+  end
+
+end


### PR DESCRIPTION
The docs here say that with a Rugged::Tree::Builder object the remove method should return false if the file does not exist, but right now it'll actually raise a Rugged::TreeError.

Here's a test case and small fix for that.
