### PR TITLE
Fix random test failure

### DIFF
--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -18,7 +18,7 @@ class ConfigTest < Rugged::TestCase
 
   def test_read_global_config_file
     config = Rugged::Config.global
-    assert config['user.name'] != nil
+    refute_nil config['user.name']
     assert_nil config['core.bare']
   end
 

--- a/test/lib_test.rb
+++ b/test/lib_test.rb
@@ -34,8 +34,14 @@ class RuggedTest < Rugged::TestCase
              ['search_path_system', '/tmp/system']]
 
     paths.each do |opt, path|
+      before = Rugged::Settings[opt]
       Rugged::Settings[opt] = path
-      assert_equal(path, Rugged::Settings[opt])
+
+      begin
+        assert_equal(path, Rugged::Settings[opt])
+      ensure
+        Rugged::Settings[opt] = before
+      end
     end
   end
 


### PR DESCRIPTION
Mutating `Rugged::Settings` will impact other tests, specifically
`test_read_global_config_file`.  This commit restores global settings so
that other tests aren't impacted.

I found the `test_search_path` and `test_read_global_config_file` pair
by using `minitest-bisect`.  First I looked up the failing seed on
Travis, which was `--seed 43037`.  Then I ran this:

```
$ minitest_bisect -Ilib:test --seed 43037 test/*_test.rb
```

It found the failing test pair, and I was able to verify the fix by
doing:

```
$ rake test TESTOPTS=--seed=43037
```