### PR TITLE
Return GIT_PASSTHROUGH if credentials callback returns nill

### DIFF
--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -152,6 +152,9 @@ static int credentials_cb(
 
 	rb_protect(extract_cred, (VALUE)&args, &payload->exception);
 
+	if (!*cred)
+		return GIT_PASSTHROUGH;
+
 	return payload->exception ? GIT_ERROR : GIT_OK;
 }
 


### PR DESCRIPTION
Fixed #625, see libgit2/libgit2#3902 for more information. Since triggering the error condition requires connecting to a repository that requires authentication I wasn't sure what a good way to test this would be.
