### PR TITLE
Use Hash#fetch instead of Hash#[] for more understandable error messages

### DIFF
--- a/ext/rugged/rugged_signature.c
+++ b/ext/rugged/rugged_signature.c
@@ -50,8 +50,8 @@ git_signature *rugged_signature_get(VALUE rb_sig, git_repository *repo)
 
 	Check_Type(rb_sig, T_HASH);
 
-	rb_name = rb_hash_aref(rb_sig, CSTR2SYM("name"));
-	rb_email = rb_hash_aref(rb_sig, CSTR2SYM("email"));
+	rb_name = rb_hash_fetch(rb_sig, CSTR2SYM("name"));
+	rb_email = rb_hash_fetch(rb_sig, CSTR2SYM("email"));
 	rb_time = rb_hash_aref(rb_sig, CSTR2SYM("time"));
 	rb_time_offset = rb_hash_aref(rb_sig, CSTR2SYM("time_offset"));
 

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -452,6 +452,18 @@ class CommitWriteTest < Rugged::TestCase
     end
   end
 
+  def test_write_signature_raises_key_error_for_missing_keys
+    person = {:name => 'Jake', :time => Time.now} # no :email
+    assert_raises KeyError do
+      Rugged::Commit.create(@repo,
+      :message => "This is the commit message\n\nThis commit is created from Rugged",
+      :committer => person,
+      :author => person,
+      :parents => [@repo.head.target],
+      :tree => "c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b")
+    end
+  end
+
   def test_create_commit_to_s
     person = {:name => 'Scott', :email => 'schacon@gmail.com', :time => Time.now }
 


### PR DESCRIPTION
When creating a commit, with a typo in `:email` key in the `:author` hash, I got an error message that didn't immediately tell me what the problem was:

> TypeError: wrong argument type nil (expected String)

With a tiny change, we can get Ruby to generate a far more understandable error message if an `:email` or `:name` is not supplied.

> KeyError: key not found: :email