### PR TITLE
Rebase: Better error handling in case of empty patches.

### DIFF
--- a/ext/rugged/rugged_rebase.c
+++ b/ext/rugged/rugged_rebase.c
@@ -189,11 +189,10 @@ cleanup:
 	git_annotated_commit_free(upstream);
 	git_annotated_commit_free(onto);
 
-	if (error) {
-		rugged_exception_check(error);
-	} else if (exception) {
+	if (exception)
 		rb_jump_tag(exception);
-	}
+
+	rugged_exception_check(error);
 
 	return rugged_rebase_new(klass, rb_repo, rebase);
 }
@@ -317,6 +316,11 @@ static VALUE rb_git_rebase_commit(int argc, VALUE *argv, VALUE self)
 	error = git_rebase_commit(&id, rebase, author, committer, NULL, message);
 	git_signature_free(author);
 	git_signature_free(committer);
+
+	if (error == GIT_EAPPLIED) {
+		giterr_clear();
+		return Qnil;
+	}
 
 	rugged_exception_check(error);
 

--- a/test/rebase_test.rb
+++ b/test/rebase_test.rb
@@ -130,5 +130,26 @@ class TestRebase < Rugged::TestCase
 
     commit_id = rebase.commit(committer: @sig)
     assert_equal "db7af47222181e548810da2ab5fec0e9357c5637", commit_id
+
+    # Make sure the next operation is what we expect
+    op = rebase.next()
+    assert_equal :pick, op[:type]
+    assert_equal "0f5f6d3353be1a9966fa5767b7d604b051798224", op[:id]
+  end
+
+  def test_inmemory_already_applied_patch
+    rebase = Rugged::Rebase.new(@repo, "refs/heads/asparagus", "refs/heads/master", inmemory: true)
+
+    rebase.next()
+
+    idx = rebase.inmemory_index
+    idx.read_tree(@repo.branches["master"].target.tree)
+
+    assert_nil rebase.commit(committer: @sig)
+
+    # Make sure the next operation is what we expect
+    op = rebase.next()
+    assert_equal :pick, op[:type]
+    assert_equal "0f5f6d3353be1a9966fa5767b7d604b051798224", op[:id]
   end
 end


### PR DESCRIPTION
Right now, Rugged will throw a `Rugged::RebaseError` when trying to commit an empty rebase patch. This error type can also be thrown for a bunch of other error conditions, which leaves consumers testing for the error's `message` to distinguish between these different error types.

Let's introduce a new exception class instead.

/cc @vmg @ethomson @carlosmn 