### PR TITLE
Release 0.24.0

### DIFF
--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -1,3 +1,3 @@
 module Rugged
-  Version = VERSION = '0.24.0b14'
+  Version = VERSION = '0.24.0'
 end

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -157,6 +157,13 @@ class TreeUpdateTest < Rugged::TestCase
     end
   end
 
+  def test_treebuilder_add_submodules_always_succeeds
+    builder = Rugged::Tree::Builder.new(@repo, @repo.head.target.tree)
+    builder << { :type => :commit, :name => "submodule", :oid => "0000000000000000000000000000000000000000", :filemode => 0160000 }
+    newtree = builder.write
+    assert_equal "ce986db11f99880a0a087ba3220dba61e9afd918", newtree
+  end
+
   def test_treebuilder_add_nonexistent_can_pass
     begin
       Rugged::Settings['strict_object_creation'] = false


### PR DESCRIPTION
We've been incrementing 0.24.0 as a beta since [way back in October](https://github.com/libgit2/rugged/commit/fb17354c).  Now that libgit2 is [updating to 0.24](https://github.com/libgit2/libgit2/issues/3626) themselves, update to match.