### PR TITLE
Ensure DB backends haven't already been freed

### DIFF
--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -216,8 +216,8 @@ static void rugged_repo_new_with_backend(git_repository **repo, VALUE rb_path, V
 
 	error = git_odb_add_backend(odb, odb_backend, 1);
 	if (error) {
-		if (odb_backend->free) odb_backend->free(odb_backend);
-		else git__free(odb_backend);
+		assert(odb_backend->free);
+		odb_backend->free(odb_backend);
 		goto cleanup;
 	}
 
@@ -229,8 +229,8 @@ static void rugged_repo_new_with_backend(git_repository **repo, VALUE rb_path, V
 
 	error = backend->refdb_backend(&refdb_backend, backend, path);
 	if (error) {
-		if (refdb_backend->free) odb_backend->free(odb_backend);
-		else git__free(refdb_backend);
+		assert(refdb_backend->free);
+		refdb_backend->free(refdb_backend);
 		goto cleanup;
 	}
 

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -189,8 +189,6 @@ static void load_alternates(git_repository *repo, VALUE rb_alternates)
 static void rugged_repo_new_with_backend(git_repository **repo, VALUE rb_path, VALUE rb_backend)
 {
 	char *path;
-	int odb_associated = 0;
-	int refdb_associated = 0;
 
 	git_odb *odb = NULL;
 	git_odb_backend *odb_backend = NULL;
@@ -217,10 +215,11 @@ static void rugged_repo_new_with_backend(git_repository **repo, VALUE rb_path, V
 	if (error) goto cleanup;
 
 	error = git_odb_add_backend(odb, odb_backend, 1);
-	if (error)
-	    goto cleanup;
-	else
-	    odb_associated = 1;
+	if (error) {
+		if (odb_backend->free) odb_backend->free(odb_backend);
+		else git__free(odb_backend);
+		goto cleanup;
+	}
 
 	error = git_repository_wrap_odb(repo, odb);
 	if (error) goto cleanup;
@@ -229,10 +228,11 @@ static void rugged_repo_new_with_backend(git_repository **repo, VALUE rb_path, V
 	if (error) goto cleanup;
 
 	error = backend->refdb_backend(&refdb_backend, backend, path);
-	if (error)
-	   goto cleanup;
-	else
-	    refdb_associated = 1;
+	if (error) {
+		if (refdb_backend->free) odb_backend->free(odb_backend);
+		else git__free(refdb_backend);
+		goto cleanup;
+	}
 
 	error = git_refdb_set_backend(refdb, refdb_backend);
 	if (error) goto cleanup;
@@ -255,9 +255,6 @@ cleanup:
 	git_repository_free(*repo);
 	git_odb_free(odb);
 	git_refdb_free(refdb);
-
-	if (odb_backend != NULL && !odb_associated && odb_backend->free) odb_backend->free(odb_backend);
-	if (refdb_backend != NULL && !refdb_associated && refdb_backend->free) refdb_backend->free(refdb_backend);
 
 	rugged_exception_check(error);
 }


### PR DESCRIPTION
When DB backends are successfully attached to the DB instacnes they
get freed along with the DB so we don't have to. Also, the free method
on the backends is optional so we shouldn't assume it is present.

Fixes: #524 