### PR TITLE
Bump libgit2 to 45d55797b661085f7f5385d748d930a5148160cd

### DIFF
--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '0.26.0b2'
+  Version = VERSION = '0.26.0b3'
 end


### PR DESCRIPTION
Bump the vendored libgit2 to 45d55797b661085f7f5385d748d930a5148160cd, which includes a fix around rename detection with submodules.

(Bump the version number as well.)

/cc @arthurschreiber 