### PR TITLE
Wrap trailer parsing API

### DIFF
--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -66,6 +66,7 @@ static VALUE rb_git_commit_trailers_GET(VALUE self)
 	git_message_trailer_array arr;
 	VALUE trailers = rb_ary_new();
 	int error;
+	size_t i;
 
 	Data_Get_Struct(self, git_commit, commit);
 
@@ -78,7 +79,7 @@ static VALUE rb_git_commit_trailers_GET(VALUE self)
 	error = git_message_trailers(&arr, message);
 	rugged_exception_check(error);
 
-	for(size_t i=0; i<arr.count; i++) {
+	for(i = 0; i < arr.count; i++) {
 		VALUE pair = rb_ary_new();
 		const char *key = arr.trailers[i].key;
 		const char *value = arr.trailers[i].value;

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -7,6 +7,7 @@
 
 #include "rugged.h"
 #include "git2/commit.h"
+#include "git2/message.h"
 
 extern VALUE rb_mRugged;
 extern VALUE rb_cRuggedObject;
@@ -42,6 +43,69 @@ static VALUE rb_git_commit_message_GET(VALUE self)
 		encoding = rb_enc_find(encoding_name);
 
 	return rb_enc_str_new(message, strlen(message), encoding);
+}
+
+struct trailer_cb_info {
+	VALUE trailers;
+	rb_encoding *encoding;
+};
+
+static int rb_each_trailer(const char *key, const char *value, void *payload)
+{
+	struct trailer_cb_info *cb_info = (struct trailer_cb_info *)payload;
+
+	VALUE pair = rb_ary_new();
+
+	// trailer key
+	rb_ary_push(pair, rb_enc_str_new(key, strlen(key), cb_info->encoding));
+
+	// trailer value
+	rb_ary_push(pair, rb_enc_str_new(value, strlen(value), cb_info->encoding));
+
+	// add it to the list
+	rb_ary_push(cb_info->trailers, pair);
+
+	return GIT_OK;
+}
+
+/*
+ *  call-seq:
+ *    commit.trailers -> [["Trailer-name", "trailer value"], ...]
+ *
+ *  Return an array of arrays, each of which is a key/value pair representing a
+ *  commit message trailer. Both the keys and values will be strings. An array
+ *  is used to preserve the order the trailers were found.
+ *
+ *  In Ruby 1.9+, the returned strings will be encoded with the encoding
+ *  specified in the +Encoding+ header of the commit, if available.
+ *
+ */
+static VALUE rb_git_commit_trailers_GET(VALUE self)
+{
+	git_commit *commit;
+	const char *message;
+	rb_encoding *encoding = rb_utf8_encoding();
+	const char *encoding_name;
+	VALUE trailers = rb_ary_new();
+	int error;
+
+	Data_Get_Struct(self, git_commit, commit);
+
+	encoding_name = git_commit_message_encoding(commit);
+	if (encoding_name != NULL)
+		encoding = rb_enc_find(encoding_name);
+
+	struct trailer_cb_info cb_info = {
+		.trailers = trailers,
+		.encoding = encoding,
+	};
+
+	message = git_commit_message(commit);
+
+	error = git_message_trailers(message, rb_each_trailer, &cb_info);
+	rugged_exception_check(error);
+
+	return trailers;
 }
 
 /*
@@ -819,6 +883,7 @@ void Init_rugged_commit(void)
 	rb_define_singleton_method(rb_cRuggedCommit, "extract_signature", rb_git_commit_extract_signature, -1);
 
 	rb_define_method(rb_cRuggedCommit, "message", rb_git_commit_message_GET, 0);
+	rb_define_method(rb_cRuggedCommit, "trailers", rb_git_commit_trailers_GET, 0);
 	rb_define_method(rb_cRuggedCommit, "summary", rb_git_commit_summary_GET, 0);
 	rb_define_method(rb_cRuggedCommit, "epoch_time", rb_git_commit_epoch_time_GET, 0);
 	rb_define_method(rb_cRuggedCommit, "committer", rb_git_commit_committer_GET, 0);

--- a/ext/rugged/rugged_config.c
+++ b/ext/rugged/rugged_config.c
@@ -43,7 +43,7 @@ static VALUE rb_git_config_new(VALUE klass, VALUE rb_path)
 		for (i = 0; i < RARRAY_LEN(rb_path) && !error; ++i) {
 			VALUE f = rb_ary_entry(rb_path, i);
 			Check_Type(f, T_STRING);
-			error = git_config_add_file_ondisk(config, StringValueCStr(f), i + 1, 1);
+			error = git_config_add_file_ondisk(config, StringValueCStr(f), i + 1, NULL, 1);
 		}
 
 		if (error) {

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -699,4 +699,31 @@ libgit2 #{Rugged.libgit2_version.join('.')}
 EOS
   end
 
+  class TrailersTest < Rugged::TestCase
+    def setup
+      @source_repo = FixtureRepo.from_rugged("testrepo.git")
+      @repo = FixtureRepo.clone(@source_repo)
+      @repo.config['core.abbrev'] = 7
+    end
+
+    def test_can_parse_trailers
+      person = {:name => 'Brian', :email => 'brian@gmail.com', :time => Time.now }
+
+      commit_oid = Rugged::Commit.create(@repo,
+        :message => "This is the commit message\n\nCo-authored-by: Charles <charliesome@github.com>\nSigned-off-by: Arthur Schreiber <arthurschreiber@github.com>",
+        :committer => person,
+        :author => person,
+        :parents => [@repo.head.target],
+        :tree => @repo.head.target.tree_oid)
+
+      commit = @repo.lookup(commit_oid)
+
+      expected = [
+        ["Co-authored-by", "Charles <charliesome@github.com>"],
+        ["Signed-off-by", "Arthur Schreiber <arthurschreiber@github.com>"]
+      ]
+
+      assert_equal expected, commit.trailers
+    end
+  end
 end


### PR DESCRIPTION
This wraps the new [trailer parsing API](https://github.com/libgit2/libgit2/pull/4451) up in a new method `Rugged::Commit#trailers`. The return value is an array of arrays like so:

```
[
  ["Trailername", "value"],
  ...
]
```

The idea here is to maintain the order the parser saw the trailers, and let the caller merge them into a hash if they don't care about the order.

We're still working on getting the libgit2 side merged for this, but this side shouldn't require any changes once that's ready.

cc @charliesome @arthurschreiber 