### PR TITLE
Update the list of ruby versions to build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,12 @@ cache: bundler
 
 os:
   - linux
-  - osx
 
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.7
-  - 2.2.3
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
   - ruby-head
   - rbx-2
 
@@ -28,6 +27,15 @@ matrix:
   allow_failures:
     - rvm: rbx-2
     - rvm: ruby-head
+  include:
+    - os: osx
+      rvm: 2.0.0
+    - os: osx
+      rvm: 2.1.5
+    - os: osx
+      rvm: 2.2.2
+    - os: osx
+      rvm: rbx-2
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./vendor/libgit2/script/install-deps-osx.sh; fi


### PR DESCRIPTION
This adds the latest 2.3.0 release to the Travis config, updates to the latest 2.1.x and 2.2.x versions and drops the builds against 1.9.3 (which has been unsupported for quite a while).

Also change the way we specify builds for OS X and only run builds for supported versions.