### PR TITLE
Strict object creation

### DIFF
--- a/ext/rugged/rugged_settings.c
+++ b/ext/rugged/rugged_settings.c
@@ -98,6 +98,11 @@ static VALUE rb_git_set_option(VALUE self, VALUE option, VALUE value)
 		set_search_path(GIT_CONFIG_LEVEL_SYSTEM, value);
 	}
 
+	else if (strcmp(opt, "strict_object_creation") == 0) {
+		int strict = RTEST(value) ? 1 : 0;
+		git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, strict);
+	}
+
 	else {
 		rb_raise(rb_eArgError, "Unknown option specified");
 	}

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -143,4 +143,17 @@ class TreeUpdateTest < Rugged::TestCase
     assert_equal builder.remove("nonexistent file"), false
   end
 
+  def test_treebuilder_add
+    builder = Rugged::Tree::Builder.new(@repo, @repo.head.target.tree)
+    builder << { :type => :blob, :name => "another-readme", :oid => "1385f264afb75a56a5bec74243be9b367ba4ca08", :filemode => 0100644 }
+    newtree = builder.write
+    assert_equal "71a3bbe701e60c1756edd23cfc0b207711dca1f2", newtree
+  end
+
+  def test_treebuilder_add_nonexistent
+    builder = Rugged::Tree::Builder.new(@repo, @repo.head.target.tree)
+    builder << { :type => :blob, :name => "another-readme", :oid => "0000000000000000000000000000000000000000", :filemode => 0100644 }
+    newtree = builder.write
+    assert_equal "7c98360ac03064bb67c6f0949e6a354155ce1b04", newtree
+  end
 end

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -150,10 +150,22 @@ class TreeUpdateTest < Rugged::TestCase
     assert_equal "71a3bbe701e60c1756edd23cfc0b207711dca1f2", newtree
   end
 
-  def test_treebuilder_add_nonexistent
+  def test_treebuilder_add_nonexistent_fails
     builder = Rugged::Tree::Builder.new(@repo, @repo.head.target.tree)
-    builder << { :type => :blob, :name => "another-readme", :oid => "0000000000000000000000000000000000000000", :filemode => 0100644 }
-    newtree = builder.write
-    assert_equal "7c98360ac03064bb67c6f0949e6a354155ce1b04", newtree
+    assert_raises Rugged::TreeError do
+      builder << { :type => :blob, :name => "another-readme", :oid => "0000000000000000000000000000000000000000", :filemode => 0100644 }
+    end
+  end
+
+  def test_treebuilder_add_nonexistent_can_pass
+    begin
+      Rugged::Settings['strict_object_creation'] = false
+      builder = Rugged::Tree::Builder.new(@repo, @repo.head.target.tree)
+      builder << { :type => :blob, :name => "another-readme", :oid => "0000000000000000000000000000000000000000", :filemode => 0100644 }
+      newtree = builder.write
+      assert_equal "7c98360ac03064bb67c6f0949e6a354155ce1b04", newtree
+    ensure
+      Rugged::Settings['strict_object_creation'] = true
+    end
   end
 end


### PR DESCRIPTION
This updates libgit2 to [`edaffe2`](https://github.com/libgit2/libgit2/commit/edaffe22a205c57022cc365ab20dcbf7e22f68c4), which turns on stricter object validation for functions like the treebuilder.  Additionally, add a `Tree::Builder` test that ensures that we throw when adding a new tree entry that is nonexistent, but that we can disable this behavior with `Rugged::Settings['strict_object_creation']`.

/cc @vmg 