### PR TITLE
add a little hint in the readme for google

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ You need to have CMake and `pkg-config` installed on your system to be able to b
 $ brew install cmake
 ```
 
+Please follow the above in case installation of the gem fails with `ERROR: CMake is required to build Rugged.`.
+
 If you want to build Rugged with HTTPS and SSH support, check out the list of optional [libgit2 dependencies](https://github.com/libgit2/libgit2#optional-dependencies).
 
 If you're using bundler and want to bundle `libgit2` with Rugged, you can use the `:submodules` option:


### PR DESCRIPTION
i think it would be helpful to find the installation instructions of the readme in case of the `ERROR: CMake is required to build Rugged.`. 

i just bundle installed a new repo and it failed with this error, so it's not apparent that one has to look into how to install rugged properly. i eventually found [this stackoverflow answer](http://stackoverflow.com/a/36587267/100731) but not the readme itself via google.