### PR TITLE
script/cibuild: add --no-pager when logging

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -10,7 +10,7 @@ export RBENV_VERSION="2.1.2-github"
 export CI_BUILD=1
 
 # Write commit we're building at
-git log -n 1 || true
+git --no-pager log -n 1 || true
 echo
 
 git submodule update --init


### PR DESCRIPTION
If you're running `script/cibuild` yourself, from an actual tty,
then `git log` will by default invoke your pager.