### PR TITLE
Move determining the make executable to earlier in the build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.bundle
 *.swp
 Gemfile.lock
+mkmf.log
 tmp/
 test/fixtures/testrepo.git
 ext/rugged/vendor/libgit2-dist/

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,20 @@ rescue LoadError
 error
 end
 
+if !ENV['MAKE']
+  require 'mkmf'
+
+  MAKE = if Gem.win_platform?
+    # On Windows, Ruby-DevKit only has 'make'.
+    find_executable('make')
+  else
+    find_executable('gmake') || find_executable('make')
+  end
+
+  # Make rake-compiler pick up the right make tool.
+  ENV['MAKE'] = MAKE unless MAKE.nil?
+end
+
 gemspec = Gem::Specification::load(File.expand_path('../rugged.gemspec', __FILE__))
 
 Gem::PackageTask.new(gemspec) do |pkg|

--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -20,12 +20,7 @@ def sys(cmd)
   ret
 end
 
-MAKE = if Gem.win_platform?
-  # On Windows, Ruby-DevKit only has 'make'.
-  find_executable('make')
-else
-  find_executable('gmake') || find_executable('make')
-end
+MAKE = ENV['MAKE']
 
 if !MAKE
   abort "ERROR: GNU make is required to build Rugged."


### PR DESCRIPTION
This way we can force rake-compiler to use whatever we found instead of
letting it determine the make executable via its own rules again.