### PR TITLE
Introduce `Rugged::Blob.merge_files`

### DIFF
--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -96,10 +96,12 @@ VALUE rugged_diff_hunk_new(VALUE owner, size_t hunk_idx, const git_diff_hunk *hu
 VALUE rugged_diff_line_new(const git_diff_line *line);
 VALUE rugged_remote_new(VALUE owner, git_remote *remote);
 VALUE rb_git_delta_file_fromC(const git_diff_file *file);
+VALUE rb_merge_file_result_fromC(const git_merge_file_result *results);
 
 void rugged_parse_diff_options(git_diff_options *opts, VALUE rb_options);
 void rugged_parse_merge_options(git_merge_options *opts, VALUE rb_options);
 void rugged_parse_checkout_options(git_checkout_options *opts, VALUE rb_options);
+void rugged_parse_merge_file_options(git_merge_file_options *opts, VALUE rb_options);
 
 void rugged_cred_extract(git_cred **cred, int allowed_types, VALUE rb_credential);
 

--- a/ext/rugged/rugged_blob.c
+++ b/ext/rugged/rugged_blob.c
@@ -551,55 +551,105 @@ static VALUE rb_git_blob_to_buffer(int argc, VALUE *argv, VALUE self)
 	return rb_ret;
 }
 
-static void rugged_parse_merge_file_input(git_merge_file_input *input, VALUE rb_input)
+#define RUGGED_MERGE_FILE_INPUT_INIT { GIT_MERGE_FILE_INPUT_INIT }
+
+typedef struct {
+	git_merge_file_input parent;
+	int has_id;
+	git_oid id;
+} rugged_merge_file_input;
+
+static void rugged_parse_merge_file_input(rugged_merge_file_input *input, git_repository *repo, VALUE rb_input)
 {
 	VALUE rb_value;
 
 	Check_Type(rb_input, T_HASH);
 
-	rb_value = rb_hash_aref(rb_input, CSTR2SYM("content"));
-	if (NIL_P(rb_value))
-		rb_raise(rb_eArgError, "File input must have `:content`.");
+	if (!NIL_P(rb_value = rb_hash_aref(rb_input, CSTR2SYM("content")))) {
+		input->parent.ptr = RSTRING_PTR(rb_value);
+		input->parent.size = RSTRING_LEN(rb_value);
+	} else if (!NIL_P(rb_value = rb_hash_aref(rb_input, CSTR2SYM("oid")))) {
+		if (!repo)
+			rb_raise(rb_eArgError, "Rugged repository is required when file input is `:oid`.");
 
-	input->ptr = RSTRING_PTR(rb_value);
-	input->size = RSTRING_LEN(rb_value);
+		rugged_exception_check(git_oid_fromstr(&input->id, RSTRING_PTR(rb_value)));
+		input->has_id = 1;
+	} else {
+		rb_raise(rb_eArgError, "File input must have `:content` or `:oid`.");
+	}
 
 	rb_value = rb_hash_aref(rb_input, CSTR2SYM("filemode"));
 	if (!NIL_P(rb_value))
-		input->mode = FIX2UINT(rb_value);
+		input->parent.mode = FIX2UINT(rb_value);
 
 	rb_value = rb_hash_aref(rb_input, CSTR2SYM("path"));
 	if (!NIL_P(rb_value)) {
 		Check_Type(rb_value, T_STRING);
-		input->path = RSTRING_PTR(rb_value);
+		input->parent.path = RSTRING_PTR(rb_value);
 	}
+}
+
+static int rugged_load_merge_file_input(git_blob **out, git_repository *repo, rugged_merge_file_input *input)
+{
+	int error;
+
+	if (!input->has_id)
+		return 0;
+
+	if ((error = git_blob_lookup(out, repo, &input->id)) < 0)
+		return error;
+
+	input->parent.ptr = git_blob_rawcontent(*out);
+	input->parent.size = git_blob_rawsize(*out);
+
+	return 0;
 }
 
 static VALUE rb_git_blob_merge_files(int argc, VALUE *argv, VALUE klass)
 {
-	VALUE rb_ancestor, rb_ours, rb_theirs, rb_options, rb_result;
+	VALUE rb_repo, rb_ancestor, rb_ours, rb_theirs, rb_options, rb_result;
 
-	git_merge_file_input ancestor = GIT_MERGE_FILE_INPUT_INIT,
-		ours = GIT_MERGE_FILE_INPUT_INIT,
-		theirs = GIT_MERGE_FILE_INPUT_INIT;
+	git_repository *repo = NULL;
+	rugged_merge_file_input ancestor = RUGGED_MERGE_FILE_INPUT_INIT,
+		ours = RUGGED_MERGE_FILE_INPUT_INIT,
+		theirs = RUGGED_MERGE_FILE_INPUT_INIT;
+	git_blob *ancestor_blob = NULL, *our_blob = NULL, *their_blob = NULL;
 	git_merge_file_options opts = GIT_MERGE_FILE_OPTIONS_INIT;
 	git_merge_file_result result = {0};
 	int error;
 
-	rb_scan_args(argc, argv, "31", &rb_ancestor, &rb_ours, &rb_theirs, &rb_options);
+	rb_scan_args(argc, argv, "41", &rb_repo, &rb_ancestor, &rb_ours, &rb_theirs, &rb_options);
 
-	rugged_parse_merge_file_input(&ancestor, rb_ancestor);
-	rugged_parse_merge_file_input(&ours, rb_ours);
-	rugged_parse_merge_file_input(&theirs, rb_theirs);
+	if (!NIL_P(rb_repo)) {
+		rugged_check_repo(rb_repo);
+		Data_Get_Struct(rb_repo, git_repository, repo);
+	}
 
 	if (!NIL_P(rb_options))
 		rugged_parse_merge_file_options(&opts, rb_options);
 
-	rugged_exception_check(git_merge_file(&result, &ancestor, &ours, &theirs, &opts));
+	if (!NIL_P(rb_ancestor))
+		rugged_parse_merge_file_input(&ancestor, repo, rb_ancestor);
+	if (!NIL_P(rb_ours))
+		rugged_parse_merge_file_input(&ours, repo, rb_ours);
+	if (!NIL_P(rb_theirs))
+		rugged_parse_merge_file_input(&theirs, repo, rb_theirs);
+
+	if ((error = rugged_load_merge_file_input(&ancestor_blob, repo, &ancestor)) < 0 ||
+		(error = rugged_load_merge_file_input(&our_blob, repo, &ours)) < 0 ||
+		(error = rugged_load_merge_file_input(&their_blob, repo, &theirs)) < 0 ||
+		(error = git_merge_file(&result, &ancestor.parent, &ours.parent, &theirs.parent, &opts)) < 0)
+		goto done;
 
 	rb_result = rb_merge_file_result_fromC(&result);
+
+done:
+	git_blob_free(ancestor_blob);
+	git_blob_free(our_blob);
+	git_blob_free(their_blob);
 	git_merge_file_result_free(&result);
 
+	rugged_exception_check(error);
 	return rb_result;
 }
 


### PR DESCRIPTION
We have `Rugged::Index.merge_files` that will produce the results of a three-way merge for a conflict.  (It looks up the conflict in the index and passes the three sides to `xdiff`).

Provide a similar function that will take the file contents directly (either as a string, or with an oid) and perform the three-way merge and return the results.

Note that this function will accept either input as a string _or_ the given object ID of a blob to lookup and merge.  This may be a bit overwrought, TBH, as most callers probably only want to deal with oids...?

/cc @brianmario 