### PR TITLE
Don't default index entries to "VALID"

### DIFF
--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -624,8 +624,6 @@ static void rb_git_indexentry_toC(git_index_entry *entry, VALUE rb_entry)
 		entry->flags &= ~GIT_IDXENTRY_VALID;
 		if (rugged_parse_bool(val))
 			entry->flags |= GIT_IDXENTRY_VALID;
-	} else {
-		entry->flags |= GIT_IDXENTRY_VALID;
 	}
 }
 


### PR DESCRIPTION
The "VALID" flag in git refers to the "assume-unchanged" feature, such
that if, in a non-bare repository, an index entry is marked as "VALID",
the git CLI (e.g. `git status`) will assume that the file never changes,
and ignore any changes that do occur.

See https://github.com/libgit2/rugged/issues/636 for the issue and research leading to this change.

I wasn't able to track down a good way of unit testing this change, as
these flags aren't really exposed in Rugged, and I didn't notice any tests
working on non-bare repositories.
