### PR TITLE
Fix Index#merge_file with custom labels

### DIFF
--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -960,19 +960,19 @@ void rugged_parse_merge_file_options(git_merge_file_options *opts, VALUE rb_opti
 
 		rb_value = rb_hash_aref(rb_options, CSTR2SYM("ancestor_label"));
 		if (!NIL_P(rb_value)) {
-			Check_Type(rb_value, T_FIXNUM);
+			Check_Type(rb_value, T_STRING);
 			opts->ancestor_label = StringValueCStr(rb_value);
 		}
 
 		rb_value = rb_hash_aref(rb_options, CSTR2SYM("our_label"));
 		if (!NIL_P(rb_value)) {
-			Check_Type(rb_value, T_FIXNUM);
+			Check_Type(rb_value, T_STRING);
 			opts->our_label = StringValueCStr(rb_value);
 		}
 
 		rb_value = rb_hash_aref(rb_options, CSTR2SYM("their_label"));
 		if (!NIL_P(rb_value)) {
-			Check_Type(rb_value, T_FIXNUM);
+			Check_Type(rb_value, T_STRING);
 			opts->their_label = StringValueCStr(rb_value);
 		}
 

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -282,6 +282,13 @@ class IndexMergeFileTest < Rugged::TestCase
     assert_equal merge_file_result[:data], "<<<<<<< conflicts-one.txt\nThis is most certainly a conflict!\n=======\nThis is a conflict!!!\n>>>>>>> conflicts-one.txt\n"
   end
 
+  def test_merge_file_with_labels
+    merge_file_result = @repo.index.merge_file("conflicts-one.txt", our_label: "ours", their_label: "theirs")
+
+    assert !merge_file_result[:automergeable]
+    assert_equal merge_file_result[:path], "conflicts-one.txt"
+    assert_equal merge_file_result[:data], "<<<<<<< ours\nThis is most certainly a conflict!\n=======\nThis is a conflict!!!\n>>>>>>> theirs\n"
+  end
 end
 
 class IndexRepositoryTest < Rugged::TestCase


### PR DESCRIPTION
Previously this required that the custom labels (for ours, theirs, and ancestor) were fixnums instead of strings, which contradicts the docs (and doesn't make a lot of sense :smiley: ).