### PR TITLE
Adds Rugged::Remote#fetch(prune:)

### DIFF
--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -555,8 +555,7 @@ static VALUE rb_git_remote_fetch(int argc, VALUE *argv, VALUE self)
 			log_message = StringValueCStr(rb_val);
 
 		VALUE rb_prune_type = rb_hash_aref(rb_options, CSTR2SYM("prune"));
-		if (!NIL_P(rb_prune_type))
-			opts.prune = parse_prune_type(rb_prune_type);
+		opts.prune = parse_prune_type(rb_prune_type);
 	}
 
 	error = git_remote_fetch(remote, &refspecs, &opts, log_message);
@@ -641,49 +640,6 @@ static VALUE rb_git_remote_push(int argc, VALUE *argv, VALUE self)
 	return payload.result;
 }
 
-/*
- *  call-seq:
- *    remote.prune(options = {}) -> nil
- *
- *  Prune tracking refs that are no longer present on remote
- *
- *  Returns nil
- *
- *  The following options can be passed in the +options+ Hash:
- *
- *  :credentials ::
- *    The credentials to use for the fetch operation. Can be either an instance of one
- *    of the Rugged::Credentials types, or a proc returning one of the former.
- *    The proc will be called with the +url+, the +username+ from the url (if applicable) and
- *    a list of applicable credential types.
- *
- *  Example:
- *
- *    remote = Rugged::Remote.lookup(@repo, 'origin')
- *    remote.prune()
- *
- */
-static VALUE rb_git_remote_prune(int argc, VALUE *argv, VALUE self)
-{
-	VALUE rb_options;
-	git_remote *remote;
-	git_fetch_options opts = GIT_FETCH_OPTIONS_INIT;
-	struct rugged_remote_cb_payload payload = { Qnil, Qnil, Qnil, Qnil, Qnil, Qnil, 0 };
-	int error;
-
-	Data_Get_Struct(self, git_remote, remote);
-	rb_scan_args(argc, argv, ":", &rb_options);
-	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &opts.callbacks, &payload);
-
-	if ((error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &opts.callbacks)) ||
-			(error = git_remote_prune(remote, &opts.callbacks)))
-	git_remote_disconnect(remote);
-
-	rugged_exception_check(error);
-
-	return Qnil;
-}
-
 void Init_rugged_remote(void)
 {
 	rb_cRuggedRemote = rb_define_class_under(rb_mRugged, "Remote", rb_cObject);
@@ -698,5 +654,4 @@ void Init_rugged_remote(void)
 	rb_define_method(rb_cRuggedRemote, "check_connection", rb_git_remote_check_connection, -1);
 	rb_define_method(rb_cRuggedRemote, "fetch", rb_git_remote_fetch, -1);
 	rb_define_method(rb_cRuggedRemote, "push", rb_git_remote_push, -1);
-	rb_define_method(rb_cRuggedRemote, "prune", rb_git_remote_prune, -1);
 }

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -186,12 +186,6 @@ class RemotePruneTest < Rugged::TestCase
     @remote_repo.references.delete("refs/heads/unit_test")
   end
 
-  def test_remote_prune
-    assert_equal "8496071c1b46c854b31185ea97743be6a8774479", @repo.ref("refs/remotes/origin/unit_test").target_id
-    assert_equal nil, @remote.prune
-    assert_nil @repo.ref("refs/remotes/origin/unit_test")
-  end
-
   def test_fetch_prune_is_forced
     assert_equal "8496071c1b46c854b31185ea97743be6a8774479", @repo.ref("refs/remotes/origin/unit_test").target_id
     @remote.fetch(prune: true)


### PR DESCRIPTION
I am using Rugged quite a bit on a project and needed a method to prune the remotes. I didn't see a way to do it in the documentation so I thought I would give it a shot myself. Here is the result.  My C-fu has long since atrophied and I have never build a C-extension before so feel free to be harsh in your review/feedback.

It also looks like it is possible to pass a `prune` option to `git_remote_fetch` but I couldn't figure out how to do it yet.