### PR TITLE
Fix memory leak in `Rugged::Tree.diff`

### DIFF
--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -484,9 +484,8 @@ static VALUE rb_git_tree_diff_(int argc, VALUE *argv, VALUE self)
 	int error;
 
 	rb_scan_args(argc, argv, "22", &rb_repo, &rb_self, &rb_other, &rb_options);
-	rugged_parse_diff_options(&opts, rb_options);
-
 	Data_Get_Struct(rb_repo, git_repository, repo);
+	rugged_parse_diff_options(&opts, rb_options);
 
 	if (!NIL_P(rb_self)) {
 		if (!rb_obj_is_kind_of(rb_self, rb_cRuggedTree))


### PR DESCRIPTION
If `Rugged::Tree.diff` can't unwrap the repository object passed in, it
can leak memory allocated in `rugged_parse_diff_options`.  Before this
commit, memory usage for this script will grow unbounded:

```ruby
require 'rugged'

loop do
  begin
    Rugged::Tree.diff nil, nil, nil, { paths: ['x' * 90] }
  rescue TypeError
  end
end
```

To fix this, just try to unwrap the repository object before calling
`rugged_parse_diff_options`.