### PR TITLE
extconf: Explicitly link against zlib on Windows to fix the build

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -77,7 +77,7 @@ else
       # in $LIBS or the final linking stage won't pick them up
       if windows?
         $LDFLAGS << " " + "-L#{Dir.pwd}/deps/winhttp"
-        $LIBS << " -lwinhttp -lcrypt32 -lrpcrt4 -lole32"
+        $LIBS << " -lwinhttp -lcrypt32 -lrpcrt4 -lole32 -lz"
       else
         pcfile = File.join(LIBGIT2_DIR, "build", "libgit2.pc")
         $LDFLAGS << " " + `pkg-config --libs --static #{pcfile}`.strip


### PR DESCRIPTION
Closes #612.