### PR TITLE
Add Commit#header_field method

### DIFF
--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -23,6 +23,7 @@
  */
 
 #include "rugged.h"
+#include "git2/commit.h"
 
 extern VALUE rb_mRugged;
 extern VALUE rb_cRuggedObject;
@@ -576,6 +577,20 @@ static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field) {
 	return rb_result;
 }
 
+static VALUE rb_git_commit_header(VALUE self) {
+	VALUE rb_result;
+	git_commit *commit;
+	const char *raw_header;
+
+	Data_Get_Struct(self, git_commit, commit);
+
+	raw_header = git_commit_raw_header(commit);
+
+	rb_result = rb_enc_str_new(raw_header, strlen(raw_header), rb_utf8_encoding());
+
+	return rb_result;
+}
+
 void Init_rugged_commit(void)
 {
 	rb_cRuggedCommit = rb_define_class_under(rb_mRugged, "Commit", rb_cRuggedObject);
@@ -600,4 +615,5 @@ void Init_rugged_commit(void)
 	rb_define_method(rb_cRuggedCommit, "to_mbox", rb_git_commit_to_mbox, -1);
 
 	rb_define_method(rb_cRuggedCommit, "header_field", rb_git_commit_header_field, 1);
+	rb_define_method(rb_cRuggedCommit, "header", rb_git_commit_header, 0);
 }

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -557,6 +557,12 @@ static VALUE rb_git_commit_to_mbox(int argc, VALUE *argv, VALUE self)
 	return rb_email_patch;
 }
 
+/*
+ *  call-seq:
+ *    commit.header_field(field_name) -> str
+ *
+ *  Returns +commit+'s header field value.
+ */
 static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field) {
 	git_buf header_field = { 0 };
 	VALUE rb_result;
@@ -577,6 +583,12 @@ static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field) {
 	return rb_result;
 }
 
+/*
+ *  call-seq:
+ *    commit.header -> str
+ *
+ *  Returns +commit+'s entire raw header.
+ */
 static VALUE rb_git_commit_header(VALUE self) {
 	VALUE rb_result;
 	git_commit *commit;

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -556,6 +556,25 @@ static VALUE rb_git_commit_to_mbox(int argc, VALUE *argv, VALUE self)
 	return rb_email_patch;
 }
 
+static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field) {
+	git_buf header_field = { 0 };
+	VALUE rb_result;
+	git_commit *commit;
+
+	Check_Type(rb_field, T_STRING);
+
+	Data_Get_Struct(self, git_commit, commit);
+
+	rugged_exception_check(
+		git_commit_header_field(&header_field, commit, StringValueCStr(rb_field))
+	);
+
+	rb_result = rb_enc_str_new(header_field.ptr, header_field.size, rb_utf8_encoding());
+
+	git_buf_free(&header_field);
+
+	return rb_result;
+}
 
 void Init_rugged_commit(void)
 {
@@ -579,4 +598,6 @@ void Init_rugged_commit(void)
 	rb_define_method(rb_cRuggedCommit, "amend", rb_git_commit_amend, 1);
 
 	rb_define_method(rb_cRuggedCommit, "to_mbox", rb_git_commit_to_mbox, -1);
+
+	rb_define_method(rb_cRuggedCommit, "header_field", rb_git_commit_header_field, 1);
 }

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -174,6 +174,14 @@ class TestCommit < Rugged::TestCase
     amended_commit = @repo.lookup(new_commit_oid)
     assert_equal tree_oid, amended_commit.tree.oid
   end
+
+  def test_header_field
+    oid = "8496071c1b46c854b31185ea97743be6a8774479"
+    obj = @repo.lookup(oid)
+
+    expected_header = "Scott Chacon <schacon@gmail.com> 1273360386 -0700"
+    assert_equal expected_header, obj.header_field("author")
+  end
 end
 
 class CommitWriteTest < Rugged::TestCase

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -179,8 +179,21 @@ class TestCommit < Rugged::TestCase
     oid = "8496071c1b46c854b31185ea97743be6a8774479"
     obj = @repo.lookup(oid)
 
-    expected_header = "Scott Chacon <schacon@gmail.com> 1273360386 -0700"
-    assert_equal expected_header, obj.header_field("author")
+    expected_header_field = "Scott Chacon <schacon@gmail.com> 1273360386 -0700"
+    assert_equal expected_header_field, obj.header_field("author")
+  end
+
+  def test_header
+    oid = "8496071c1b46c854b31185ea97743be6a8774479"
+    obj = @repo.lookup(oid)
+
+    expected_header = <<-HEADER
+tree 181037049a54a1eb5fab404658a3a250b44335d7
+author Scott Chacon <schacon@gmail.com> 1273360386 -0700
+committer Scott Chacon <schacon@gmail.com> 1273360386 -0700
+    HEADER
+
+    assert_equal expected_header, obj.header
   end
 end
 


### PR DESCRIPTION
This adds `Commit#header_field`, which was added to libgit2 in https://github.com/libgit2/libgit2/pull/3240. This should make it possible to fetch and verify commit signatures in Ruby.

/cc @carlosmn @peff