### PR TITLE
Tag strings without a known encoding as ASCII-8BIT.

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -225,7 +225,7 @@ static VALUE rb_git_prettify_message(int argc, VALUE *argv, VALUE self)
 				StringValueCStr(rb_message), strip_comments, comment_char);
 
 	if (!error)
-		result = rb_enc_str_new(message.ptr, message.size, rb_utf8_encoding());
+		result = rb_str_new(message.ptr, message.size);
 
 	git_buf_free(&message);
 	rugged_exception_check(error);
@@ -391,7 +391,7 @@ VALUE rugged_strarray_to_rb_ary(git_strarray *str_array)
 	size_t i;
 
 	for (i = 0; i < str_array->count; ++i) {
-		rb_ary_push(rb_array, rb_str_new_utf8(str_array->strings[i]));
+		rb_ary_push(rb_array, rb_str_new2(str_array->strings[i]));
 	}
 
 	return rb_array;

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -41,7 +41,6 @@
 #include <git2.h>
 #include <git2/odb_backend.h>
 
-#define rb_str_new_utf8(str) rb_enc_str_new(str, strlen(str), rb_utf8_encoding())
 #define CSTR2SYM(s) (ID2SYM(rb_intern((s))))
 
 /*
@@ -81,7 +80,7 @@ VALUE rb_git_object_init(git_otype type, int argc, VALUE *argv, VALUE self);
 
 VALUE rugged_raw_read(git_repository *repo, const git_oid *oid);
 
-VALUE rugged_signature_new(const git_signature *sig, const char *encoding_name);
+VALUE rugged_signature_new(const git_signature *sig);
 
 VALUE rugged_repo_new(VALUE klass, git_repository *repo);
 VALUE rugged_index_new(VALUE klass, VALUE owner, git_index *index);

--- a/ext/rugged/rugged_blame.c
+++ b/ext/rugged/rugged_blame.c
@@ -39,12 +39,12 @@ static VALUE rb_git_blame_hunk_fromC(const git_blame_hunk *hunk)
 
 	rb_hash_aset(rb_hunk, CSTR2SYM("final_commit_id"), rugged_create_oid(&(hunk->final_commit_id)));
 	rb_hash_aset(rb_hunk, CSTR2SYM("final_start_line_number"), UINT2NUM(hunk->final_start_line_number));
-	rb_hash_aset(rb_hunk, CSTR2SYM("final_signature"), hunk->final_signature ? rugged_signature_new(hunk->final_signature, NULL) : Qnil);
+	rb_hash_aset(rb_hunk, CSTR2SYM("final_signature"), hunk->final_signature ? rugged_signature_new(hunk->final_signature) : Qnil);
 
 	rb_hash_aset(rb_hunk, CSTR2SYM("orig_commit_id"), rugged_create_oid(&(hunk->orig_commit_id)));
 	rb_hash_aset(rb_hunk, CSTR2SYM("orig_path"), hunk->orig_path ? rb_str_new2(hunk->orig_path) : Qnil);
 	rb_hash_aset(rb_hunk, CSTR2SYM("orig_start_line_number"), UINT2NUM(hunk->orig_start_line_number));
-	rb_hash_aset(rb_hunk, CSTR2SYM("orig_signature"), hunk->orig_signature ? rugged_signature_new(hunk->orig_signature, NULL) : Qnil);
+	rb_hash_aset(rb_hunk, CSTR2SYM("orig_signature"), hunk->orig_signature ? rugged_signature_new(hunk->orig_signature) : Qnil);
 
 	rb_hash_aset(rb_hunk, CSTR2SYM("boundary"), hunk->boundary ? Qtrue : Qfalse);
 

--- a/ext/rugged/rugged_branch.c
+++ b/ext/rugged/rugged_branch.c
@@ -65,7 +65,7 @@ static VALUE rb_git_branch_name(VALUE self)
 
 	rugged_exception_check(git_branch_name(&branch_name, branch));
 
-	return rb_str_new_utf8(branch_name);
+	return rb_str_new2(branch_name);
 }
 
 static VALUE rb_git_branch__remote_name(VALUE rb_repo, const char *canonical_name)
@@ -78,7 +78,7 @@ static VALUE rb_git_branch__remote_name(VALUE rb_repo, const char *canonical_nam
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	if ((error = git_branch_remote_name(&remote_name, repo, canonical_name)) == GIT_OK)
-		result = rb_enc_str_new(remote_name.ptr, remote_name.size, rb_utf8_encoding());
+		result = rb_str_new(remote_name.ptr, remote_name.size);
 
 	git_buf_free(&remote_name);
 	rugged_exception_check(error);

--- a/ext/rugged/rugged_branch_collection.c
+++ b/ext/rugged/rugged_branch_collection.c
@@ -221,7 +221,7 @@ static VALUE each_branch(int argc, VALUE *argv, VALUE self, int branch_names_onl
 	if (branch_names_only) {
 		git_reference *branch;
 		while (!exception && (error = git_branch_next(&branch, &branch_type, iter)) == GIT_OK) {
-			rb_protect(rb_yield, rb_str_new_utf8(git_reference_shorthand(branch)), &exception);
+			rb_protect(rb_yield, rb_str_new2(git_reference_shorthand(branch)), &exception);
 		}
 	} else {
 		git_reference *branch;

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -47,7 +47,7 @@ VALUE rb_cRuggedCommit;
 static VALUE rb_git_commit_message_GET(VALUE self)
 {
 	git_commit *commit;
-	rb_encoding *encoding = rb_utf8_encoding();
+	rb_encoding *encoding = rb_ascii8bit_encoding();
 	const char *encoding_name;
 	const char *message;
 
@@ -82,9 +82,7 @@ static VALUE rb_git_commit_committer_GET(VALUE self)
 	git_commit *commit;
 	Data_Get_Struct(self, git_commit, commit);
 
-	return rugged_signature_new(
-		git_commit_committer(commit),
-		git_commit_message_encoding(commit));
+	return rugged_signature_new(git_commit_committer(commit));
 }
 
 /*
@@ -107,9 +105,7 @@ static VALUE rb_git_commit_author_GET(VALUE self)
 	git_commit *commit;
 	Data_Get_Struct(self, git_commit, commit);
 
-	return rugged_signature_new(
-		git_commit_author(commit),
-		git_commit_message_encoding(commit));
+	return rugged_signature_new(git_commit_author(commit));
 }
 
 /*
@@ -577,7 +573,7 @@ static VALUE rb_git_commit_to_mbox(int argc, VALUE *argv, VALUE self)
 
 	if (error) goto cleanup;
 
-	rb_email_patch = rb_enc_str_new(email_patch.ptr, email_patch.size, rb_utf8_encoding());
+	rb_email_patch = rb_str_new(email_patch.ptr, email_patch.size);
 
 	cleanup:
 
@@ -598,9 +594,6 @@ static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field)
 {
 	git_buf header_field = { 0 };
 	git_commit *commit = NULL;
-
-	const char *encoding_name;
-	rb_encoding *encoding = rb_utf8_encoding();
 	VALUE rb_result;
 
 	int error;
@@ -617,11 +610,7 @@ static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field)
 		rugged_exception_check(error);
 	}
 
-	encoding_name = git_commit_message_encoding(commit);
-	if (encoding_name != NULL)
-		encoding = rb_enc_find(encoding_name);
-
-	rb_result = rb_enc_str_new(header_field.ptr, header_field.size, encoding);
+	rb_result = rb_str_new(header_field.ptr, header_field.size);
 	git_buf_free(&header_field);
 	return rb_result;
 }
@@ -640,7 +629,7 @@ static VALUE rb_git_commit_header(VALUE self)
 	Data_Get_Struct(self, git_commit, commit);
 
 	raw_header = git_commit_raw_header(commit);
-	return rb_str_new_utf8(raw_header);
+	return rb_str_new2(raw_header);
 }
 
 /*
@@ -753,7 +742,7 @@ cleanup:
 
 	rugged_exception_check(error);
 
-	ret = rb_str_new_utf8(buf.ptr);
+	ret = rb_str_new(buf.ptr, buf.size);
 	git_buf_free(&buf);
 
 	return ret;

--- a/ext/rugged/rugged_config.c
+++ b/ext/rugged/rugged_config.c
@@ -105,7 +105,7 @@ static VALUE rb_git_config_get(VALUE self, VALUE rb_key)
 		return Qnil;
 
 	rugged_exception_check(error);
-	rb_result = rb_str_new_utf8(buf.ptr);
+	rb_result = rb_str_new(buf.ptr, buf.size);
 	git_buf_free(&buf);
 
 	return rb_result;
@@ -188,15 +188,15 @@ static VALUE rb_git_config_delete(VALUE self, VALUE rb_key)
 
 static int cb_config__each_key(const git_config_entry *entry, void *opaque)
 {
-	rb_funcall((VALUE)opaque, rb_intern("call"), 1, rb_str_new_utf8(entry->name));
+	rb_funcall((VALUE)opaque, rb_intern("call"), 1, rb_str_new2(entry->name));
 	return GIT_OK;
 }
 
 static int cb_config__each_pair(const git_config_entry *entry, void *opaque)
 {
 	rb_funcall((VALUE)opaque, rb_intern("call"), 2,
-		rb_str_new_utf8(entry->name),
-		rb_str_new_utf8(entry->value)
+		rb_str_new2(entry->name),
+		rb_str_new2(entry->value)
 	);
 
 	return GIT_OK;
@@ -205,8 +205,8 @@ static int cb_config__each_pair(const git_config_entry *entry, void *opaque)
 static int cb_config__to_hash(const git_config_entry *entry, void *opaque)
 {
 	rb_hash_aset((VALUE)opaque,
-		rb_str_new_utf8(entry->name),
-		rb_str_new_utf8(entry->value)
+		rb_str_new2(entry->name),
+		rb_str_new2(entry->value)
 	);
 
 	return GIT_OK;

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -530,7 +530,7 @@ static VALUE rb_git_indexentry_fromC(const git_index_entry *entry)
 
 	rb_entry = rb_hash_new();
 
-	rb_hash_aset(rb_entry, CSTR2SYM("path"), rb_str_new_utf8(entry->path));
+	rb_hash_aset(rb_entry, CSTR2SYM("path"), rb_str_new2(entry->path));
 	rb_hash_aset(rb_entry, CSTR2SYM("oid"), rugged_create_oid(&entry->id));
 
 	rb_hash_aset(rb_entry, CSTR2SYM("dev"), INT2FIX(entry->dev));

--- a/ext/rugged/rugged_note.c
+++ b/ext/rugged/rugged_note.c
@@ -29,14 +29,7 @@ extern VALUE rb_cRuggedObject;
 
 static VALUE rugged_git_note_message(const git_note *note)
 {
-	const char *message;
-	message = git_note_message(note);
-
-	/*
-	 * assume the note message is utf8 compatible, because that's
-	 * the sensible thing to do.
-	 */
-	return rb_str_new_utf8(message);
+	return rb_str_new2(git_note_message(note));
 }
 
 static VALUE rugged_git_note_oid(const git_note* note)
@@ -358,7 +351,7 @@ static VALUE rb_git_note_default_ref_GET(VALUE self)
 		git_note_default_ref(&ref_name, repo)
 	);
 
-	rb_result = rb_enc_str_new(ref_name.ptr, ref_name.size, rb_utf8_encoding());
+	rb_result = rb_str_new(ref_name.ptr, ref_name.size);
 
 	git_buf_free(&ref_name);
 

--- a/ext/rugged/rugged_rebase.c
+++ b/ext/rugged/rugged_rebase.c
@@ -243,7 +243,7 @@ static VALUE rb_git_rebase_next(VALUE self)
 	}
 
 	if (operation->exec) {
-		val = rb_str_new_utf8(operation->exec);
+		val = rb_str_new2(operation->exec);
 		rb_hash_aset(hash, CSTR2SYM("exec"), val);
 	}
 

--- a/ext/rugged/rugged_reference.c
+++ b/ext/rugged/rugged_reference.c
@@ -105,7 +105,7 @@ static VALUE rb_git_ref_peel(VALUE self)
 	} else {
 		git_oid_tostr(oid, sizeof(oid), git_object_id(object));
 		git_object_free(object);
-		return rb_str_new_utf8(oid);
+		return rb_str_new2(oid);
 	}
 }
 
@@ -177,7 +177,7 @@ static VALUE rb_git_ref_target_id(VALUE self)
 	if (git_reference_type(ref) == GIT_REF_OID) {
 		return rugged_create_oid(git_reference_target(ref));
 	} else {
-		return rb_str_new_utf8(git_reference_symbolic_target(ref));
+		return rb_str_new2(git_reference_symbolic_target(ref));
 	}
 }
 
@@ -219,7 +219,7 @@ static VALUE rb_git_ref_name(VALUE self)
 {
 	git_reference *ref;
 	Data_Get_Struct(self, git_reference, ref);
-	return rb_str_new_utf8(git_reference_name(ref));
+	return rb_str_new2(git_reference_name(ref));
 }
 
 /*
@@ -266,11 +266,11 @@ static VALUE reflog_entry_new(const git_reflog_entry *entry)
 
 	rb_hash_aset(rb_entry,
 		CSTR2SYM("committer"),
-		rugged_signature_new(git_reflog_entry_committer(entry), NULL)
+		rugged_signature_new(git_reflog_entry_committer(entry))
 	);
 
 	if ((message = git_reflog_entry_message(entry)) != NULL) {
-		rb_hash_aset(rb_entry, CSTR2SYM("message"), rb_str_new_utf8(message));
+		rb_hash_aset(rb_entry, CSTR2SYM("message"), rb_str_new2(message));
 	}
 
 	return rb_entry;

--- a/ext/rugged/rugged_reference_collection.c
+++ b/ext/rugged/rugged_reference_collection.c
@@ -156,7 +156,7 @@ static VALUE rb_git_reference_collection__each(int argc, VALUE *argv, VALUE self
 	if (only_names) {
 		const char *ref_name;
 		while (!exception && (error = git_reference_next_name(&ref_name, iter)) == GIT_OK) {
-			rb_protect(rb_yield, rb_str_new_utf8(ref_name), &exception);
+			rb_protect(rb_yield, rb_str_new2(ref_name), &exception);
 		}
 	} else {
 		git_reference *ref;

--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -73,7 +73,7 @@ static int push_update_reference_cb(const char *refname, const char *status, voi
 	struct rugged_remote_cb_payload *payload = data;
 
 	if (status != NULL)
-		rb_hash_aset(payload->result, rb_str_new_utf8(refname), rb_str_new_utf8(status));
+		rb_hash_aset(payload->result, rb_str_new2(refname), rb_str_new2(status));
 
 	return GIT_OK;
 }
@@ -87,7 +87,7 @@ static int update_tips_cb(const char *refname, const git_oid *src, const git_oid
 		return 0;
 
 	rb_ary_push(args, payload->update_tips);
-	rb_ary_push(args, rb_str_new_utf8(refname));
+	rb_ary_push(args, rb_str_new2(refname));
 	rb_ary_push(args, git_oid_iszero(src) ? Qnil : rugged_create_oid(src));
 	rb_ary_push(args, git_oid_iszero(dest) ? Qnil : rugged_create_oid(dest));
 
@@ -225,7 +225,7 @@ static VALUE rugged_rhead_new(const git_remote_head *head)
 	rb_hash_aset(rb_head, CSTR2SYM("oid"), rugged_create_oid(&head->oid));
 	rb_hash_aset(rb_head, CSTR2SYM("loid"),
 			git_oid_iszero(&head->loid) ? Qnil : rugged_create_oid(&head->loid));
-	rb_hash_aset(rb_head, CSTR2SYM("name"), rb_str_new_utf8(head->name));
+	rb_hash_aset(rb_head, CSTR2SYM("name"), rb_str_new2(head->name));
 
 	return rb_head;
 }
@@ -327,7 +327,7 @@ static VALUE rb_git_remote_name(VALUE self)
 
 	name = git_remote_name(remote);
 
-	return name ? rb_str_new_utf8(name) : Qnil;
+	return name ? rb_str_new2(name) : Qnil;
 }
 
 /*
@@ -343,7 +343,7 @@ static VALUE rb_git_remote_url(VALUE self)
 	git_remote *remote;
 	Data_Get_Struct(self, git_remote, remote);
 
-	return rb_str_new_utf8(git_remote_url(remote));
+	return rb_str_new2(git_remote_url(remote));
 }
 
 /*
@@ -363,7 +363,7 @@ static VALUE rb_git_remote_push_url(VALUE self)
 	Data_Get_Struct(self, git_remote, remote);
 
 	push_url = git_remote_pushurl(remote);
-	return push_url ? rb_str_new_utf8(push_url) : Qnil;
+	return push_url ? rb_str_new2(push_url) : Qnil;
 }
 
 /*

--- a/ext/rugged/rugged_remote_collection.c
+++ b/ext/rugged/rugged_remote_collection.c
@@ -172,7 +172,7 @@ static VALUE rb_git_remote_collection__each(VALUE self, int only_names)
 
 	if (only_names) {
 		for (i = 0; !exception && i < remotes.count; ++i) {
-			rb_protect(rb_yield, rb_str_new_utf8(remotes.strings[i]), &exception);
+			rb_protect(rb_yield, rb_str_new2(remotes.strings[i]), &exception);
 		}
 	} else {
 		for (i = 0; !exception && !error && i < remotes.count; ++i) {
@@ -272,7 +272,7 @@ static VALUE rb_git_remote_collection_rename(VALUE self, VALUE rb_name_or_remote
 	rugged_exception_check(error);
 
 	for (i = exception = 0; !exception && i < problems.count; ++i) {
-		rb_protect(rb_yield, rb_str_new_utf8(problems.strings[i]), &exception);
+		rb_protect(rb_yield, rb_str_new2(problems.strings[i]), &exception);
 	}
 
 	git_strarray_free(&problems);

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -654,11 +654,11 @@ static VALUE rb_git_repo_get_ident(VALUE self)
 	);
 
 	if (name) {
-		rb_hash_aset(rb_ident, CSTR2SYM("name"), rb_str_new_utf8(name));
+		rb_hash_aset(rb_ident, CSTR2SYM("name"), rb_str_new2(name));
 	}
 
 	if (email) {
-		rb_hash_aset(rb_ident, CSTR2SYM("email"), rb_str_new_utf8(email));
+		rb_hash_aset(rb_ident, CSTR2SYM("email"), rb_str_new2(email));
 	}
 
 	return rb_ident;
@@ -832,7 +832,7 @@ static VALUE rb_git_repo_merge_analysis(int argc, VALUE *argv, VALUE self)
 /*
  *  call-seq:
  *    repo.revert_commit(revert_commit, our_commit, options = {}) -> index
- *    
+ *
  *	Reverts the given commit against the given "our" commit, producing an
  *	index that reflects the result of the revert.
  */
@@ -1382,7 +1382,7 @@ static VALUE rb_git_repo_path(VALUE self)
 	Data_Get_Struct(self, git_repository, repo);
 	path = git_repository_path(repo);
 
-	return path ? rb_str_new_utf8(path) : Qnil;
+	return path ? rb_str_new2(path) : Qnil;
 }
 
 /*
@@ -1406,7 +1406,7 @@ static VALUE rb_git_repo_workdir(VALUE self)
 	Data_Get_Struct(self, git_repository, repo);
 	workdir = git_repository_workdir(repo);
 
-	return workdir ? rb_str_new_utf8(workdir) : Qnil;
+	return workdir ? rb_str_new2(workdir) : Qnil;
 }
 
 /*
@@ -1522,7 +1522,7 @@ static VALUE flags_to_rb(unsigned int flags)
 static int rugged__status_cb(const char *path, unsigned int flags, void *payload)
 {
 	rb_funcall((VALUE)payload, rb_intern("call"), 2,
-		rb_str_new_utf8(path), flags_to_rb(flags)
+		rb_str_new2(path), flags_to_rb(flags)
 	);
 
 	return GIT_OK;
@@ -1804,7 +1804,7 @@ static VALUE rb_git_repo_get_namespace(VALUE self)
 	Data_Get_Struct(self, git_repository, repo);
 
 	namespace = git_repository_get_namespace(repo);
-	return namespace ? rb_str_new_utf8(namespace) : Qnil;
+	return namespace ? rb_str_new2(namespace) : Qnil;
 }
 
 /*
@@ -1872,7 +1872,7 @@ static VALUE rb_git_repo_default_signature(VALUE self) {
 
 	rugged_exception_check(error);
 
-	rb_signature = rugged_signature_new(signature, NULL);
+	rb_signature = rugged_signature_new(signature);
 	git_signature_free(signature);
 	return rb_signature;
 }

--- a/ext/rugged/rugged_settings.c
+++ b/ext/rugged/rugged_settings.c
@@ -53,7 +53,7 @@ static VALUE get_search_path(int level)
 
 	rugged_exception_check(git_libgit2_opts(GIT_OPT_GET_SEARCH_PATH, level, &buf));
 
-	ret = rb_str_new_utf8(buf.ptr);
+	ret = rb_str_new(buf.ptr, buf.size);
 	git_buf_free(&buf);
 
 	return ret;

--- a/ext/rugged/rugged_signature.c
+++ b/ext/rugged/rugged_signature.c
@@ -24,13 +24,9 @@
 
 #include "rugged.h"
 
-VALUE rugged_signature_new(const git_signature *sig, const char *encoding_name)
+VALUE rugged_signature_new(const git_signature *sig)
 {
 	VALUE rb_sig, rb_time;
-	rb_encoding *encoding = rb_utf8_encoding();
-
-	if (encoding_name != NULL)
-		encoding = rb_enc_find(encoding_name);
 
 	rb_sig = rb_hash_new();
 
@@ -42,10 +38,10 @@ VALUE rugged_signature_new(const git_signature *sig, const char *encoding_name)
 	);
 
 	rb_hash_aset(rb_sig, CSTR2SYM("name"),
-		rb_enc_str_new(sig->name, strlen(sig->name), encoding));
+		rb_str_new(sig->name, strlen(sig->name)));
 
 	rb_hash_aset(rb_sig, CSTR2SYM("email"),
-		rb_enc_str_new(sig->email, strlen(sig->email), encoding));
+		rb_str_new(sig->email, strlen(sig->email)));
 
 	rb_hash_aset(rb_sig, CSTR2SYM("time"), rb_time);
 

--- a/ext/rugged/rugged_submodule.c
+++ b/ext/rugged/rugged_submodule.c
@@ -535,7 +535,7 @@ static VALUE rb_git_submodule_name(VALUE self)
 
 	name = git_submodule_name(submodule);
 
-	return rb_str_new_utf8(name);
+	return rb_str_new2(name);
 }
 
 /*
@@ -554,7 +554,7 @@ static VALUE rb_git_submodule_url(VALUE self)
 
 	url = git_submodule_url(submodule);
 
-	return url ? rb_str_new_utf8(url) : Qnil;
+	return url ? rb_str_new2(url) : Qnil;
 }
 
 /*
@@ -575,7 +575,7 @@ static VALUE rb_git_submodule_path(VALUE self)
 
 	path = git_submodule_path(submodule);
 
-	return rb_str_new_utf8(path);
+	return rb_str_new2(path);
 }
 
 #define RB_GIT_OID_GETTER(_klass, _attribute) \

--- a/ext/rugged/rugged_tag.c
+++ b/ext/rugged/rugged_tag.c
@@ -112,7 +112,7 @@ static VALUE rb_git_tag_annotation_name(VALUE self)
 	git_tag *tag;
 	Data_Get_Struct(self, git_tag, tag);
 
-	return rb_str_new_utf8(git_tag_name(tag));
+	return rb_str_new2(git_tag_name(tag));
 }
 
 /*
@@ -136,7 +136,7 @@ static VALUE rb_git_tag_annotation_tagger(VALUE self)
 	if (!tagger)
 		return Qnil;
 
-	return rugged_signature_new(tagger, NULL);
+	return rugged_signature_new(tagger);
 }
 
 /*
@@ -159,7 +159,7 @@ static VALUE rb_git_tag_annotation_message(VALUE self)
 	if (!message)
 		return Qnil;
 
-	return rb_str_new_utf8(message);
+	return rb_str_new2(message);
 }
 
 /*

--- a/ext/rugged/rugged_tag_collection.c
+++ b/ext/rugged/rugged_tag_collection.c
@@ -273,11 +273,11 @@ static VALUE each_tag(int argc, VALUE *argv, VALUE self, int tag_names_only)
 
 	if (tag_names_only) {
 		for (i = 0; !exception && i < tags.count; ++i)
-			rb_protect(rb_yield, rb_str_new_utf8(tags.strings[i]), &exception);
+			rb_protect(rb_yield, rb_str_new2(tags.strings[i]), &exception);
 	} else {
 		for (i = 0; !exception && i < tags.count; ++i) {
 			rb_protect(rb_yield, rb_git_tag_collection_aref(self,
-				rb_str_new_utf8(tags.strings[i])), &exception);
+				rb_str_new2(tags.strings[i])), &exception);
 		}
 	}
 

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -44,7 +44,7 @@ static VALUE rb_git_treeentry_fromC(const git_tree_entry *entry)
 
 	rb_entry = rb_hash_new();
 
-	rb_hash_aset(rb_entry, CSTR2SYM("name"), rb_str_new_utf8(git_tree_entry_name(entry)));
+	rb_hash_aset(rb_entry, CSTR2SYM("name"), rb_str_new2(git_tree_entry_name(entry)));
 	rb_hash_aset(rb_entry, CSTR2SYM("oid"), rugged_create_oid(git_tree_entry_id(entry)));
 
 	rb_hash_aset(rb_entry, CSTR2SYM("filemode"), INT2FIX(git_tree_entry_filemode(entry)));
@@ -257,7 +257,7 @@ static int rugged__treewalk_cb(const char *root, const git_tree_entry *entry, vo
 
 	VALUE rb_result, rb_args = rb_ary_new2(2);
 
-	rb_ary_push(rb_args, rb_str_new_utf8(root));
+	rb_ary_push(rb_args, rb_str_new2(root));
 	rb_ary_push(rb_args, rb_git_treeentry_fromC(entry));
 
 	rb_result = rb_protect(rb_yield_splat, rb_args, exception);

--- a/test/branch_test.rb
+++ b/test/branch_test.rb
@@ -116,8 +116,8 @@ class BranchTest < Rugged::TestCase
     new_branch = @repo.create_branch(branch_name, "5b5b025afb0b4c913b4c338a42934a3863bf3644")
     refute_nil new_branch
 
-    assert_equal branch_name.force_encoding("ascii-8bit"), new_branch.name
-    assert_equal "refs/heads/#{branch_name}".force_encoding("ascii-8bit"), new_branch.canonical_name
+    assert_equal branch_name.b, new_branch.name
+    assert_equal "refs/heads/#{branch_name}".b, new_branch.canonical_name
 
     refute_nil @repo.branches[branch_name]
   end
@@ -134,8 +134,8 @@ class BranchTest < Rugged::TestCase
       expected_name = branch_name
     end
 
-    assert_equal expected_name.force_encoding("ascii-8bit"), new_branch.name
-    assert_equal "refs/heads/#{expected_name}".force_encoding("ascii-8bit"), new_branch.canonical_name
+    assert_equal expected_name.b, new_branch.name
+    assert_equal "refs/heads/#{expected_name}".b, new_branch.canonical_name
 
     refute_nil @repo.branches[branch_name]
     refute_nil @repo.branches[expected_name]

--- a/test/branch_test.rb
+++ b/test/branch_test.rb
@@ -116,8 +116,8 @@ class BranchTest < Rugged::TestCase
     new_branch = @repo.create_branch(branch_name, "5b5b025afb0b4c913b4c338a42934a3863bf3644")
     refute_nil new_branch
 
-    assert_equal branch_name, new_branch.name
-    assert_equal "refs/heads/#{branch_name}", new_branch.canonical_name
+    assert_equal branch_name.force_encoding("ascii-8bit"), new_branch.name
+    assert_equal "refs/heads/#{branch_name}".force_encoding("ascii-8bit"), new_branch.canonical_name
 
     refute_nil @repo.branches[branch_name]
   end
@@ -134,8 +134,8 @@ class BranchTest < Rugged::TestCase
       expected_name = branch_name
     end
 
-    assert_equal expected_name, new_branch.name
-    assert_equal "refs/heads/#{expected_name}", new_branch.canonical_name
+    assert_equal expected_name.force_encoding("ascii-8bit"), new_branch.name
+    assert_equal "refs/heads/#{expected_name}".force_encoding("ascii-8bit"), new_branch.canonical_name
 
     refute_nil @repo.branches[branch_name]
     refute_nil @repo.branches[expected_name]

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -179,8 +179,8 @@ class ReferenceWriteTest < Rugged::TestCase
     new_ref = @repo.references.create(ref_name, "5b5b025afb0b4c913b4c338a42934a3863bf3644")
     refute_nil new_ref
 
-    assert_equal ref_name, new_ref.name
-    assert_equal ref_name, new_ref.canonical_name
+    assert_equal ref_name.force_encoding("ascii-8bit"), new_ref.name
+    assert_equal ref_name.force_encoding("ascii-8bit"), new_ref.canonical_name
 
     refute_nil @repo.references[ref_name]
   end
@@ -197,8 +197,8 @@ class ReferenceWriteTest < Rugged::TestCase
       expected_name = ref_name
     end
 
-    assert_equal expected_name, new_ref.name
-    assert_equal expected_name, new_ref.canonical_name
+    assert_equal expected_name.force_encoding("ascii-8bit"), new_ref.name
+    assert_equal expected_name.force_encoding("ascii-8bit"), new_ref.canonical_name
 
     refute_nil @repo.references[ref_name]
     refute_nil @repo.references[expected_name]
@@ -217,8 +217,8 @@ class ReferenceWriteTest < Rugged::TestCase
       expected_name = ref_name
     end
 
-    assert_equal expected_name, new_ref.name
-    assert_equal expected_name, new_ref.canonical_name
+    assert_equal expected_name.force_encoding("ascii-8bit"), new_ref.name
+    assert_equal expected_name.force_encoding("ascii-8bit"), new_ref.canonical_name
 
     refute_nil @repo.references[ref_name]
     refute_nil @repo.references[expected_name]
@@ -273,8 +273,8 @@ class ReferenceWriteTest < Rugged::TestCase
     ref1 = @repo.references.create("refs/heads/Ångström", "refs/heads/master")
     ref2 = @repo.references.create("refs/heads/foobar", "refs/heads/Ångström")
 
-    assert_equal "refs/heads/Ångström", ref1.name
-    assert_equal "refs/heads/Ångström", ref2.target_id
+    assert_equal "refs/heads/Ångström".force_encoding("ascii-8bit"), ref1.name
+    assert_equal "refs/heads/Ångström".force_encoding("ascii-8bit"), ref2.target_id
   end
 end
 

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -174,51 +174,51 @@ class ReferenceWriteTest < Rugged::TestCase
   end
 
   def test_create_unicode_reference_nfc
-    ref_name = "refs/heads/\xC3\x85\x73\x74\x72\xC3\xB6\x6D"
+    ref_name = "refs/heads/\xC3\x85\x73\x74\x72\xC3\xB6\x6D".b
 
     new_ref = @repo.references.create(ref_name, "5b5b025afb0b4c913b4c338a42934a3863bf3644")
     refute_nil new_ref
 
-    assert_equal ref_name.force_encoding("ascii-8bit"), new_ref.name
-    assert_equal ref_name.force_encoding("ascii-8bit"), new_ref.canonical_name
+    assert_equal ref_name, new_ref.name
+    assert_equal ref_name, new_ref.canonical_name
 
     refute_nil @repo.references[ref_name]
   end
 
   def test_create_unicode_reference_nfd
-    ref_name = "refs/heads/\x41\xCC\x8A\x73\x74\x72\x6F\xCC\x88\x6D"
+    ref_name = "refs/heads/\x41\xCC\x8A\x73\x74\x72\x6F\xCC\x88\x6D".b
 
     new_ref = @repo.references.create(ref_name, "5b5b025afb0b4c913b4c338a42934a3863bf3644")
     refute_nil new_ref
 
     if @repo.config["core.precomposeunicode"] == "true"
-      expected_name = "refs/heads/\xC3\x85\x73\x74\x72\xC3\xB6\x6D"
+      expected_name = "refs/heads/\xC3\x85\x73\x74\x72\xC3\xB6\x6D".b
     else
       expected_name = ref_name
     end
 
-    assert_equal expected_name.force_encoding("ascii-8bit"), new_ref.name
-    assert_equal expected_name.force_encoding("ascii-8bit"), new_ref.canonical_name
+    assert_equal expected_name, new_ref.name
+    assert_equal expected_name, new_ref.canonical_name
 
     refute_nil @repo.references[ref_name]
     refute_nil @repo.references[expected_name]
   end
 
   def test_rename_unicode_reference_nfd
-    ref_name = "refs/heads/\x41\xCC\x8A\x73\x74\x72\x6F\xCC\x88\x6D"
+    ref_name = "refs/heads/\x41\xCC\x8A\x73\x74\x72\x6F\xCC\x88\x6D".b
 
     @repo.references.create("refs/heads/unit_test", "36060c58702ed4c2a40832c51758d5344201d89a")
     new_ref = @repo.references.rename("refs/heads/unit_test", ref_name)
     refute_nil new_ref
 
     if @repo.config["core.precomposeunicode"] == "true"
-      expected_name = "refs/heads/\xC3\x85\x73\x74\x72\xC3\xB6\x6D"
+      expected_name = "refs/heads/\xC3\x85\x73\x74\x72\xC3\xB6\x6D".b
     else
       expected_name = ref_name
     end
 
-    assert_equal expected_name.force_encoding("ascii-8bit"), new_ref.name
-    assert_equal expected_name.force_encoding("ascii-8bit"), new_ref.canonical_name
+    assert_equal expected_name, new_ref.name
+    assert_equal expected_name, new_ref.canonical_name
 
     refute_nil @repo.references[ref_name]
     refute_nil @repo.references[expected_name]
@@ -273,8 +273,8 @@ class ReferenceWriteTest < Rugged::TestCase
     ref1 = @repo.references.create("refs/heads/Ångström", "refs/heads/master")
     ref2 = @repo.references.create("refs/heads/foobar", "refs/heads/Ångström")
 
-    assert_equal "refs/heads/Ångström".force_encoding("ascii-8bit"), ref1.name
-    assert_equal "refs/heads/Ångström".force_encoding("ascii-8bit"), ref2.target_id
+    assert_equal "refs/heads/Ångström".b, ref1.name
+    assert_equal "refs/heads/Ångström".b, ref2.target_id
   end
 end
 

--- a/test/status_test.rb
+++ b/test/status_test.rb
@@ -18,7 +18,7 @@ class LibgitRepositoryStatusTest < Rugged::TestCase
     "subdir/deleted_file" => [:worktree_deleted],
     "subdir/modified_file" => [:worktree_modified],
     "subdir/new_file" => [:worktree_new],
-    "\xe8\xbf\x99" => [:worktree_new]
+    "\xe8\xbf\x99".force_encoding('ascii-8bit') => [:worktree_new]
   }
 
   STATUSES.each do |file,expected_statuses|

--- a/test/status_test.rb
+++ b/test/status_test.rb
@@ -18,7 +18,7 @@ class LibgitRepositoryStatusTest < Rugged::TestCase
     "subdir/deleted_file" => [:worktree_deleted],
     "subdir/modified_file" => [:worktree_modified],
     "subdir/new_file" => [:worktree_new],
-    "\xe8\xbf\x99".force_encoding('ascii-8bit') => [:worktree_new]
+    "\xe8\xbf\x99".b => [:worktree_new]
   }
 
   STATUSES.each do |file,expected_statuses|


### PR DESCRIPTION
Almost all of the string used inside a git repository are encoding unaware.

This includes things like refnames, commit metadata, path names, and a lot more. The exception is commit messages, which can optionally be tagged with an encoding through a header in the commit metadata. We should only tag strings with an encoding if we know the exact encoding, and otherwise tag them as ASCII 8-BIT (binary).
