### PR TITLE
Fix `Rugged::Tree.diff` with first tree being `nil`

### DIFF
--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -391,7 +391,9 @@ static VALUE rb_git_diff_tree_to_tree(VALUE self, VALUE rb_repo, VALUE rb_tree, 
 	struct nogvl_diff_args args;
 
 	Data_Get_Struct(rb_repo, git_repository, repo);
-	Data_Get_Struct(rb_tree, git_tree, tree);
+
+	if(RTEST(rb_tree))
+	    Data_Get_Struct(rb_tree, git_tree, tree);
 
 	if(RTEST(rb_other_tree))
 	    Data_Get_Struct(rb_other_tree, git_tree, other_tree);

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -1188,6 +1188,50 @@ class TreeDiffRegression < Rugged::TestCase
     assert_equal "A Rugged::Commit, Rugged::Tree or Rugged::Index instance is required", ex.message
   end
 
+  def test_self_is_nil_other_is_tree_does_not_fail
+    repo = FixtureRepo.from_libgit2("diff")
+
+    a = repo.lookup("d70d245ed97ed2aa596dd1af6536e4bfdb047b69")
+
+    diff = Rugged::Tree.diff(repo, nil, a.tree)
+    assert_equal 2, diff.size
+    assert_equal 2, diff.deltas.size
+
+    delta = diff.deltas[0]
+    assert_equal({
+      oid: "0000000000000000000000000000000000000000",
+      path: "another.txt",
+      size: 0,
+      flags: 4,
+      mode: 0
+    }, delta.old_file)
+
+    assert_equal({
+      oid: "3e5bcbad2a68e5bc60a53b8388eea53a1a7ab847",
+      path: "another.txt",
+      size: 0,
+      flags: 12,
+      mode: 0100644
+    }, delta.new_file)
+
+    delta = diff.deltas[1]
+    assert_equal({
+      oid: "0000000000000000000000000000000000000000",
+      path: "readme.txt",
+      size: 0,
+      flags: 4,
+      mode: 0
+    }, delta.old_file)
+
+    assert_equal({
+      oid: "7b808f723a8ca90df319682c221187235af76693",
+      path: "readme.txt",
+      size: 0,
+      flags: 12,
+      mode: 0100644
+    }, delta.new_file)
+  end
+
   def test_other_tree_is_an_index_but_tree_is_nil
     repo = FixtureRepo.from_libgit2("diff")
 


### PR DESCRIPTION
Looks like this issue got introduced when the internals of `Rugged::Tree.diff` were refactored.

I added a test case and fixed the underlying issue.