### PR TITLE
Add `Rugged::Patch#header`

### DIFF
--- a/ext/rugged/rugged_patch.c
+++ b/ext/rugged/rugged_patch.c
@@ -357,9 +357,10 @@ static int patch_print_header_cb(
 
 	if (line->origin == GIT_DIFF_LINE_FILE_HDR) {
 		rb_ary_push(rb_buffer, rb_str_new(line->content, line->content_len));
+		return GIT_OK;
+	} else {
+		return GIT_ITEROVER;
 	}
-
-	return GIT_OK;
 }
 
 /*
@@ -388,10 +389,13 @@ static VALUE rb_git_diff_patch_to_s(VALUE self)
 static VALUE rb_git_diff_patch_header(VALUE self)
 {
 	git_patch *patch;
+	int error = 0;
 	VALUE rb_buffer = rb_ary_new();
 	Data_Get_Struct(self, git_patch, patch);
 
-	rugged_exception_check(git_patch_print(patch, patch_print_header_cb, (void*)rb_buffer));
+	error = git_patch_print(patch, patch_print_header_cb, (void*)rb_buffer);
+	if (error && error != GIT_ITEROVER)
+		rugged_exception_check(error);
 
 	return rb_ary_join(rb_buffer, Qnil);
 }

--- a/test/patch_test.rb
+++ b/test/patch_test.rb
@@ -76,4 +76,21 @@ EOS
 
     assert_equal 0, patch.lines(exclude_eofnl: true, exclude_additions: true, exclude_deletions: true, exclude_context: true)
   end
+
+  def test_header
+    repo = FixtureRepo.from_libgit2("diff")
+    repo.config['core.abbrev'] = 7
+
+    a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
+    b = repo.lookup("7a9e0b02e63179929fed24f0a3e0f19168114d10")
+
+    diff = a.tree.diff(b.tree, :context_lines => 0)
+
+    assert_equal <<-DIFF, diff.patches[1].header
+diff --git a/readme.txt b/readme.txt
+index 7b808f7..29ab705 100644
+--- a/readme.txt
++++ b/readme.txt
+    DIFF
+  end
 end


### PR DESCRIPTION
In some cases we might want to only generate the header of a `Rugged::Patch`, not the whole output.