### PR TITLE
Add Commit#header_field? for checking header existence

### DIFF
--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -585,6 +585,33 @@ static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field) {
 
 /*
  *  call-seq:
+ *    commit.header_field?(field_name) -> bool
+ *
+ *  Returns true if header field is present, false otherwise.
+ */
+static VALUE rb_git_commit_header_field_present(VALUE self, VALUE rb_field) {
+	git_buf header_field = { 0 };
+	git_commit *commit;
+	int err;
+
+	Check_Type(rb_field, T_STRING);
+
+	Data_Get_Struct(self, git_commit, commit);
+
+	err = git_commit_header_field(&header_field, commit, StringValueCStr(rb_field));
+
+	git_buf_free(&header_field);
+
+	if (err == GIT_ENOTFOUND)
+		return Qfalse;
+
+	rugged_exception_check(err);
+
+	return Qtrue;
+}
+
+/*
+ *  call-seq:
  *    commit.header -> str
  *
  *  Returns +commit+'s entire raw header.
@@ -627,5 +654,6 @@ void Init_rugged_commit(void)
 	rb_define_method(rb_cRuggedCommit, "to_mbox", rb_git_commit_to_mbox, -1);
 
 	rb_define_method(rb_cRuggedCommit, "header_field", rb_git_commit_header_field, 1);
+	rb_define_method(rb_cRuggedCommit, "header_field?", rb_git_commit_header_field_present, 1);
 	rb_define_method(rb_cRuggedCommit, "header", rb_git_commit_header, 0);
 }

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -592,20 +592,20 @@ static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field) {
 static VALUE rb_git_commit_header_field_present(VALUE self, VALUE rb_field) {
 	git_buf header_field = { 0 };
 	git_commit *commit;
-	int err;
+	int error;
 
 	Check_Type(rb_field, T_STRING);
 
 	Data_Get_Struct(self, git_commit, commit);
 
-	err = git_commit_header_field(&header_field, commit, StringValueCStr(rb_field));
+	error = git_commit_header_field(&header_field, commit, StringValueCStr(rb_field));
 
 	git_buf_free(&header_field);
 
-	if (err == GIT_ENOTFOUND)
+	if (error == GIT_ENOTFOUND)
 		return Qfalse;
 
-	rugged_exception_check(err);
+	rugged_exception_check(error);
 
 	return Qtrue;
 }

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -183,6 +183,14 @@ class TestCommit < Rugged::TestCase
     assert_equal expected_header_field, obj.header_field("author")
   end
 
+  def test_header_field?
+    oid = "8496071c1b46c854b31185ea97743be6a8774479"
+    obj = @repo.lookup(oid)
+
+    assert_equal true, obj.header_field?("author")
+    assert_equal false, obj.header_field?("foobar")
+  end
+
   def test_header
     oid = "8496071c1b46c854b31185ea97743be6a8774479"
     obj = @repo.lookup(oid)


### PR DESCRIPTION
This PR adds a `Commit#header_field?` method for checking if a commit has the given header.