### PR TITLE
Only ask pkg-config for -l options

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -78,7 +78,7 @@ else
         $LIBS << " -lwinhttp -lcrypt32 -lrpcrt4 -lole32"
       else
         pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")
-        $LDFLAGS << " " + `pkg-config --libs --static #{pcfile}`.strip
+        $LDFLAGS << " " + `pkg-config --libs-only-l --static #{pcfile}`.strip
       end
     end
   end


### PR DESCRIPTION
On Windows the default configuration for CMake ends up causing `pkg-config` to generate the following options:

```
# libgit2.pc
libdir=C:/Program Files (x86)/libgit2/lib
includedir=C:/Program Files (x86)/libgit2/include

Name: libgit2
Description: The git library, take 2
Version: 0.23.3

Libs: -L${libdir} -lgit2
Libs.private: 
Requires.private: 

Cflags: -I${includedir}
```

```
C:\Users\Matthew $ pkg-config --libs --static C:\Ruby22-x64\lib\ruby\gems\2.2.0\gems\rugged-0.23.3\vendor\libgit2\build\libgit2.pc
-LC:/Program Files (x86)/libgit2/lib -lgit2
```

This causes quoting issues because of the spaces. Since rugged never actually uses the installation folder anyway since we're building something to vendor it makes sense to just not ask `pkg-config` for the -L options.