### PR TITLE
Fix infinite loop: Introduce a counter to Rugged::Credentials

### DIFF
--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -157,6 +157,7 @@ struct rugged_remote_cb_payload
 	VALUE transfer_progress;
 	VALUE update_tips;
 	VALUE credentials;
+	unsigned int credentials_counter;
 	VALUE result;
 	int exception;
 };

--- a/lib/rugged/credentials.rb
+++ b/lib/rugged/credentials.rb
@@ -6,7 +6,10 @@ module Rugged
         @username, @password = options[:username], options[:password]
       end
 
-      def call(url, username_from_url, allowed_types)
+      def call(url, username_from_url, allowed_types, counter)
+        if counter > 0
+          raise Rugged::CallbackError.new('Authentication failed')
+        end
         self
       end
     end

--- a/lib/rugged/credentials.rb
+++ b/lib/rugged/credentials.rb
@@ -20,7 +20,7 @@ module Rugged
         @username, @publickey, @privatekey, @passphrase = options[:username], options[:publickey], options[:privatekey], options[:passphrase]
       end
 
-      def call(url, username_from_url, allowed_types)
+      def call(url, username_from_url, allowed_types, counter)
         self
       end
     end
@@ -30,7 +30,7 @@ module Rugged
         @username = options[:username]
       end
 
-      def call(url, username_from_url, allowed_types)
+      def call(url, username_from_url, allowed_types, counter)
         self
       end
     end
@@ -38,7 +38,7 @@ module Rugged
     # A "default" credential usable for Negotiate mechanisms like NTLM or
     # Kerberos authentication
     class Default
-      def call(url, username_from_url, allowed_types)
+      def call(url, username_from_url, allowed_types, counter)
         self
       end
     end

--- a/test/online/clone_test.rb
+++ b/test/online/clone_test.rb
@@ -35,7 +35,7 @@ class OnlineCloneTest < Rugged::OnlineTestCase
     def test_clone_over_ssh_with_credentials_callback
       Dir.mktmpdir do |dir|
         repo = Rugged::Repository.clone_at(ENV['GITTEST_REMOTE_SSH_URL'], dir, {
-          credentials: lambda { |url, username, allowed_types|
+          credentials: lambda { |url, username, allowed_types, counter|
             return ssh_key_credential
           }
         })

--- a/test/online/fetch_test.rb
+++ b/test/online/fetch_test.rb
@@ -51,7 +51,7 @@ class OnlineFetchTest < Rugged::OnlineTestCase
       @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
 
       @repo.fetch("origin", {
-        credentials: lambda { |url, username, allowed_types|
+        credentials: lambda { |url, username, allowed_types, counter|
           return ssh_key_credential
         }
       })


### PR DESCRIPTION
A counter makes it possible to exit authentication loops with static
username and password.

possible fix for #592

I’m not happy with this workaround. I don’t know whether this would be better handled in libgit2.

libgit2 discussion for the issue:
- https://github.com/libgit2/libgit2/pull/3243
- https://github.com/libgit2/libgit2/issues/3358
