### PR TITLE
Show that inmemory rebase is losing files

### DIFF
--- a/test/rebase_test.rb
+++ b/test/rebase_test.rb
@@ -152,4 +152,28 @@ class TestRebase < Rugged::TestCase
     assert_equal :pick, op[:type]
     assert_equal "0f5f6d3353be1a9966fa5767b7d604b051798224", op[:id]
   end
+
+  def test_inmemory_rebase_does_not_lose_files
+    commit = Rugged::Commit.create(@repo, {
+      :author => { :email => "rebaser@rebaser.com", :time => Time.now, :name => "Rebaser" },
+      :message => "Add some files",
+      :parents => [ @repo.branches["gravy"].target_id ],
+      :update_ref => "refs/heads/gravy",
+      :tree => @repo.branches["gravy"].target.tree.update([
+        { :action => :upsert,
+          :path => "some/nested/file",
+          :oid => Rugged::Blob.from_buffer(@repo, "a new blob content"),
+          :filemode => 0100644
+        }
+      ])
+    })
+
+    rebase = Rugged::Rebase.new(@repo, "refs/heads/gravy", "refs/heads/veal", inmemory: true)
+
+    rebase.next
+    assert rebase.commit({ committer: { :email => "rebaser@rebaser.com", :name => "Rebaser" } })
+
+    rebase.next
+    assert rebase.commit({ committer: { :email => "rebaser@rebaser.com", :name => "Rebaser" } })
+  end
 end


### PR DESCRIPTION
Inmemory rebases seem to be losing files. Add two examples that show a successful rebase and a (failing) inmemory rebase.