### PR TITLE
Build on Windows with WinHTTP

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -15,6 +15,10 @@ def sys(cmd)
   ret
 end
 
+def on_windows
+  RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+end
+
 if !(MAKE = find_executable('gmake') || find_executable('make'))
   abort "ERROR: GNU make is required to build Rugged."
 end
@@ -55,7 +59,7 @@ else
     abort "ERROR: CMake is required to build Rugged."
   end
 
-  if !find_executable('pkg-config')
+  if !on_windows && !find_executable('pkg-config')
     abort "ERROR: pkg-config is required to build Rugged."
   end
 
@@ -66,8 +70,16 @@ else
       sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Unix Makefiles\"")
       sys(MAKE)
 
-      pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")
-      $LDFLAGS << " " + `pkg-config --libs --static #{pcfile}`.strip
+	  # "normal" libraries (and libgit2 builds) get all these when they build but we're doing it
+	  # statically so we put the libraries in by hand. It's important that we put the libraries themselves
+	  # in $LIBS or the final linking stage won't pick them up
+      if on_windows
+	    $LDFLAGS << " " + "-L#{Dir.pwd}/deps/winhttp"
+		$LIBS << " -lwinhttp -lcrypt32 -lrpcrt4 -lole32"
+	  else
+        pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")
+        $LDFLAGS << " " + `pkg-config --libs --static #{pcfile}`.strip
+      end
     end
   end
 

--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -70,13 +70,13 @@ else
       sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Unix Makefiles\"")
       sys(MAKE)
 
-	  # "normal" libraries (and libgit2 builds) get all these when they build but we're doing it
-	  # statically so we put the libraries in by hand. It's important that we put the libraries themselves
-	  # in $LIBS or the final linking stage won't pick them up
+      # "normal" libraries (and libgit2 builds) get all these when they build but we're doing it
+      # statically so we put the libraries in by hand. It's important that we put the libraries themselves
+      # in $LIBS or the final linking stage won't pick them up
       if on_windows
-	    $LDFLAGS << " " + "-L#{Dir.pwd}/deps/winhttp"
-		$LIBS << " -lwinhttp -lcrypt32 -lrpcrt4 -lole32"
-	  else
+        $LDFLAGS << " " + "-L#{Dir.pwd}/deps/winhttp"
+        $LIBS << " -lwinhttp -lcrypt32 -lrpcrt4 -lole32"
+      else
         pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")
         $LDFLAGS << " " + `pkg-config --libs --static #{pcfile}`.strip
       end

--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -15,7 +15,7 @@ def sys(cmd)
   ret
 end
 
-def on_windows
+def windows?
   RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
 end
 
@@ -59,7 +59,7 @@ else
     abort "ERROR: CMake is required to build Rugged."
   end
 
-  if !on_windows && !find_executable('pkg-config')
+  if !windows? && !find_executable('pkg-config')
     abort "ERROR: pkg-config is required to build Rugged."
   end
 
@@ -73,7 +73,7 @@ else
       # "normal" libraries (and libgit2 builds) get all these when they build but we're doing it
       # statically so we put the libraries in by hand. It's important that we put the libraries themselves
       # in $LIBS or the final linking stage won't pick them up
-      if on_windows
+      if windows?
         $LDFLAGS << " " + "-L#{Dir.pwd}/deps/winhttp"
         $LIBS << " -lwinhttp -lcrypt32 -lrpcrt4 -lole32"
       else


### PR DESCRIPTION
Insert the right libraries to link to to get WinHTTP working. These are
normally done by the build system, but we're building statically so we put
them in ourselves.

We don't write out any dependencies to pkg-config, so let's get rid of it.
To boot, it's not always installed on this platform.

---

It'd be nice to be able to build this without having to specify the dependencies manually, like we do for the other deps on unix, but pkg-config isn't really a thing on Windows (and it doesn't come in the devkit), so we kinda have to put the dependencies here.

This resolves the linking issues from #506 though the tests still fail spectacularly as files are either missing or read-only. But those are all issues with the teardown, so the actual tests are working.