### PR TITLE
Fix memory leak in Rugged::Repository#status

### DIFF
--- a/test/status_test.rb
+++ b/test/status_test.rb
@@ -33,6 +33,26 @@ class LibgitRepositoryStatusTest < Rugged::TestCase
     @repo = FixtureRepo.from_libgit2 "status"
   end
 
+  class TestException < RuntimeError
+  end
+
+  def test_status_block_raises
+    assert_raises(TestException) do
+      @repo.status do |file, status|
+        raise TestException, "wow"
+      end
+    end
+  end
+
+  def test_status_block_breaks
+    yielded = 0
+    @repo.status do |file, status|
+      yielded += 1
+      break
+    end
+    assert_equal 1, yielded
+  end
+
   def test_status_with_callback
     actual_statuses = {}
     @repo.status do |file, status|


### PR DESCRIPTION
`Rugged::Repository#status` takes a block, and the block form of the
method will call `git_status_foreach`.  That function will eventually
[allocate memory](https://github.com/libgit2/libgit2/blob/a9d6b9d529daa920b558ee3f34151422d10bc95e/src/status.c#L425),
and it doesn't free the memory until after the `git_vector_foreach`
function finishes iteration.  The problem is that anything that does a
long jump (like raising an exception, or calling `break`) will jump out
of the `git_status_foreach_ext` before the list gets freed, so we will
have a leak.  For example, this program will consume memory
indefinitely:

```ruby
require 'rugged'

repo = Rugged::Repository.new ARGV[0]
loop do
  repo.status do |file, status_data|
    break
  end
end
```

This commit ensures the loop finishes and memory gets freed before any
long jumps happen.  Note that this is a **HUGE HACK**.  To make sure the
code jumps to the right place, I took advantage of the fact that Rugged
error codes are less than 0 and Ruby jump tags are greater than 0, and
that the `git_vector_foreach` will return the error code if it is
anything *except* 0.  This means I can overload the error code to be the
Ruby jump destination.  I apologize to the programming gods for my
transgressions, but this seemed like the easiest way to return the jump
location back up the stack.