### PR TITLE
Set a custom allocator to redirect via the ruby runtime

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -604,7 +604,8 @@ void Init_rugged(void)
 	 */
 	rb_define_const(rb_mRugged, "SORT_REVERSE", INT2FIX(GIT_SORT_REVERSE));
 
-	/* Initialize libgit2 */
+	/* Set the allocator and initialize libgit2 */
+	rugged_set_allocator();
 	git_libgit2_init();
 
 	/* Hook a global object to cleanup the library

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -173,4 +173,6 @@ typedef struct _rugged_backend {
   int (* refdb_backend)(git_refdb_backend **backend_out, struct _rugged_backend *backend, const char* path);
 } rugged_backend;
 
+extern void rugged_set_allocator(void);
+
 #endif

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -20,6 +20,8 @@
 #include <ruby/encoding.h>
 #endif
 
+#include <ruby/util.h>
+
 #include <assert.h>
 #include <git2.h>
 #include <git2/odb_backend.h>

--- a/ext/rugged/rugged_allocator.c
+++ b/ext/rugged/rugged_allocator.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) the Rugged contributors.  All rights reserved.
+ *
+ * This file is part of Rugged, distributed under the MIT license.
+ * For full terms see the included LICENSE file.
+ */
+
+#include "rugged.h"
+#include <git2/sys/alloc.h>
+
+static void *rugged_gmalloc(size_t n, const char *file, int line)
+{
+	return xmalloc(n);
+}
+
+static void *rugged_gcalloc(size_t nelem, size_t elsize, const char *file, int line)
+{
+	return xcalloc(nelem, elsize);
+}
+
+static char *rugged_gstrdup(const char *str, const char *file, int line)
+{
+	char *newstr;
+	size_t n;
+
+	n = strlen(str);
+	newstr = xmalloc(n+1);
+	memcpy(newstr, str, n);
+	newstr[n] = '\0';
+
+	return newstr;
+}
+
+static char *rugged_gstrndup(const char *str, size_t n, const char *file, int line)
+{
+	size_t len;
+	char *newstr;
+
+	len = strlen(str);
+	if (len < n)
+		n = len;
+
+	newstr = xmalloc(n+1);
+	memcpy(newstr, str, n);
+	newstr[n] = '\0';
+
+	return newstr;
+}
+
+static char *rugged_gsubstrdup(const char *str, size_t n, const char *file, int line)
+{
+	char *newstr;
+
+	newstr = xmalloc(n+1);
+	memcpy(newstr, str, n);
+	newstr[n] = '\0';
+
+	return newstr;
+}
+
+static void *rugged_grealloc(void *ptr, size_t size, const char *file, int line)
+{
+	return xrealloc(ptr, size);
+}
+
+static void *rugged_greallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
+{
+	return xrealloc2(ptr, nelem, elsize);
+}
+
+static void *rugged_gmallocarray(size_t nelem, size_t elsize, const char *file, int line)
+{
+	return xmalloc2(nelem, elsize);
+}
+
+static void rugged_gfree(void *ptr)
+{
+	xfree(ptr);
+}
+
+void rugged_set_allocator(void)
+{
+	git_allocator allocator;
+
+	allocator.gmalloc = rugged_gmalloc;
+	allocator.gcalloc = rugged_gcalloc;
+	allocator.gstrdup = rugged_gstrdup;
+	allocator.gstrndup = rugged_gstrndup;
+	allocator.gstrndup = rugged_gstrndup;
+	allocator.gsubstrdup = rugged_gsubstrdup;
+	allocator.grealloc = rugged_grealloc;
+	allocator.greallocarray = rugged_greallocarray;
+	allocator.gmallocarray = rugged_gmallocarray;
+	allocator.gfree = rugged_gfree;
+
+	git_libgit2_opts(GIT_OPT_SET_ALLOCATOR, &allocator);
+}

--- a/ext/rugged/rugged_allocator.c
+++ b/ext/rugged/rugged_allocator.c
@@ -20,15 +20,7 @@ static void *rugged_gcalloc(size_t nelem, size_t elsize, const char *file, int l
 
 static char *rugged_gstrdup(const char *str, const char *file, int line)
 {
-	char *newstr;
-	size_t n;
-
-	n = strlen(str);
-	newstr = xmalloc(n+1);
-	memcpy(newstr, str, n);
-	newstr[n] = '\0';
-
-	return newstr;
+	return ruby_strdup(str);
 }
 
 static char *rugged_gstrndup(const char *str, size_t n, const char *file, int line)


### PR DESCRIPTION
This lets us tell the ruby runtime how much memory rugged/libgit2 is allocating to give it a more realistic view of how much memory the process is using.
    
The expectation/hope is that long-lived processes will give back memory to the system more readily than is currently the case.

---

This is something which was spoken about at the contributors' summit as a likely source of server-side processes using rugged taking up silly amounts of memory.

/cc @arthurschreiber who suggested this