### PR TITLE
Add support for new GIT_MERGE_NO_RECURSIVE option for merges 

### DIFF
--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -614,15 +614,15 @@ void rugged_parse_merge_options(git_merge_options *opts, VALUE rb_options)
 		}
 
 		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("renames")))) {
-			opts->tree_flags |= GIT_MERGE_TREE_FIND_RENAMES;
+			opts->flags |= GIT_MERGE_FIND_RENAMES;
 		}
 
 		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("fail_on_conflict")))) {
-			opts->tree_flags |= GIT_MERGE_TREE_FAIL_ON_CONFLICT;
+			opts->flags |= GIT_MERGE_FAIL_ON_CONFLICT;
 		}
 
 		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("skip_reuc")))) {
-			opts->tree_flags |= GIT_MERGE_TREE_SKIP_REUC;
+			opts->flags |= GIT_MERGE_SKIP_REUC;
 		}
 	}
 }

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -624,6 +624,10 @@ void rugged_parse_merge_options(git_merge_options *opts, VALUE rb_options)
 		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("skip_reuc")))) {
 			opts->flags |= GIT_MERGE_SKIP_REUC;
 		}
+
+		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("no_recursive")))) {
+			opts->flags |= GIT_MERGE_NO_RECURSIVE;
+		}
 	}
 }
 


### PR DESCRIPTION
This bumps libgit2 to a589f22a9441523327e4c987c5b5f5f857472067, fixes Rugged for the API changes from that bump and adds support for the `GIT_MERGE_NO_RECURSIVE` tree merge option.

/cc @josh @aroben @vmg @ethomson 