### PR TITLE
Make Commit#header_field return nil for non-existent headers

### DIFF
--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -567,20 +567,20 @@ static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field) {
 	git_buf header_field = { 0 };
 	VALUE rb_result;
 	git_commit *commit;
-	int err;
+	int error;
 
 	Check_Type(rb_field, T_STRING);
 
 	Data_Get_Struct(self, git_commit, commit);
 
-	err = git_commit_header_field(&header_field, commit, StringValueCStr(rb_field));
+	error = git_commit_header_field(&header_field, commit, StringValueCStr(rb_field));
 
-	if (err == GIT_ENOTFOUND) {
+	if (error == GIT_ENOTFOUND) {
 		git_buf_free(&header_field);
 		return Qnil;
 	}
 
-	rugged_exception_check(err);
+	rugged_exception_check(error);
 
 	rb_result = rb_enc_str_new(header_field.ptr, header_field.size, rb_utf8_encoding());
 

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -567,14 +567,20 @@ static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field) {
 	git_buf header_field = { 0 };
 	VALUE rb_result;
 	git_commit *commit;
+	int err;
 
 	Check_Type(rb_field, T_STRING);
 
 	Data_Get_Struct(self, git_commit, commit);
 
-	rugged_exception_check(
-		git_commit_header_field(&header_field, commit, StringValueCStr(rb_field))
-	);
+	err = git_commit_header_field(&header_field, commit, StringValueCStr(rb_field));
+
+	if (err == GIT_ENOTFOUND) {
+		git_buf_free(&header_field);
+		return Qnil;
+	}
+
+	rugged_exception_check(err);
 
 	rb_result = rb_enc_str_new(header_field.ptr, header_field.size, rb_utf8_encoding());
 

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -181,6 +181,7 @@ class TestCommit < Rugged::TestCase
 
     expected_header_field = "Scott Chacon <schacon@gmail.com> 1273360386 -0700"
     assert_equal expected_header_field, obj.header_field("author")
+    assert_equal nil, obj.header_field("foobar")
   end
 
   def test_header


### PR DESCRIPTION
The `Commit#header_field` method added in #562 raises an exception currently if the header field is not present. This PR changes the method to return `nil` in this case.