### PR TITLE
[WIP] Implementation of Repository#clean

### DIFF
--- a/lib/rugged/repository.rb
+++ b/lib/rugged/repository.rb
@@ -223,5 +223,24 @@ module Rugged
 
       remote_or_url.push(*args)
     end
+
+    # Clean a repository of untracked files
+    #
+    # Returns a hash of files that were cleaned up
+    def clean(force: false, ignored: false, directories: false)
+      self.status do |file, status_data|
+        full_path = File.join(self.workdir, file)
+        if status_data == [:worktree_new] || (ignored && status_data == [:ignored])
+          puts "#{file} has status: #{status_data.inspect}"
+          if File.directory?(full_path) && (force || Dir.glob("#{full_path}/.git").empty?)
+            puts "Deleting folder #{full_path}"
+            #FileUtils.rm_r(full_path)
+          else
+            puts "Deleting file #{full_path}"
+            # File.delete(full_path)
+          end
+        end
+      end
+    end
   end
 end

--- a/test/repo_clean_test.rb
+++ b/test/repo_clean_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+require 'base64'
+
+class RepositoryCleanTest < Rugged::TestCase
+  def setup
+    @source_repo = FixtureRepo.from_rugged("testrepo.git")
+    @repo = FixtureRepo.clone(@source_repo)
+  end
+
+  def repo_file_path; File.join('subdir', 'README') end
+  def file_path;      File.join(@repo.workdir, 'subdir', 'README') end
+
+  def test_clean_with_no_arguments
+    new_file = File.join(@repo.workdir, 'subdir', 'README.md')
+    File.open(new_file, 'w') do |f|
+      f.puts "test content"
+    end
+    @repo.clean
+    refute File.exist?(new_file)
+  end
+
+  def test_clean_directories
+    directory = File.join(@repo.workdir, 'clean_dir')
+    FileUtils.mkdir_p(directory)
+    @repo.clean(directories: true)
+    refute File.exist?(directory)
+  end
+
+  def test_clean_force
+    directory = File.join(@repo.workdir, 'clean_dir')
+    FileUtils.mkdir_p(directory)
+    @repo.clean(force: true)
+    refute File.exist?(directory)
+  end
+
+  def test_clean_ignored
+    FileUtils.mkdir_p(File.join(@repo.workdir, 'clean_dir'))
+    @repo.clean(ignored: true)
+  end
+end


### PR DESCRIPTION
I am not sure if this is something that would be included in rugged. As stated elsewhere `clean` isn't exactly a git core command/process and I can see how it makes sense not to have it included.  I started this branch as it `git clean` is a command I am using in an existing process that I am converting from shelling out to git to a pure rugged implementation. If this isn't something that should be in rugged that's cool. In that case, I would build and separate gem that extends rugged to add the functionality so that users who may want it.

This PR is not complete but I wanted to open this PR as a discussion point so please discuss away. 