### PR TITLE
remote: do not free the custom header ruby strings

### DIFF
--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -324,7 +324,7 @@ static VALUE rb_git_remote_ls(int argc, VALUE *argv, VALUE self)
 	cleanup:
 
 	git_remote_disconnect(remote);
-	git_strarray_free(&custom_headers);
+	xfree(custom_headers.strings);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);
@@ -517,7 +517,7 @@ static VALUE rb_git_remote_check_connection(int argc, VALUE *argv, VALUE self)
 	error = git_remote_connect(remote, direction, &callbacks, NULL, &custom_headers);
 	git_remote_disconnect(remote);
 
-	git_strarray_free(&custom_headers);
+	xfree(custom_headers.strings);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);
@@ -617,7 +617,7 @@ static VALUE rb_git_remote_fetch(int argc, VALUE *argv, VALUE self)
 	error = git_remote_fetch(remote, &refspecs, &opts, log_message);
 
 	xfree(refspecs.strings);
-	git_strarray_free(&opts.custom_headers);
+	xfree(opts.custom_headers.strings);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);
@@ -692,7 +692,7 @@ static VALUE rb_git_remote_push(int argc, VALUE *argv, VALUE self)
 	error = git_remote_push(remote, &refspecs, &opts);
 
 	xfree(refspecs.strings);
-	git_strarray_free(&opts.custom_headers);
+	xfree(opts.custom_headers.strings);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);


### PR DESCRIPTION
The strings themselves are owned by the ruby runtime. We must only free the
array we allocated to point to their buffers.