### PR TITLE
ext: Use `xmalloc` instead of `malloc`

### DIFF
--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -1945,7 +1945,7 @@ void rugged_parse_checkout_options(git_checkout_options *opts, VALUE rb_options)
 
 	rb_value = rb_hash_aref(rb_options, CSTR2SYM("progress"));
 	if (!NIL_P(rb_value)) {
-		struct rugged_cb_payload *payload = malloc(sizeof(struct rugged_cb_payload));
+		struct rugged_cb_payload *payload = xmalloc(sizeof(struct rugged_cb_payload));
 		payload->rb_data = rb_value;
 		payload->exception = 0;
 
@@ -1955,7 +1955,7 @@ void rugged_parse_checkout_options(git_checkout_options *opts, VALUE rb_options)
 
 	rb_value = rb_hash_aref(rb_options, CSTR2SYM("notify"));
 	if (!NIL_P(rb_value)) {
-		struct rugged_cb_payload *payload = malloc(sizeof(struct rugged_cb_payload));
+		struct rugged_cb_payload *payload = xmalloc(sizeof(struct rugged_cb_payload));
 		payload->rb_data = rb_value;
 		payload->exception = 0;
 


### PR DESCRIPTION
Use `xmalloc` instead of `malloc`, as `xmalloc` will fail gracefully, raising an exception and [returning to Ruby itself](https://github.com/ruby/ruby/blob/5fa5b50e587918f7003a9a6579e655896e82aa2d/eval.c#L589) while `malloc` will merrily carry-on and we will doubtless try to dereference a null pointer.