### PR TITLE
Help YARD parse files in the correct order.

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+{lib,app}/**/*.rb ext/rugged/rugged_object.c ext/rugged/rugged_reference.c ext/**/*.c


### PR DESCRIPTION
Many people (including me) use the yard documentation available over http://www.rubydoc.info/github/libgit2/rugged to look up API documentation for rugged.

Unfortunately, YARD has some problems understanding the class hierarchy for the classes defined in C. But we can fix this by telling yard to parse the `ext/rugged/rugged_object.c` and `ext/rugged/rugged_reference.c` files before the other source files.

This is a bit unfortunate, because for subclasses like `Rugged::Blob`, all the methods inherited from `Rugged::Object` are not mentioned or linked at all.

---

This is how the documentation looks like before the config change:

<img width="1308" alt="screen shot 2018-01-18 at 17 22 50" src="https://user-images.githubusercontent.com/2195/35108600-405d85be-fc74-11e7-9172-ee4a4f3ab83f.png">

You can see that the superclass for `Rugged::Blob` is called `RuggedObject` and not linked correctly.

---

This is how it looks like after the change:

<img width="1308" alt="screen shot 2018-01-18 at 17 22 53" src="https://user-images.githubusercontent.com/2195/35108583-3cb9ebbe-fc74-11e7-935f-cacc2a03568f.png">

Here you can see that the superclass for `Rugged::Blob` is `Object` and linked to `Rugged::Object` documentation.