### PR TITLE
Index.merge_file: raise when conflict is missing one side

### DIFF
--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -1092,6 +1092,11 @@ static VALUE rb_git_merge_file(int argc, VALUE *argv, VALUE self)
 	else
 		rugged_exception_check(error);
 
+	if (ours == NULL)
+		rb_raise(rb_eRuntimeError, "The conflict does not have a stage 2 entry");
+	else if (theirs == NULL)
+		rb_raise(rb_eRuntimeError, "The conflict does not have a stage 3 entry");
+
 	error = git_merge_file_from_index(&merge_file_result, repo, ancestor, ours, theirs, &opts);
 	rugged_exception_check(error);
 

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -289,6 +289,31 @@ class IndexMergeFileTest < Rugged::TestCase
     assert_equal merge_file_result[:path], "conflicts-one.txt"
     assert_equal merge_file_result[:data], "<<<<<<< ours\nThis is most certainly a conflict!\n=======\nThis is a conflict!!!\n>>>>>>> theirs\n"
   end
+
+  def test_merge_file_without_ancestor
+    # remove the stage 1 (ancestor), this is now an add/add conflict
+    @repo.index.remove("conflicts-one.txt", 1)
+    merge_file_result = @repo.index.merge_file("conflicts-one.txt", our_label: "ours", their_label: "theirs")
+    assert !merge_file_result[:automergeable]
+    assert_equal merge_file_result[:path], "conflicts-one.txt"
+    assert_equal merge_file_result[:data], "<<<<<<< ours\nThis is most certainly a conflict!\n=======\nThis is a conflict!!!\n>>>>>>> theirs\n"
+  end
+
+  def test_merge_file_without_ours
+    # turn this into a modify/delete conflict
+    @repo.index.remove("conflicts-one.txt", 2)
+    assert_raises RuntimeError do
+      @repo.index.merge_file("conflicts-one.txt", our_label: "ours", their_label: "theirs")
+    end
+  end
+
+  def test_merge_file_without_theirs
+    # turn this into a modify/delete conflict
+    @repo.index.remove("conflicts-one.txt", 3)
+    assert_raises RuntimeError do
+      @repo.index.merge_file("conflicts-one.txt", our_label: "ours", their_label: "theirs")
+    end
+  end
 end
 
 class IndexRepositoryTest < Rugged::TestCase


### PR DESCRIPTION
libgit2's `git_merge_file` expects and `ours` and a `theirs` side so that it can either automerge the two, or if that fails, produce a merge file with conflicts marked up.  It cannot produce anything if the ours or the theirs side is missing.  (libgit2 in fact `assert`s here.)

Raise an error in this situation instead of trying to call `libgit2` where it will undoubtedly crash.