### PR TITLE
Add Commit::extract_signature

### DIFF
--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -204,6 +204,74 @@ committer Scott Chacon <schacon@gmail.com> 1273360386 -0700
 
     assert_equal expected_header, obj.header
   end
+
+  def test_extract_signature
+
+    raw_commit = <<-COMMIT
+tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6
+parent 34734e478d6cf50c27c9d69026d93974d052c454
+author Ben Burkert <ben@benburkert.com> 1358451456 -0800
+committer Ben Burkert <ben@benburkert.com> 1358451456 -0800
+gpgsig -----BEGIN PGP SIGNATURE-----
+ Version: GnuPG v1.4.12 (Darwin)
+ 
+ iQIcBAABAgAGBQJQ+FMIAAoJEH+LfPdZDSs1e3EQAJMjhqjWF+WkGLHju7pTw2al
+ o6IoMAhv0Z/LHlWhzBd9e7JeCnanRt12bAU7yvYp9+Z+z+dbwqLwDoFp8LVuigl8
+ JGLcnwiUW3rSvhjdCp9irdb4+bhKUnKUzSdsR2CK4/hC0N2i/HOvMYX+BRsvqweq
+ AsAkA6dAWh+gAfedrBUkCTGhlNYoetjdakWqlGL1TiKAefEZrtA1TpPkGn92vbLq
+ SphFRUY9hVn1ZBWrT3hEpvAIcZag3rTOiRVT1X1flj8B2vGCEr3RrcwOIZikpdaW
+ who/X3xh/DGbI2RbuxmmJpxxP/8dsVchRJJzBwG+yhwU/iN3MlV2c5D69tls/Dok
+ 6VbyU4lm/ae0y3yR83D9dUlkycOnmmlBAHKIZ9qUts9X7mWJf0+yy2QxJVpjaTGG
+ cmnQKKPeNIhGJk2ENnnnzjEve7L7YJQF6itbx5VCOcsGh3Ocb3YR7DMdWjt7f8pu
+ c6j+q1rP7EpE2afUN/geSlp5i3x8aXZPDj67jImbVCE/Q1X9voCtyzGJH7MXR0N9
+ ZpRF8yzveRfMH8bwAJjSOGAFF5XkcR/RNY95o+J+QcgBLdX48h+ZdNmUf6jqlu3J
+ 7KmTXXQcOVpN6dD3CmRFsbjq+x6RHwa8u1iGn+oIkX908r97ckfB/kHKH7ZdXIJc
+ cpxtDQQMGYFpXK/71stq
+ =ozeK
+ -----END PGP SIGNATURE-----
+
+a simple commit which works
+COMMIT
+
+    exp_signature = <<-SIGNATURE.strip
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1.4.12 (Darwin)
+
+iQIcBAABAgAGBQJQ+FMIAAoJEH+LfPdZDSs1e3EQAJMjhqjWF+WkGLHju7pTw2al
+o6IoMAhv0Z/LHlWhzBd9e7JeCnanRt12bAU7yvYp9+Z+z+dbwqLwDoFp8LVuigl8
+JGLcnwiUW3rSvhjdCp9irdb4+bhKUnKUzSdsR2CK4/hC0N2i/HOvMYX+BRsvqweq
+AsAkA6dAWh+gAfedrBUkCTGhlNYoetjdakWqlGL1TiKAefEZrtA1TpPkGn92vbLq
+SphFRUY9hVn1ZBWrT3hEpvAIcZag3rTOiRVT1X1flj8B2vGCEr3RrcwOIZikpdaW
+who/X3xh/DGbI2RbuxmmJpxxP/8dsVchRJJzBwG+yhwU/iN3MlV2c5D69tls/Dok
+6VbyU4lm/ae0y3yR83D9dUlkycOnmmlBAHKIZ9qUts9X7mWJf0+yy2QxJVpjaTGG
+cmnQKKPeNIhGJk2ENnnnzjEve7L7YJQF6itbx5VCOcsGh3Ocb3YR7DMdWjt7f8pu
+c6j+q1rP7EpE2afUN/geSlp5i3x8aXZPDj67jImbVCE/Q1X9voCtyzGJH7MXR0N9
+ZpRF8yzveRfMH8bwAJjSOGAFF5XkcR/RNY95o+J+QcgBLdX48h+ZdNmUf6jqlu3J
+7KmTXXQcOVpN6dD3CmRFsbjq+x6RHwa8u1iGn+oIkX908r97ckfB/kHKH7ZdXIJc
+cpxtDQQMGYFpXK/71stq
+=ozeK
+-----END PGP SIGNATURE-----
+SIGNATURE
+
+    exp_signed_data = <<-SIGNEDDATA
+tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6
+parent 34734e478d6cf50c27c9d69026d93974d052c454
+author Ben Burkert <ben@benburkert.com> 1358451456 -0800
+committer Ben Burkert <ben@benburkert.com> 1358451456 -0800
+
+a simple commit which works
+SIGNEDDATA
+
+    commit_sha = @repo.write(raw_commit, :commit)
+
+    signature, signed_data = Rugged::Commit.extract_signature(@repo, commit_sha, "gpgsig")
+    assert_equal exp_signature, signature
+    assert_equal exp_signed_data, signed_data
+
+    signature, signed_data = Rugged::Commit.extract_signature(@repo, commit_sha)
+    assert_equal exp_signature, signature
+    assert_equal exp_signed_data, signed_data
+  end
 end
 
 class CommitWriteTest < Rugged::TestCase


### PR DESCRIPTION
This returns the signature and the signed data so the user can compare
them.

---

This depends on libgit2/libgit2#3599 so we shouldn't merge until that gets resolved.