### PR TITLE
fix authentication with passphrased private key

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -158,7 +158,7 @@ module Rugged
         username:   ENV["GITTEST_REMOTE_SSH_USER"],
         publickey:  ENV["GITTEST_REMOTE_SSH_PUBKEY"],
         privatekey: ENV["GITTEST_REMOTE_SSH_KEY"],
-        passphrase: ENV["GITTEST_REMOTE_SSH_PASSPHASE"],
+        passphrase: ENV["GITTEST_REMOTE_SSH_PASSPHRASE"],
       })
     end
 


### PR DESCRIPTION
I'm chasing a bug (?) related to [this SO question][1]. One thing I could find so far was this typo.

Please keep this as work-in-progress as I try to find out exactly why the bug happens. I'll update the PR in case I happen to find anything else.

[1]: http://stackoverflow.com/questions/42398837/how-can-i-use-public-key-authentication-over-ssh-with-rugged