### PR TITLE
Add Rugged::Diff::Patch#bytesize

### DIFF
--- a/ext/rugged/rugged_patch.c
+++ b/ext/rugged/rugged_patch.c
@@ -190,6 +190,36 @@ static VALUE rb_git_diff_patch_lines(VALUE self)
 	return INT2FIX(context + adds + dels);
 }
 
+static VALUE rb_git_diff_patch_bytesize(int argc, VALUE *argv, VALUE self)
+{
+	git_patch *patch;
+	size_t bytesize;
+	VALUE rb_options;
+	int options[3];
+	Data_Get_Struct(self, git_patch, patch);
+
+	memset(options, 0, sizeof(options));
+
+	rb_scan_args(argc, argv, "0:", &rb_options);
+	if (!NIL_P(rb_options)) {
+		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("include_context")))) {
+			options[0] = 1;
+		}
+
+		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("include_hunk_headers")))) {
+			options[1] = 1;
+		}
+
+		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("include_file_headers")))) {
+			options[2] = 1;
+		}
+	}
+
+	bytesize = git_patch_size(patch, options[0], options[1], options[2]);
+
+	return INT2FIX(bytesize);
+}
+
 static int patch_print_cb(
 	const git_diff_delta *delta,
 	const git_diff_hunk *hunk,
@@ -235,6 +265,7 @@ void Init_rugged_patch(void)
 
 	rb_define_method(rb_cRuggedPatch, "stat", rb_git_diff_patch_stat, 0);
 	rb_define_method(rb_cRuggedPatch, "lines", rb_git_diff_patch_lines, 0);
+	rb_define_method(rb_cRuggedPatch, "bytesize", rb_git_diff_patch_bytesize, -1);
 
 	rb_define_method(rb_cRuggedPatch, "delta", rb_git_diff_patch_delta, 0);
 

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -73,10 +73,12 @@ class RepoDiffTest < Rugged::TestCase
     patches = diff.patches
     hunks = patches.map(&:hunks).flatten
     lines = hunks.map(&:lines).flatten
+    bytesize = patches.inject(0) {|n, p| n += p.bytesize(include_context: true)}
 
     assert_equal 5, diff.size
     assert_equal 5, deltas.size
     assert_equal 5, patches.size
+    assert_equal 975, bytesize
 
     assert_equal 2, deltas.select(&:added?).size
     assert_equal 1, deltas.select(&:deleted?).size


### PR DESCRIPTION
Similar to `Rugged::Diff::Patch#lines`, this returns the number of bytes in the patch text.

It accepts 3 optional boolean, keyword arguments:

* `include_context` - include context lines in the byte count
* `include_hunk_headers` - include hunk header lines in the byte count
* `include_file_headers` - include file header lines in the byte count

This needs inline-documentation written still but wanted to get this open for review early in case any changes to the API will mean only writing the docs once.

