### PR TITLE
Bump libgit2 to v0.27.3

### DIFF
--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '0.27.2'
+  Version = VERSION = '0.27.3'
 end


### PR DESCRIPTION
libgit2 v0.27.3 contains a security fix that should be rolled into Rugged: https://github.com/libgit2/libgit2/releases