### PR TITLE
WIP: Better Backend Support

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -482,6 +482,14 @@ void Init_rugged(void)
 	Init_rugged_cred();
 	Init_rugged_backend();
 
+	Init_rugged_refdb();
+	Init_rugged_refdb_backend();
+	Init_rugged_refdb_backend_fs();
+
+	Init_rugged_odb();
+	Init_rugged_odb_backend();
+	Init_rugged_odb_backend_loose();
+
 	/*
 	 * Sort the repository contents in no particular ordering;
 	 * this sorting is arbitrary, implementation-specific

--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -484,6 +484,7 @@ void Init_rugged(void)
 
 	Init_rugged_refdb();
 	Init_rugged_refdb_backend();
+	Init_rugged_refdb_backend_custom();
 	Init_rugged_refdb_backend_fs();
 
 	Init_rugged_odb();

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -40,6 +40,8 @@
 #include <assert.h>
 #include <git2.h>
 #include <git2/odb_backend.h>
+#include <git2/sys/refdb_backend.h>
+#include <git2/sys/odb_backend.h>
 
 #define rb_str_new_utf8(str) rb_enc_str_new(str, strlen(str), rb_utf8_encoding())
 #define CSTR2SYM(s) (ID2SYM(rb_intern((s))))
@@ -75,6 +77,12 @@ void Init_rugged_diff_line(void);
 void Init_rugged_blame(void);
 void Init_rugged_cred(void);
 void Init_rugged_backend(void);
+void Init_rugged_refdb(void);
+void Init_rugged_refdb_backend(void);
+void Init_rugged_refdb_backend_fs(void);
+void Init_rugged_odb(void);
+void Init_rugged_odb_backend(void);
+void Init_rugged_odb_backend_loose(void);
 
 VALUE rb_git_object_init(git_otype type, int argc, VALUE *argv, VALUE self);
 

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -79,6 +79,7 @@ void Init_rugged_cred(void);
 void Init_rugged_backend(void);
 void Init_rugged_refdb(void);
 void Init_rugged_refdb_backend(void);
+void Init_rugged_refdb_backend_custom(void);
 void Init_rugged_refdb_backend_fs(void);
 void Init_rugged_odb(void);
 void Init_rugged_odb_backend(void);

--- a/ext/rugged/rugged_odb.c
+++ b/ext/rugged/rugged_odb.c
@@ -1,0 +1,130 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 GitHub, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "rugged.h"
+
+extern VALUE rb_mRugged;
+VALUE rb_cRuggedOdb;
+
+/*
+ *  call-seq:
+ *    Odb.new() -> odb
+ *
+ *  Create a new object database with no backend.
+ *
+ *  Before the object database can be used, backends
+ *  needs to be assigned using `Odb#add_backend`.
+ */
+static VALUE rb_git_odb_new(VALUE klass) {
+  git_odb *odb;
+  rugged_exception_check(git_odb_new(&odb));
+  return Data_Wrap_Struct(klass, NULL, git_odb_free, odb);
+}
+
+/*
+ *  call-seq:
+ *    Odb.open(dir) -> odb
+ *
+ *  Create a new object database with the default filesystem
+ *  backends.
+ *
+ *  `dir` needs to boint to the objects folder to be used
+ *  by the filesystem backends.
+ */
+ static VALUE rb_git_odb_open(VALUE klass, VALUE rb_path) {
+   git_odb *odb;
+
+   rugged_exception_check(git_odb_open(&odb, StringValueCStr(rb_path)));
+
+   return Data_Wrap_Struct(klass, NULL, git_odb_free, odb);
+ }
+
+/*
+ *  call-seq:
+ *    odb.add_backend(backend) -> odb
+ *
+ *  Set the backend to be used by the reference db.
+ *
+ *  A backend can only be assigned once, and becomes unusable from that
+ *  point on. Trying to assign a backend a second time will raise an
+ *  exception.
+ */
+static VALUE rb_git_odb_add_backend(VALUE self, VALUE rb_backend, VALUE rb_priority)
+{
+  git_odb *odb;
+  git_odb_backend *backend;
+
+  Data_Get_Struct(self, git_odb, odb);
+  Data_Get_Struct(rb_backend, git_odb_backend, backend);
+
+  if (!backend)
+    rb_exc_raise(rb_exc_new_cstr(rb_eRuntimeError, "Can not reuse odb backend instances"));
+
+  rugged_exception_check(git_odb_add_backend(odb, backend, NUM2INT(rb_priority)));
+
+  // libgit2 has taken ownership of the backend, so we should make sure
+  // we don't try to free it.
+  ((struct RData *)rb_backend)->data = NULL;
+
+  return self;
+}
+
+static int cb_odb__each(const git_oid *id, void *data)
+{
+  char out[40];
+	struct rugged_cb_payload *payload = data;
+
+  git_oid_fmt(out, id);
+  rb_protect(rb_yield, rb_str_new(out, 40), &payload->exception);
+
+  return payload->exception ? GIT_ERROR : GIT_OK;
+}
+
+static VALUE rb_git_odb_each(VALUE self)
+{
+  git_odb *odb;
+  int error;
+  struct rugged_cb_payload payload = { self, 0 };
+
+  Data_Get_Struct(self, git_odb, odb);
+
+  error = git_odb_foreach(odb, &cb_odb__each, &payload);
+
+	if (payload.exception)
+		rb_jump_tag(payload.exception);
+	rugged_exception_check(error);
+
+  return Qnil;
+}
+
+void Init_rugged_odb(void)
+{
+	rb_cRuggedOdb = rb_define_class_under(rb_mRugged, "Odb", rb_cObject);
+
+  rb_define_singleton_method(rb_cRuggedOdb, "new", rb_git_odb_new, 0);
+	rb_define_singleton_method(rb_cRuggedOdb, "open", rb_git_odb_open, 1);
+
+	rb_define_method(rb_cRuggedOdb, "add_backend", rb_git_odb_add_backend, 2);
+  rb_define_method(rb_cRuggedOdb, "each", rb_git_odb_each, 0);
+}

--- a/ext/rugged/rugged_odb_backend.c
+++ b/ext/rugged/rugged_odb_backend.c
@@ -1,0 +1,33 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 GitHub, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "rugged.h"
+
+extern VALUE rb_cRuggedOdb;
+VALUE rb_cRuggedOdbBackend;
+
+void Init_rugged_odb_backend(void)
+{
+	rb_cRuggedOdbBackend = rb_define_class_under(rb_cRuggedOdb, "Backend", rb_cObject);
+}

--- a/ext/rugged/rugged_odb_backend_loose.c
+++ b/ext/rugged/rugged_odb_backend_loose.c
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 GitHub, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "rugged.h"
+
+extern VALUE rb_cRuggedOdbBackend;
+VALUE rb_cRuggedOdbBackendLoose;
+
+void rb_git_odb_backend__free(git_odb_backend *backend)
+{
+  if (backend) backend->free(backend);
+}
+
+static VALUE rb_git_odb_backend_loose_new(VALUE self, VALUE rb_path, VALUE rb_compression_level, VALUE rb_do_fsync, VALUE rb_dir_mode, VALUE rb_file_mode)
+{
+  git_odb_backend *backend;
+
+  rugged_exception_check(git_odb_backend_loose(&backend, StringValueCStr(rb_path), NUM2INT(rb_compression_level), NUM2INT(rb_do_fsync), NUM2INT(rb_dir_mode), NUM2INT(rb_file_mode)));
+
+  return Data_Wrap_Struct(self, NULL, rb_git_odb_backend__free, backend);
+}
+
+void Init_rugged_odb_backend_loose(void)
+{
+	rb_cRuggedOdbBackendLoose = rb_define_class_under(rb_cRuggedOdbBackend, "Loose", rb_cRuggedOdbBackend);
+
+  rb_define_singleton_method(rb_cRuggedOdbBackendLoose, "new", rb_git_odb_backend_loose_new, 5);
+}

--- a/ext/rugged/rugged_refdb.c
+++ b/ext/rugged/rugged_refdb.c
@@ -37,14 +37,14 @@ VALUE rb_cRuggedRefdb;
  *  needs to be assigned using `Refdb#backend=`.
  */
 static VALUE rb_git_refdb_new(VALUE klass, VALUE rb_repo) {
-  git_refdb *refdb;
-  git_repository *repo;
+	git_refdb *refdb;
+	git_repository *repo;
 
-  Data_Get_Struct(rb_repo, git_repository, repo);
+	Data_Get_Struct(rb_repo, git_repository, repo);
 
-  rugged_exception_check(git_refdb_new(&refdb, repo));
+	rugged_exception_check(git_refdb_new(&refdb, repo));
 
-  return Data_Wrap_Struct(klass, NULL, git_refdb_free, refdb);
+	return Data_Wrap_Struct(klass, NULL, git_refdb_free, refdb);
 }
 
 /*
@@ -55,14 +55,14 @@ static VALUE rb_git_refdb_new(VALUE klass, VALUE rb_repo) {
  *  backend.
  */
  static VALUE rb_git_refdb_open(VALUE klass, VALUE rb_repo) {
-   git_refdb *refdb;
-   git_repository *repo;
+	 git_refdb *refdb;
+	 git_repository *repo;
 
-   Data_Get_Struct(rb_repo, git_repository, repo);
+	 Data_Get_Struct(rb_repo, git_repository, repo);
 
-   rugged_exception_check(git_refdb_open(&refdb, repo));
+	 rugged_exception_check(git_refdb_open(&refdb, repo));
 
-   return Data_Wrap_Struct(klass, NULL, git_refdb_free, refdb);
+	 return Data_Wrap_Struct(klass, NULL, git_refdb_free, refdb);
  }
 
 /*
@@ -77,30 +77,46 @@ static VALUE rb_git_refdb_new(VALUE klass, VALUE rb_repo) {
  */
 static VALUE rb_git_refdb_set_backend(VALUE self, VALUE rb_backend)
 {
-  git_refdb *refdb;
-  git_refdb_backend *backend;
+	git_refdb *refdb;
+	git_refdb_backend *backend;
 
-  Data_Get_Struct(self, git_refdb, refdb);
-  Data_Get_Struct(rb_backend, git_refdb_backend, backend);
+	Data_Get_Struct(self, git_refdb, refdb);
+	Data_Get_Struct(rb_backend, git_refdb_backend, backend);
 
-  if (!backend)
-    rb_exc_raise(rb_exc_new_cstr(rb_eRuntimeError, "Can not reuse refdb backend instances"));
+	if (!backend)
+		rb_exc_raise(rb_exc_new_cstr(rb_eRuntimeError, "Can not reuse refdb backend instances"));
 
-  rugged_exception_check(git_refdb_set_backend(refdb, backend));
+	rugged_exception_check(git_refdb_set_backend(refdb, backend));
 
-  // libgit2 has taken ownership of the backend, so we should make sure
-  // we don't try to free it.
-  ((struct RData *)rb_backend)->data = NULL;
+	// libgit2 has taken ownership of the backend, so we should make sure
+	// we don't try to free it.
+	((struct RData *)rb_backend)->data = NULL;
 
-  return Qnil;
+	return Qnil;
+}
+
+/*
+ *  call-seq:
+ *    refdb.compress -> nil
+ */
+static VALUE rb_git_refdb_compress(VALUE self)
+{
+	git_refdb *refdb;
+
+	Data_Get_Struct(self, git_refdb, refdb);
+
+	rugged_exception_check(git_refdb_compress(refdb));
+
+	return Qnil;
 }
 
 void Init_rugged_refdb(void)
 {
 	rb_cRuggedRefdb = rb_define_class_under(rb_mRugged, "Refdb", rb_cObject);
 
-  rb_define_singleton_method(rb_cRuggedRefdb, "new", rb_git_refdb_new, 1);
+	rb_define_singleton_method(rb_cRuggedRefdb, "new", rb_git_refdb_new, 1);
 	rb_define_singleton_method(rb_cRuggedRefdb, "open", rb_git_refdb_open, 1);
 
 	rb_define_method(rb_cRuggedRefdb, "backend=", rb_git_refdb_set_backend, 1);
+	rb_define_method(rb_cRuggedRefdb, "compress", rb_git_refdb_compress, 0);
 }

--- a/ext/rugged/rugged_refdb.c
+++ b/ext/rugged/rugged_refdb.c
@@ -1,0 +1,106 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 GitHub, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "rugged.h"
+
+extern VALUE rb_mRugged;
+VALUE rb_cRuggedRefdb;
+
+/*
+ *  call-seq:
+ *    Refdb.new(repository) -> refdb
+ *
+ *  Create a new reference database with no backends.
+ *
+ *  Before the reference database can be used, a backend
+ *  needs to be assigned using `Refdb#backend=`.
+ */
+static VALUE rb_git_refdb_new(VALUE klass, VALUE rb_repo) {
+  git_refdb *refdb;
+  git_repository *repo;
+
+  Data_Get_Struct(rb_repo, git_repository, repo);
+
+  rugged_exception_check(git_refdb_new(&refdb, repo));
+
+  return Data_Wrap_Struct(klass, NULL, git_refdb_free, refdb);
+}
+
+/*
+ *  call-seq:
+ *    Refdb.open(repository) -> refdb
+ *
+ *  Create a new reference database with the default filesystem
+ *  backend.
+ */
+ static VALUE rb_git_refdb_open(VALUE klass, VALUE rb_repo) {
+   git_refdb *refdb;
+   git_repository *repo;
+
+   Data_Get_Struct(rb_repo, git_repository, repo);
+
+   rugged_exception_check(git_refdb_open(&refdb, repo));
+
+   return Data_Wrap_Struct(klass, NULL, git_refdb_free, refdb);
+ }
+
+/*
+ *  call-seq:
+ *    refdb.backend = backend
+ *
+ *  Set the backend to be used by the reference db.
+ *
+ *  A backend can only be assigned once, and becomes unusable from that
+ *  point on. Trying to assign a backend a second time will raise an
+ *  exception.
+ */
+static VALUE rb_git_refdb_set_backend(VALUE self, VALUE rb_backend)
+{
+  git_refdb *refdb;
+  git_refdb_backend *backend;
+
+  Data_Get_Struct(self, git_refdb, refdb);
+  Data_Get_Struct(rb_backend, git_refdb_backend, backend);
+
+  if (!backend)
+    rb_exc_raise(rb_exc_new_cstr(rb_eRuntimeError, "Can not reuse refdb backend instances"));
+
+  rugged_exception_check(git_refdb_set_backend(refdb, backend));
+
+  // libgit2 has taken ownership of the backend, so we should make sure
+  // we don't try to free it.
+  ((struct RData *)rb_backend)->data = NULL;
+
+  return Qnil;
+}
+
+void Init_rugged_refdb(void)
+{
+	rb_cRuggedRefdb = rb_define_class_under(rb_mRugged, "Refdb", rb_cObject);
+
+  rb_define_singleton_method(rb_cRuggedRefdb, "new", rb_git_refdb_new, 1);
+	rb_define_singleton_method(rb_cRuggedRefdb, "open", rb_git_refdb_open, 1);
+
+	rb_define_method(rb_cRuggedRefdb, "backend=", rb_git_refdb_set_backend, 1);
+}

--- a/ext/rugged/rugged_refdb_backend.c
+++ b/ext/rugged/rugged_refdb_backend.c
@@ -1,0 +1,33 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 GitHub, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "rugged.h"
+
+extern VALUE rb_cRuggedRefdb;
+VALUE rb_cRuggedRefdbBackend;
+
+void Init_rugged_refdb_backend(void)
+{
+	rb_cRuggedRefdbBackend = rb_define_class_under(rb_cRuggedRefdb, "Backend", rb_cObject);
+}

--- a/ext/rugged/rugged_refdb_backend_custom.c
+++ b/ext/rugged/rugged_refdb_backend_custom.c
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 GitHub, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "rugged.h"
+
+extern VALUE rb_cRuggedRefdbBackend;
+VALUE rb_cRuggedRefdbBackendCustom;
+
+typedef struct {
+	git_refdb_backend parent;
+	VALUE self;
+} rugged_refdb_backend_custom;
+
+static int rugged_refdb_backend_custom__exists(
+	int *exists,
+	git_refdb_backend *_backend,
+	const char *ref_name)
+{
+	rugged_refdb_backend_custom *backend = (rugged_refdb_backend_custom *)_backend;
+
+	// TODO: Proper exception handling
+	*exists = RTEST(rb_funcall(backend->self, rb_intern("exists"), 1, rb_str_new2(ref_name)));
+
+	return GIT_OK;
+}
+
+static int rugged_refdb_backend_custom__compress(git_refdb_backend *_backend)
+{
+	rugged_refdb_backend_custom *backend = (rugged_refdb_backend_custom *)_backend;
+
+	// TODO: Proper exception handling
+	rb_funcall(backend->self, rb_intern("compress"), 0);
+
+	return GIT_OK;
+}
+
+static void rb_git_refdb_backend__free(git_refdb_backend *backend)
+{
+	if (backend) backend->free(backend);
+}
+
+static VALUE rb_git_refdb_backend_custom_new(VALUE self, VALUE rb_repo)
+{
+	rugged_refdb_backend_custom *backend;
+
+	backend = xcalloc(1, sizeof(rugged_refdb_backend_custom));
+
+	backend->parent.exists = &rugged_refdb_backend_custom__exists;
+	backend->parent.compress = &rugged_refdb_backend_custom__compress;
+	backend->parent.free = xfree;
+
+	backend->self = Data_Wrap_Struct(self, NULL, rb_git_refdb_backend__free, backend);
+	return backend->self;
+}
+
+void Init_rugged_refdb_backend_custom(void)
+{
+	rb_cRuggedRefdbBackendCustom = rb_define_class_under(rb_cRuggedRefdbBackend, "Custom", rb_cRuggedRefdbBackend);
+
+	rb_define_singleton_method(rb_cRuggedRefdbBackendCustom, "new", rb_git_refdb_backend_custom_new, 1);
+}

--- a/ext/rugged/rugged_refdb_backend_fs.c
+++ b/ext/rugged/rugged_refdb_backend_fs.c
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 GitHub, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "rugged.h"
+
+extern VALUE rb_cRuggedRefdbBackend;
+VALUE rb_cRuggedRefdbBackendFileSystem;
+
+void rb_git_refdb_backend__free(git_refdb_backend *backend)
+{
+  if (backend) backend->free(backend);
+}
+
+static VALUE rb_git_refdb_backend_fs_new(VALUE self, VALUE rb_repo)
+{
+  git_repository *repo;
+  git_refdb_backend *backend;
+
+  Data_Get_Struct(rb_repo, git_repository, repo);
+
+  rugged_exception_check(git_refdb_backend_fs(&backend, repo));
+
+  return Data_Wrap_Struct(self, NULL, rb_git_refdb_backend__free, backend);
+}
+
+void Init_rugged_refdb_backend_fs(void)
+{
+	rb_cRuggedRefdbBackendFileSystem = rb_define_class_under(rb_cRuggedRefdbBackend, "FileSystem", rb_cRuggedRefdbBackend);
+
+  rb_define_singleton_method(rb_cRuggedRefdbBackendFileSystem, "new", rb_git_refdb_backend_fs_new, 1);
+}

--- a/ext/rugged/rugged_refdb_backend_fs.c
+++ b/ext/rugged/rugged_refdb_backend_fs.c
@@ -29,24 +29,24 @@ VALUE rb_cRuggedRefdbBackendFileSystem;
 
 void rb_git_refdb_backend__free(git_refdb_backend *backend)
 {
-  if (backend) backend->free(backend);
+	if (backend) backend->free(backend);
 }
 
 static VALUE rb_git_refdb_backend_fs_new(VALUE self, VALUE rb_repo)
 {
-  git_repository *repo;
-  git_refdb_backend *backend;
+	git_repository *repo;
+	git_refdb_backend *backend;
 
-  Data_Get_Struct(rb_repo, git_repository, repo);
+	Data_Get_Struct(rb_repo, git_repository, repo);
 
-  rugged_exception_check(git_refdb_backend_fs(&backend, repo));
+	rugged_exception_check(git_refdb_backend_fs(&backend, repo));
 
-  return Data_Wrap_Struct(self, NULL, rb_git_refdb_backend__free, backend);
+	return Data_Wrap_Struct(self, NULL, rb_git_refdb_backend__free, backend);
 }
 
 void Init_rugged_refdb_backend_fs(void)
 {
 	rb_cRuggedRefdbBackendFileSystem = rb_define_class_under(rb_cRuggedRefdbBackend, "FileSystem", rb_cRuggedRefdbBackend);
 
-  rb_define_singleton_method(rb_cRuggedRefdbBackendFileSystem, "new", rb_git_refdb_backend_fs_new, 1);
+	rb_define_singleton_method(rb_cRuggedRefdbBackendFileSystem, "new", rb_git_refdb_backend_fs_new, 1);
 }

--- a/test/odb_test.rb
+++ b/test/odb_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class OdbTest < Rugged::TestCase
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
+
+  def test_new
+    refdb = Rugged::Odb.new()
+    assert_instance_of Rugged::Odb, refdb
+  end
+
+  def test_add_backend
+    refdb = Rugged::Odb.new()
+    refdb.add_backend(Rugged::Odb::Backend::Loose.new(File.join(@repo.path, "objects"), -1, 0, 0, 0), 1)
+  end
+
+  def test_each
+    refdb = Rugged::Odb.new()
+    refdb.add_backend(Rugged::Odb::Backend::Loose.new(File.join(@repo.path, "objects"), -1, 0, 0, 0), 1)
+
+    ids = []
+    refdb.each { |id| ids << id }
+    assert_equal 90, ids.length
+  end
+end

--- a/test/refdb_test.rb
+++ b/test/refdb_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class RefdbTest < Rugged::TestCase
+  def setup
+    @repo = FixtureRepo.from_rugged("testrepo.git")
+  end
+
+  def test_new
+    refdb = Rugged::Refdb.new(@repo)
+    assert_instance_of Rugged::Refdb, refdb
+  end
+
+  def test_set_backend
+    refdb = Rugged::Refdb.new(@repo)
+    refdb.backend = Rugged::Refdb::Backend::FileSystem.new(@repo)
+  end
+
+  def test_set_backend_reuse_error
+    refdb = Rugged::Refdb.new(@repo)
+    backend = Rugged::Refdb::Backend::FileSystem.new(@repo)
+
+    refdb.backend = backend
+    assert_raises RuntimeError do
+      refdb.backend = backend
+    end
+  end
+end

--- a/test/refdb_test.rb
+++ b/test/refdb_test.rb
@@ -1,5 +1,11 @@
 require "test_helper"
 
+class TestBackend < Rugged::Refdb::Backend::Custom
+  def compress
+    puts "compress!"
+  end
+end
+
 class RefdbTest < Rugged::TestCase
   def setup
     @repo = FixtureRepo.from_rugged("testrepo.git")
@@ -23,5 +29,13 @@ class RefdbTest < Rugged::TestCase
     assert_raises RuntimeError do
       refdb.backend = backend
     end
+  end
+
+  def test_custom_backend
+    refdb = Rugged::Refdb.new(@repo)
+    backend = TestBackend.new(@repo)
+
+    refdb.backend = backend
+    refdb.compress
   end
 end


### PR DESCRIPTION
Initial backend support was added by @charypar as part of #410.

Unfortunately, the implementation is a bit convoluted: Every backend implementation needs to `include <rugged.h>` to get the definition of `rugged_backend`. Also, the way backends are implemented right now, they always need to provide a `refdb` and `odb` backend together, there's no way to use e.g. one backend type for the odb and another backend type for the refdb. Also, config backends were missing completely.

This PR is aimed at fixing those shortcomings and make backend support first class.

It introduces a few new classes that wrap existing functionality from libgit2, provides abstract implementations of custom refdb, odb and config backends and exposes new APIs on the `Repository` object to make it easier to initialize repositories with custom backends.

---

- [x] Add `Rugged::Refdb` to wrap `git_refdb` functionality from `libgit2`.
- [ ] Add `Rugged::Refdb::Backend::FileSystem` to expose `git_refdb_backend_fs` and to serve as an example on how to wrap `git_refdb_backend`.
- [ ] Add `Rugged::Refdb::Backend::Custom` as an abstract base class that can be extended to provide new refdb backends that are defined using Ruby code.
- [x] Add `Rugged::Odb` to wrap `git_odb` functionality from `libgit2`.
- [ ] Add `Rugged::Odb::Backend::Loose`, `Rugged::Odb::Backend::Packed` and `Rugged::Odb::Backend::Single` to expose `git_odb_backend_loose`, `git_odb_backend_packed` and `git_odb_backend_single` and to serve as examples on how to wrap `git_odb_backend`.
- [ ] Add `Rugged::Odb::Backend::Custom` as an abstract base class that can be extended to provide new odb backends that are defined using Ruby code.
- [ ] Add `Rugged::Config::Backend::Custom` as an abstract base class that can be extended to provide new config backends that are defined using Ruby code.