### PR TITLE
Change Rugged::Patch#lines to accept count exclusion options

### DIFF
--- a/ext/rugged/rugged_patch.c
+++ b/ext/rugged/rugged_patch.c
@@ -233,16 +233,16 @@ static VALUE rb_git_diff_patch_lines(int argc, VALUE *argv, VALUE self)
  *
  *  The following options can be passed in the +options+ Hash:
  *
- *  :include_context ::
- *    Boolean value specifying that context lines should be included when
+ *  :exclude_context ::
+ *    Boolean value specifying that context lines should be excluded when
  *    counting the number of bytes in the patch.
  *
- *  :include_hunk_headers ::
- *    Boolean value specifying that hunk headers should be included when
+ *  :exclude_hunk_headers ::
+ *    Boolean value specifying that hunk headers should be excluded when
  *    counting the number of bytes in the patch.
  *
- *  :include_file_headers ::
- *    Boolean value specifying that file headers should be included when
+ *  :exclude_file_headers ::
+ *    Boolean value specifying that file headers should be excluded when
  *    counting the number of bytes in the patch.
  *
  *  Returns the number of bytes in the patch, depending on which options are
@@ -253,27 +253,29 @@ static VALUE rb_git_diff_patch_bytesize(int argc, VALUE *argv, VALUE self)
 	git_patch *patch;
 	size_t bytesize;
 	VALUE rb_options;
-	int options[3];
+	int include_context, include_hunk_headers, include_file_headers;
 	Data_Get_Struct(self, git_patch, patch);
 
-	memset(options, 0, sizeof(options));
+	include_context = 1;
+	include_hunk_headers = 1;
+	include_file_headers = 1;
 
 	rb_scan_args(argc, argv, "0:", &rb_options);
 	if (!NIL_P(rb_options)) {
-		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("include_context")))) {
-			options[0] = 1;
+		if (rb_hash_aref(rb_options, CSTR2SYM("include_context")) == Qfalse) {
+			include_context = 0;
 		}
 
-		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("include_hunk_headers")))) {
-			options[1] = 1;
+		if (rb_hash_aref(rb_options, CSTR2SYM("include_hunk_headers")) == Qfalse) {
+			include_hunk_headers = 0;
 		}
 
-		if (RTEST(rb_hash_aref(rb_options, CSTR2SYM("include_file_headers")))) {
-			options[2] = 1;
+		if (rb_hash_aref(rb_options, CSTR2SYM("include_file_headers")) == Qfalse) {
+			include_file_headers = 0;
 		}
 	}
 
-	bytesize = git_patch_size(patch, options[0], options[1], options[2]);
+	bytesize = git_patch_size(patch, include_context, include_hunk_headers, include_file_headers);
 
 	return INT2FIX(bytesize);
 }

--- a/ext/rugged/rugged_patch.c
+++ b/ext/rugged/rugged_patch.c
@@ -226,7 +226,27 @@ static VALUE rb_git_diff_patch_lines(int argc, VALUE *argv, VALUE self)
 
 	return INT2FIX(total_out);
 }
-
+/*
+ *  call-seq:
+ *    patch.bytesize(options = {}) -> int
+ *
+ *  The following options can be passed in the +options+ Hash:
+ *
+ *  :include_context ::
+ *    Boolean value specifying that context lines should be included when
+ *    counting the number of bytes in the patch.
+ *
+ *  :include_hunk_headers ::
+ *    Boolean value specifying that hunk headers should be included when
+ *    counting the number of bytes in the patch.
+ *
+ *  :include_file_headers ::
+ *    Boolean value specifying that file headers should be included when
+ *    counting the number of bytes in the patch.
+ *
+ *  Returns the number of bytes in the patch, depending on which options are
+ *  specified.
+ */
 static VALUE rb_git_diff_patch_bytesize(int argc, VALUE *argv, VALUE self)
 {
 	git_patch *patch;

--- a/ext/rugged/rugged_patch.c
+++ b/ext/rugged/rugged_patch.c
@@ -191,7 +191,8 @@ static VALUE rb_git_diff_patch_stat(VALUE self)
  *    Boolean value specifying that deletion line counts should be excluded from
  *    the returned total.
  *
- *  Returns the total number of lines in the patch.
+ *  Returns the total number of lines in the patch, depending on the options
+ *  specified.
  */
 static VALUE rb_git_diff_patch_lines(int argc, VALUE *argv, VALUE self)
 {

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -373,15 +373,15 @@ class TreeToWorkdirDiffTest < Rugged::TestCase
 
     # expected per-file values from the diff --stat output plus total lines
     expected_patch_stat = [
-      [ 0, 1, 1 ], [ 1, 0, 2 ], [ 1, 0, 2 ], [ 0, 1, 1 ], [ 2, 0, 3 ],
-      [ 0, 1, 1 ], [ 0, 1, 1 ], [ 1, 0, 1 ], [ 2, 0, 2 ], [ 0, 1, 1 ],
-      [ 1, 0, 2 ]
+      [ 0, 1, 1, 1 ], [ 1, 0, 2, 1 ], [ 1, 0, 2, 1 ], [ 0, 1, 1, 1 ], [ 2, 0, 3, 2 ],
+      [ 0, 1, 1, 1 ], [ 0, 1, 1, 1 ], [ 1, 0, 1, 1 ], [ 2, 0, 2, 2 ], [ 0, 1, 1, 1 ],
+      [ 1, 0, 2, 1 ]
     ]
 
     diff.each_patch do |patch|
       next if [:unmodified, :ignored, :untracked].include? patch.delta.status
 
-      expected_adds, expected_dels, expected_lines = expected_patch_stat.shift
+      expected_adds, expected_dels, expected_lines, lines_wo_context = expected_patch_stat.shift
 
       actual_adds, actual_dels = patch.stat
 
@@ -390,6 +390,7 @@ class TreeToWorkdirDiffTest < Rugged::TestCase
       assert_equal expected_adds + expected_dels, patch.changes
 
       assert_equal expected_lines, patch.lines
+      assert_equal lines_wo_context, patch.lines(exclude_context: true)
     end
   end
 end

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -73,12 +73,12 @@ class RepoDiffTest < Rugged::TestCase
     patches = diff.patches
     hunks = patches.map(&:hunks).flatten
     lines = hunks.map(&:lines).flatten
-    bytesize = patches.inject(0) {|n, p| n += p.bytesize(include_context: true)}
+    bytesize = patches.inject(0) {|n, p| n += p.bytesize(include_context: false)}
 
     assert_equal 5, diff.size
     assert_equal 5, deltas.size
     assert_equal 5, patches.size
-    assert_equal 975, bytesize
+    assert_equal 1589, bytesize
 
     assert_equal 2, deltas.select(&:added?).size
     assert_equal 1, deltas.select(&:deleted?).size


### PR DESCRIPTION
This is related to https://github.com/libgit2/rugged/pull/622 which added the `Rugged::Patch#bytesize` - which itself accepts options for what to include in the counts.

But, since `Rugged::Patch#lines` already existed and included the _total_ counts of context, addition and deletion lines - the options added to that method here are **exclusionary**. Meaning by default this method will continue to return the same value it always has, unless  you specify otherwise.

This feels annoyingly inconsistent with `Rugged::Patch#bytesize` but unless we're willing to break the API I'm not sure what else to do ;)

Thoughts?