### PR TITLE
Add regression tests for error cases on `Rugged::Diff.diff`

### DIFF
--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -1153,3 +1153,38 @@ EOS
     end
   end
 end
+
+class TreeDiffRegression < Rugged::TestCase
+  def test_nil_repo
+    assert_raises TypeError do
+      Rugged::Tree.diff nil, "foo"
+    end
+  end
+
+  def test_self_is_not_tree
+    repo = FixtureRepo.from_libgit2("diff")
+
+    ex = assert_raises TypeError do
+      Rugged::Tree.diff repo, "foo"
+    end
+    assert_equal "At least a Rugged::Tree object is required for diffing", ex.message
+  end
+
+  def test_self_or_other_must_be_present
+    repo = FixtureRepo.from_libgit2("diff")
+
+    ex = assert_raises TypeError do
+      Rugged::Tree.diff repo, nil, nil
+    end
+    assert_equal "Need 'old' or 'new' for diffing", ex.message
+  end
+
+  def test_other_is_wrong_type
+    repo = FixtureRepo.from_libgit2("diff")
+
+    ex = assert_raises TypeError do
+      Rugged::Tree.diff repo, nil, Object.new
+    end
+    assert_equal "A Rugged::Commit, Rugged::Tree or Rugged::Index instance is required", ex.message
+  end
+end


### PR DESCRIPTION
I would like to start refactoring `Rugged::Diff.diff`, but we are
missing tests for some of the branches in the C code.  This commit adds
tests for those branches.

I wasn't sure where to put these tests, so I just made a new test class.