### PR TITLE
Add a method to parse a signature from a buffer

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -368,6 +368,29 @@ static VALUE rb_git_cache_usage(VALUE self)
 	return rb_ary_new3(2, LL2NUM(used), LL2NUM(max));
 }
 
+/*
+ *  call-seq:
+ *    Rugged.signature_from_buffer(buffer[, encoding_name]) -> signature
+ *
+ * Parse the signature from the given buffer. If an encoding is given, the
+ * strings will be tagged with that encoding.
+ *
+ *    commit.author #=> {:email=>"tanoku@gmail.com", :time=>Tue Jan 24 05:42:45 UTC 2012, :name=>"Vicent Mart\303\255"}
+ */
+static VALUE rb_git_signature_from_buffer(int argc, VALUE *argv, VALUE self)
+{
+	VALUE rb_buffer, rb_encoding_name;
+	const char *buffer, *encoding_name = NULL;
+
+	rb_scan_args(argc, argv, "11", &rb_buffer, &rb_encoding_name);
+
+	buffer = StringValueCStr(rb_buffer);
+	if (!NIL_P(rb_encoding_name))
+		encoding_name = StringValueCStr(rb_encoding_name);
+
+	return rugged_signature_from_buffer(buffer, encoding_name);
+}
+
 VALUE rugged_strarray_to_rb_ary(git_strarray *str_array)
 {
 	VALUE rb_array = rb_ary_new2(str_array->count);
@@ -520,6 +543,7 @@ void Init_rugged(void)
 	rb_define_module_function(rb_mRugged, "minimize_oid", rb_git_minimize_oid, -1);
 	rb_define_module_function(rb_mRugged, "prettify_message", rb_git_prettify_message, -1);
 	rb_define_module_function(rb_mRugged, "__cache_usage__", rb_git_cache_usage, 0);
+	rb_define_module_function(rb_mRugged, "signature_from_buffer", rb_git_signature_from_buffer, -1);
 
 	Init_rugged_reference();
 	Init_rugged_reference_collection();

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -96,6 +96,8 @@ git_object *rugged_object_get(git_repository *repo, VALUE object_value, git_otyp
 int rugged_oid_get(git_oid *oid, git_repository *repo, VALUE p);
 const char * rugged_refname_from_string_or_ref(VALUE rb_name_or_ref);
 
+VALUE rugged_signature_from_buffer(const char *buffer, const char *encoding_name);
+
 void rugged_rb_ary_to_strarray(VALUE rb_array, git_strarray *str_array);
 VALUE rugged_strarray_to_rb_ary(git_strarray *str_array);
 

--- a/ext/rugged/rugged_signature.c
+++ b/ext/rugged/rugged_signature.c
@@ -35,6 +35,19 @@ VALUE rugged_signature_new(const git_signature *sig, const char *encoding_name)
 	return rb_sig;
 }
 
+VALUE rugged_signature_from_buffer(const char *buffer, const char *encoding_name)
+{
+	git_signature *sig;
+	VALUE rb_ret;
+
+	rugged_exception_check(git_signature_from_buffer(&sig, buffer));
+
+	rb_ret = rugged_signature_new(sig, encoding_name);
+	git_signature_free(sig);
+
+	return rb_ret;
+}
+
 git_signature *rugged_signature_get(VALUE rb_sig, git_repository *repo)
 {
 	int error;

--- a/test/signature_test.rb
+++ b/test/signature_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class SignatureTest < Rugged::TestCase
+  def test_parse_signature_from_buffer
+    buf = "Random J Hacker <hacks@example.com> 1499423310 +0200"
+    sig = Rugged::signature_from_buffer(buf)
+
+    expected = {
+      :name => "Random J Hacker",
+      :email => "hacks@example.com",
+      :time => Time.at(1499423310),
+    }
+
+    assert_equal expected, sig
+    assert_equal 2*3600, sig[:time].gmt_offset
+  end
+
+  def test_parse_signature_from_buffer_invalid
+    buf = "Random J Hacker <hacks@example.com> foobar 1499423310 +0200"
+    assert_raises(Rugged::InvalidError) { Rugged::signature_from_buffer(buf) }
+  end
+end


### PR DESCRIPTION
I'm not sure if `signature_from_string` or `parse_signature` would be more appropriate for ruby.

/cc @brianmario 