### PR TITLE
Add Rugged::Config#get_all

### DIFF
--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -5,6 +5,13 @@ class ConfigTest < Rugged::TestCase
     @repo = FixtureRepo.from_rugged("testrepo.git")
   end
 
+  def test_multi_fetch
+    config = @repo.config
+    fetches = ["+refs/heads/*:refs/remotes/test_remote/*",
+               "+refs/heads/*:refs/remotes/hello_remote/*"]
+    assert_equal fetches, config.get_all("remote.test_multiple_fetches.fetch")
+  end
+
   def test_read_config_file
     config = @repo.config
     assert_equal 'false', config['core.bare']

--- a/test/fixtures/testrepo.git/config
+++ b/test/fixtures/testrepo.git/config
@@ -11,3 +11,6 @@
 	pushurl = git://github.com/libgit2/TestEmptyRepository.git
 	fetch = +refs/heads/*:refs/remotes/test_remote/*
 	push = refs/heads/*:refs/heads/testing/*
+[remote "test_multiple_fetches"]
+	fetch = +refs/heads/*:refs/remotes/test_remote/*
+	fetch = +refs/heads/*:refs/remotes/hello_remote/*


### PR DESCRIPTION
This method allows you to fetch all values for a particular config,
similar to `git config --get-all "remote.origin.fetch"`.

For example, I have a git config with two `fetch` settings in one
remote:

```
$ cat ~/git/uart/.git/config
[core]
	repositoryformatversion = 0
	filemode = true
	bare = false
	logallrefupdates = true
	ignorecase = true
	precomposeunicode = true
[remote "origin"]
	url = git@github.com:tenderlove/uart.git
	fetch = +refs/heads/*:refs/remotes/origin/*
	fetch = +refs/heads/*:refs/remotes/lololol/*
[branch "master"]
	remote = origin
	merge = refs/heads/master
```

With `Rugged::Config#get_all` I can get the list of `fetch` options from
the config:

```
$ ruby -I lib -rrugged -e'p Rugged::Repository.new("/Users/aaron/git/uart").config.get_all("remote.origin.fetch")'
["+refs/heads/*:refs/remotes/origin/*", "+refs/heads/*:refs/remotes/lololol/*"]
```

References #725