### PR TITLE
extconf: Use MSYS Makefiles with CMake on Windows

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -67,7 +67,9 @@ else
     Dir.mkdir("build") if !Dir.exists?("build")
 
     Dir.chdir("build") do
-      sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Unix Makefiles\"")
+      # On Windows, Ruby-DevKit is MSYS-based, so ensure to use MSYS Makefiles.
+      generator = "-G \"MSYS Makefiles\"" if windows?
+      sys("cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo #{generator}")
       sys(MAKE)
 
       # "normal" libraries (and libgit2 builds) get all these when they build but we're doing it


### PR DESCRIPTION
On Windows, Ruby-DevKit is MSYS based. As such we should use MSYS
Makefiles with CMake. Otherwise it might happen that CMake picks a
gmake.exe from somewhere instead of make.exe from Ruby-DevKit as CMake
seems to prefer gmake over make.

In a concrete case, when doing "gem install rugged" on Windows with
Strawberry Perl installed and in PATH, CMake was picking

    C:/Strawberry/c/bin/gmake.exe

instead of

    C:/Ruby-DevKit/bin/make.exe

While the latter is linked against MSYS-1.0.DLL and understands Unix-style
paths on Windows, the first is a native Windows executable linked against
MSVCRT.DLL that does not. This resulted in path mangling issues leading to
CMake's "Detecting C compiler ABI info" step to fail because the helper
executable failed to build, which in turn led to CMAKE_SIZEOF_VOID_P not
being set and libgit2 being unable to detect the architecture.