### PR TITLE
commit: Cleanup header extraction APIs

### DIFF
--- a/lib/rugged/commit.rb
+++ b/lib/rugged/commit.rb
@@ -9,6 +9,10 @@ module Rugged
       "#<Rugged::Commit:#{object_id} {message: #{message.inspect}, tree: #{tree.inspect}, parents: #{parent_oids}}>"
     end
 
+    def header_field?(field)
+      !!header_field(field)
+    end
+
     # Return a diff between this commit and its first parent or another commit or tree.
     #
     # See Rugged::Tree#diff for more details.


### PR DESCRIPTION
Just some simple changes since I missed review the previous time.
`Commit#header_field?` can be implemented directly in Ruby since the C
code is almost 100% redundant.

The original `Commit#header_field` has been refactored to prevent a
possible memory leak, and to properly tag the resulting header with the
encoding of the commit message, if we know it.

There are no breaking API changes

cc @mastahyeti 