### PR TITLE
Use strnlen in the strndup allocator

### DIFF
--- a/ext/rugged/rugged_allocator.c
+++ b/ext/rugged/rugged_allocator.c
@@ -28,7 +28,7 @@ static char *rugged_gstrndup(const char *str, size_t n, const char *file, int li
 	size_t len;
 	char *newstr;
 
-	len = strlen(str);
+	len = strnlen(str, n);
 	if (len < n)
 		n = len;
 


### PR DESCRIPTION
If we use `strlen` we'll go over the whole string rather than just the part that
interests us, and sometimes we are given large strings.

As en example, a 15MB reflog took ~5s to parse when using `strlen` and it fell
within the noise of the tests when using `strnlen`.