### PR TITLE
Add reader methods for cache information

### DIFF
--- a/ext/rugged/rugged_settings.c
+++ b/ext/rugged/rugged_settings.c
@@ -135,9 +135,37 @@ static VALUE rb_git_get_option(VALUE self, VALUE option)
 	}
 }
 
+/*
+ *  call-seq:
+ *    Rugged::Settings.max_cache_size -> max cache size
+ *
+ *  Returns the maximum amount of memory the cache will consume.
+ */
+static VALUE rb_git_get_max_cache_size(VALUE mod) {
+    size_t val;
+    size_t max;
+    git_libgit2_opts(GIT_OPT_GET_CACHED_MEMORY, &val, &max);
+    return SIZET2NUM(max);
+}
+
+/*
+ *  call-seq:
+ *    Rugged::Settings.used_cache_size -> used cache size
+ *
+ *  Returns the amount of memory the cache is currently consuming.
+ */
+static VALUE rb_git_get_used_cache_size(VALUE mod) {
+    size_t val;
+    size_t max;
+    git_libgit2_opts(GIT_OPT_GET_CACHED_MEMORY, &val, &max);
+    return SIZET2NUM(val);
+}
+
 void Init_rugged_settings(void)
 {
 	VALUE rb_cRuggedSettings = rb_define_class_under(rb_mRugged, "Settings", rb_cObject);
 	rb_define_module_function(rb_cRuggedSettings, "[]=", rb_git_set_option, 2);
 	rb_define_module_function(rb_cRuggedSettings, "[]", rb_git_get_option, 1);
+	rb_define_module_function(rb_cRuggedSettings, "max_cache_size", rb_git_get_max_cache_size, 0);
+	rb_define_module_function(rb_cRuggedSettings, "used_cache_size", rb_git_get_used_cache_size, 0);
 }

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class SettingsTest < Rugged::TestCase
+  def scrub_stack size
+    return if size == 0
+    scrub_stack size - 1
+  end
+
+  def test_used_cache_size
+    # Repo objects hold on to the cache, so make sure all unreferenced repo objects
+    # get GC'd
+    scrub_stack 50
+    GC.start
+
+    size = Rugged::Settings.used_cache_size
+    repo = FixtureRepo.from_libgit2("attr")
+    diff = repo.diff("605812a", "370fe9ec22", :context_lines => 1, :interhunk_lines => 1)
+
+    # cache size should grow
+    assert_operator size, :<, Rugged::Settings.used_cache_size
+  end
+
+  def test_max_cache_size
+    # We don't assert anything about the default max cache size because it is
+    # an implementation detail (libgit2 should be allowed to change the
+    # default size without breaking these tests).
+    assert Rugged::Settings.max_cache_size
+  end
+end


### PR DESCRIPTION
This commit adds two methods to `Rugged::Settings`:

* Rugged::Settings.max_cache_size
* Rugged::Settings.used_cache_size

`max_cache_size` returns the maximum size the internal libgit2 caches
will consume, and `used_cache_size` is the size the cache is currently
consuming.

I realize we already have `Rugged::Settings[]`, but `GIT_OPT_GET_CACHED_MEMORY` returns two values.  Returning an Array seems unhelpful because end users won't know what the elements mean.  Returning a struct instance would be more descriptive for end users, but allocating an object feels like a waste.  I could have introduced two new string parameters to `Rugged::Settings[]`, but I think string parameters aren't that great for API discoverability.  OTOH, all other settings are done via `Rugged::Settings[]`.  I personally prefer adding two methods, but my feelings aren't that strong.