### PR TITLE
Tag oids as US_ASCII

### DIFF
--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -176,7 +176,7 @@ static inline VALUE rugged_create_oid(const git_oid *oid)
 {
 	char out[40];
 	git_oid_fmt(out, oid);
-	return rb_str_new(out, 40);
+	return rb_usascii_str_new(out, 40);
 }
 
 

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -53,6 +53,12 @@ class ReferenceTest < Rugged::TestCase
     ], @repo.refs('refs/tags/*').map(&:name).sort
   end
 
+  def test_target_id_encoding
+    ref = @repo.references["refs/heads/master"]
+    assert_equal "099fabac3a9ea935598528c27f866e34089c2eff", ref.target_id
+    assert_equal Encoding::US_ASCII, ref.target_id.encoding
+  end
+
   def test_can_open_reference
     ref = @repo.references["refs/heads/master"]
     assert_equal "099fabac3a9ea935598528c27f866e34089c2eff", ref.target_id


### PR DESCRIPTION
We should be tagging oids as US-ASCII (or UTF-8).  We know the encoding
of the bytes in that string, so we should be indicating that encoding to
clients of the library.