### PR TITLE
Add Tag.extract_signature method

### DIFF
--- a/lib/rugged/tag.rb
+++ b/lib/rugged/tag.rb
@@ -1,5 +1,24 @@
 module Rugged
   class Tag < Rugged::Reference
+    GPG_SIGNATURE_PREFIX = "-----BEGIN PGP SIGNATURE-----".freeze
+
+    def self.extract_signature(repo, oid, prefix=GPG_SIGNATURE_PREFIX)
+      object = repo.read(oid)
+
+      unless object.type == :tag
+        raise GitRPC::InvalidObject, "Invalid object type #{object.type}, expected tag"
+      end
+
+      unless index = object.data.index(prefix)
+        raise GitRPC::InvalidObject, "Tag does not contain signature"
+      end
+
+      [
+        object.data.byteslice(index..-1),
+        object.data.byteslice(0...index)
+      ]
+    end
+
     def name
       canonical_name.sub(%r{^refs/tags/}, "")
     end

--- a/lib/rugged/tag.rb
+++ b/lib/rugged/tag.rb
@@ -9,14 +9,14 @@ module Rugged
         raise GitRPC::InvalidObject, "Invalid object type #{object.type}, expected tag"
       end
 
-      unless index = object.data.index(prefix)
-        raise GitRPC::InvalidObject, "Tag does not contain signature"
+      if index = object.data.index(prefix)
+        [
+          object.data.byteslice(index..-1),
+          object.data.byteslice(0...index)
+        ]
+      else
+        [nil, object.data]
       end
-
-      [
-        object.data.byteslice(index..-1),
-        object.data.byteslice(0...index)
-      ]
     end
 
     def name

--- a/test/tag_test.rb
+++ b/test/tag_test.rb
@@ -98,6 +98,61 @@ class TagTest < Rugged::TestCase
     assert_equal tag_names[0], "annotated_tag_to_blob"
     assert_equal tag_names[1], "e90810b"
   end
+
+  def test_extract_signature
+    raw_tag = <<-TAG
+object 36060c58702ed4c2a40832c51758d5344201d89a
+type commit
+tag signed
+tagger Ben Toews <mastahyeti@users.noreply.github.com> 1455121460 -0700
+
+my signed tag
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQEcBAABAgAGBQJWu2Q0AAoJEDJi7/JboNJwYNgH/0NQAgNthQi5kiZL5LdAKNE9
+HRHj1Gumcqf04pPbuNXBTt4jdsWka8cTLu8q4CVE2EBtJRJfYhoKXt+bhDSa4WRc
+W/M02GASaqBbY3BVAI0+jd/nmoUqz97jsYotOjVOhUbIGJjo2V2nKi1x6lAN3Nr2
+bq9zJBbYWkIExZU29ycWWk+yTLPGcmcnr0itoUyywgg9NKivH2e8EmyQgAjLUp+M
+NL9Fgg5UMTDoRvJs98i+SIJAkNzxN0mypr51G0kmZbWkSEshHvBoZlV731QqmT+j
+1+eI1odAMHSNHqkmel8+1yooQQzPFc9ZmxGi8DdyuSv6AD7pzxX5vmU0AuBU9C4=
+=Tmm9
+-----END PGP SIGNATURE-----
+TAG
+
+    exp_signature = <<-SIGNATURE
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQEcBAABAgAGBQJWu2Q0AAoJEDJi7/JboNJwYNgH/0NQAgNthQi5kiZL5LdAKNE9
+HRHj1Gumcqf04pPbuNXBTt4jdsWka8cTLu8q4CVE2EBtJRJfYhoKXt+bhDSa4WRc
+W/M02GASaqBbY3BVAI0+jd/nmoUqz97jsYotOjVOhUbIGJjo2V2nKi1x6lAN3Nr2
+bq9zJBbYWkIExZU29ycWWk+yTLPGcmcnr0itoUyywgg9NKivH2e8EmyQgAjLUp+M
+NL9Fgg5UMTDoRvJs98i+SIJAkNzxN0mypr51G0kmZbWkSEshHvBoZlV731QqmT+j
+1+eI1odAMHSNHqkmel8+1yooQQzPFc9ZmxGi8DdyuSv6AD7pzxX5vmU0AuBU9C4=
+=Tmm9
+-----END PGP SIGNATURE-----
+SIGNATURE
+
+    exp_signed_data = <<-SIGNEDDATA
+object 36060c58702ed4c2a40832c51758d5344201d89a
+type commit
+tag signed
+tagger Ben Toews <mastahyeti@users.noreply.github.com> 1455121460 -0700
+
+my signed tag
+SIGNEDDATA
+
+    tag_oid = @repo.write(raw_tag, :tag)
+
+    signature, signed_data = Rugged::Tag.extract_signature(@repo, tag_oid)
+    assert_equal exp_signature, signature
+    assert_equal exp_signed_data, signed_data
+
+    signature, signed_data = Rugged::Tag.extract_signature(@repo, tag_oid, Rugged::Tag::GPG_SIGNATURE_PREFIX)
+    assert_equal exp_signature, signature
+    assert_equal exp_signed_data, signed_data
+  end
 end
 
 class AnnotatedTagTest < Rugged::TestCase


### PR DESCRIPTION
This adds `Rugged::Tag.extract_signature method` to extract tag signatures/signing-data from tags.

/cc @vmg @carlosmn @brianmario 