### PR TITLE
Added support for certificate_check callback

### DIFF
--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -157,6 +157,7 @@ struct rugged_remote_cb_payload
 	VALUE transfer_progress;
 	VALUE update_tips;
 	VALUE credentials;
+	VALUE certificate_check;
 	VALUE result;
 	int exception;
 };

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -485,7 +485,7 @@ static VALUE rb_git_repo_clone_at(int argc, VALUE *argv, VALUE klass)
 {
 	VALUE url, local_path, rb_options_hash;
 	git_clone_options options = GIT_CLONE_OPTIONS_INIT;
-	struct rugged_remote_cb_payload remote_payload = { Qnil, Qnil, Qnil, Qnil, 0 };
+	struct rugged_remote_cb_payload remote_payload = { Qnil, Qnil, Qnil, Qnil, Qnil, Qnil, Qnil, 0 };
 	git_repository *repo;
 	int error;
 

--- a/test/online/fetch_test.rb
+++ b/test/online/fetch_test.rb
@@ -28,6 +28,49 @@ class OnlineFetchTest < Rugged::OnlineTestCase
         "refs/tags/commit_tree"
       ], @repo.refs.map(&:name).sort
     end
+
+    def test_fetch_over_https_with_certificate_callback
+      result = {}
+      @repo.remotes.create("origin", "https://github.com/libgit2/TestGitRepository.git")
+
+      @repo.fetch("origin", {
+        certificate_check: lambda { |valid, host|
+         result[:valid] = valid
+         true
+        }
+      })
+      assert_equal result[:valid], 1
+    end
+
+    def test_fetch_over_https_with_certificate_callback_fail
+      result = {}
+      @repo.remotes.create("origin", "https://github.com/libgit2/TestGitRepository.git")
+
+      exception = assert_raises Rugged::NetworkError do
+        @repo.fetch("origin", {
+          certificate_check: lambda { |valid, host|
+            result[:valid] = valid
+            false
+          }
+        })
+      end
+      assert_equal "user cancelled certificate check", exception.message
+    end
+
+    def test_fetch_over_https_with_certificate_callback_exception
+      result = {}
+      @repo.remotes.create("origin", "https://github.com/libgit2/TestGitRepository.git")
+
+      exception = assert_raises RuntimeError do
+        @repo.fetch("origin", {
+          certificate_check: lambda { |valid, host|
+            result[:valid] = valid
+            raise "Exception from callback"
+          }
+        })
+      end
+      assert_equal "Exception from callback", exception.message
+    end
   end
 
   if Rugged.features.include?(:ssh) && ssh_creds?


### PR DESCRIPTION
Since libgit2 removed support for GIT_SSL_NO_VERIFY environment variable
and  "http.sslverify" in favor of certificate check callbacks, we need
rugged to support the certificate check callback.

One usecase for this is self-signed certificates which can be verified
in the callback.