### PR TITLE
fix bad character in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Rugged.raw_to_hex("\277\336Y\315\320\337\254\035\211(\024\366j\225d\032\275\212\
 
 ---
 
-### Alternative backends
+### Alternative backends
 
 You can store bare repositories in alternative backends instead of storing on disk. (see
 `redbadger/rugged-redis` for an example of how a rugged backend works).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rugged
+# Rugged [![Build Status](https://travis-ci.org/libgit2/rugged.svg?branch=master)](https://travis-ci.org/libgit2/rugged)
 **libgit2 bindings in Ruby**
 
 Rugged is a library for accessing [libgit2](https://github.com/libgit2/libgit2) in Ruby. It gives you the speed and


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1159138/27934342-1cc9133e-625a-11e7-8067-337102ceb1ca.png)
After:
![image](https://user-images.githubusercontent.com/1159138/27934324-095951c4-625a-11e7-8223-df468e73d99f.png)
