### PR TITLE
commit: raise when given bad data to extract the signature

### DIFF
--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -625,7 +625,7 @@ static VALUE rb_git_commit_header(VALUE self)
 static VALUE rb_git_commit_extract_signature(int argc, VALUE *argv, VALUE self)
 {
 	int error;
-	VALUE ret_arr;
+	VALUE ret;
 	git_oid commit_id;
 	const char *field;
 	git_repository *repo;
@@ -648,18 +648,18 @@ static VALUE rb_git_commit_extract_signature(int argc, VALUE *argv, VALUE self)
 	}
 
 	if (error == GIT_ENOTFOUND && giterr_last()->klass == GITERR_OBJECT ) {
-		ret_arr = rb_ary_new3(2, Qnil, Qnil);
+		ret = Qnil;
 	} else {
 		rugged_exception_check(error);
 
-		ret_arr = rb_ary_new3(2, rb_str_new(signature.ptr, signature.size),
-				      rb_str_new(signed_data.ptr, signed_data.size));
+		ret = rb_ary_new3(2, rb_str_new(signature.ptr, signature.size),
+				     rb_str_new(signed_data.ptr, signed_data.size));
 	}
 
 	git_buf_free(&signature);
 	git_buf_free(&signed_data);
 
-	return ret_arr;
+	return ret;
 }
 
 void Init_rugged_commit(void)

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -647,7 +647,7 @@ static VALUE rb_git_commit_extract_signature(int argc, VALUE *argv, VALUE self)
 		git_buf_free(&signed_data);
 	}
 
-	if (error == GIT_ENOTFOUND) {
+	if (error == GIT_ENOTFOUND && giterr_last()->klass == GITERR_OBJECT ) {
 		ret_arr = rb_ary_new3(2, Qnil, Qnil);
 	} else {
 		rugged_exception_check(error);

--- a/lib/rugged/tag.rb
+++ b/lib/rugged/tag.rb
@@ -15,7 +15,7 @@ module Rugged
           object.data.byteslice(0...index)
         ]
       else
-        [nil, object.data]
+        nil
       end
     end
 

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -272,7 +272,7 @@ SIGNEDDATA
     assert_equal exp_signature, signature
     assert_equal exp_signed_data, signed_data
 
-    assert_equal [nil, nil], Rugged::Commit.extract_signature(@repo, "8496071c1b46c854b31185ea97743be6a8774479")
+    assert_nil Rugged::Commit.extract_signature(@repo, "8496071c1b46c854b31185ea97743be6a8774479")
 
     # Ask for a tree
     assert_raises(Rugged::InvalidError) { Rugged::Commit.extract_signature(@repo, "181037049a54a1eb5fab404658a3a250b44335d7") }

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -273,6 +273,12 @@ SIGNEDDATA
     assert_equal exp_signed_data, signed_data
 
     assert_equal [nil, nil], Rugged::Commit.extract_signature(@repo, "8496071c1b46c854b31185ea97743be6a8774479")
+
+    # Ask for a tree
+    assert_raises(Rugged::InvalidError) { Rugged::Commit.extract_signature(@repo, "181037049a54a1eb5fab404658a3a250b44335d7") }
+
+    # Ask for a non-existent object
+    assert_raises(Rugged::OdbError) { Rugged::Commit.extract_signature(@repo, "181037049a54a1eb5fab404658a3a250b44335d8") }
   end
 end
 


### PR DESCRIPTION
This lets the caller distinguish between a missing object, the wrong
kind of object and unsigned commits.

---

Limitations you discover when actually trying to integrate into the product.