### PR TITLE
Patch to s timeout

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -63,6 +63,7 @@ const char *RUGGED_ERROR_NAMES[] = {
 VALUE rb_mRugged;
 VALUE rb_eRuggedError;
 VALUE rb_eRuggedErrors[RUGGED_ERROR_COUNT];
+VALUE rb_eRuggedTimeoutError;
 
 static VALUE rb_mShutdownHook;
 
@@ -437,6 +438,7 @@ void Init_rugged(void)
 		int i;
 
 		rb_eRuggedError = rb_define_class_under(rb_mRugged, "Error", rb_eStandardError);
+		rb_eRuggedTimeoutError = rb_define_class_under(rb_mRugged, "TimeoutError", rb_eRuggedError);
 
 		rb_eRuggedErrors[0] = Qnil; /* 0 return value -- no exception */
 		rb_eRuggedErrors[1] = rb_define_class_under(rb_mRugged, RUGGED_ERROR_NAMES[1], rb_eNoMemError);

--- a/test/patch_test.rb
+++ b/test/patch_test.rb
@@ -52,6 +52,11 @@ index 7b808f7..29ab705 100644
 +it.!
 \\ No newline at end of file
 EOS
+
+    assert_raises(Rugged::TimeoutError) { diff.patches[1].to_s(timeout: 0.00000000001) }
+
+    # shouldn't raise anything here
+    diff.patches[1].to_s(timeout: 100)
   end
 
   def test_lines


### PR DESCRIPTION
When calculating very large patches, there is the potential for the call to hang for a while without any feedback to the caller.

Potentially this could manifest itself in one of two places:

1. Calculating the diff_hunks in the original diff
2. Translating the lines of those hunks into ruby strings

This patch addresses the latter and gives us a mechanism to bail early when the diff output is taking too long.

I'm not sure if there is a clear path to addressing a timeout in the former case, but I am open to suggestions and feedback on both ideas.

Thanks so much to @brianmario for 🍐 ing with me on this one!