### PR TITLE
Support Ruby's convention for pathnames and Pathname lib

### DIFF
--- a/ext/rugged/rugged_blob.c
+++ b/ext/rugged/rugged_blob.c
@@ -165,7 +165,7 @@ static VALUE rb_git_blob_from_workdir(VALUE self, VALUE rb_repo, VALUE rb_path)
 	git_oid oid;
 	git_repository *repo;
 
-	Check_Type(rb_path, T_STRING);
+	FilePathValue(rb_path);
 	rugged_check_repo(rb_repo);
 
 	Data_Get_Struct(rb_repo, git_repository, repo);
@@ -193,7 +193,7 @@ static VALUE rb_git_blob_from_disk(VALUE self, VALUE rb_repo, VALUE rb_path)
 	git_oid oid;
 	git_repository *repo;
 
-	Check_Type(rb_path, T_STRING);
+	FilePathValue(rb_path);
 	rugged_check_repo(rb_repo);
 
 	Data_Get_Struct(rb_repo, git_repository, repo);
@@ -254,7 +254,7 @@ static VALUE rb_git_blob_from_io(int argc, VALUE *argv, VALUE klass)
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
 	if (!NIL_P(rb_hint_path)) {
-		Check_Type(rb_hint_path, T_STRING);
+		FilePathValue(rb_hint_path);
 		hint_path = StringValueCStr(rb_hint_path);
 	}
 

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -182,7 +182,7 @@ static void rugged_repo_new_with_backend(git_repository **repo, VALUE rb_path, V
 
 	int error = 0;
 
-	Check_Type(rb_path, T_STRING);
+	FilePathValue(rb_path);
 	path = StringValueCStr(rb_path);
 
 	if (rb_obj_is_kind_of(rb_backend, rb_cRuggedBackend) == Qfalse) {
@@ -291,7 +291,7 @@ static VALUE rb_git_repo_open_bare(int argc, VALUE *argv, VALUE klass)
 	}
 
 	if (!repo) {
-		Check_Type(rb_path, T_STRING);
+		FilePathValue(rb_path);
 
 		error = git_repository_open_bare(&repo, StringValueCStr(rb_path));
 		rugged_exception_check(error);
@@ -335,7 +335,7 @@ static VALUE rb_git_repo_new(int argc, VALUE *argv, VALUE klass)
 	VALUE rb_path, rb_options;
 
 	rb_scan_args(argc, argv, "10:", &rb_path, &rb_options);
-	Check_Type(rb_path, T_STRING);
+	FilePathValue(rb_path);
 
 	error = git_repository_open(&repo, StringValueCStr(rb_path));
 	rugged_exception_check(error);
@@ -377,7 +377,7 @@ static VALUE rb_git_repo_init_at(int argc, VALUE *argv, VALUE klass)
 	int error;
 
 	rb_scan_args(argc, argv, "11:", &rb_path, &rb_is_bare, &rb_options);
-	Check_Type(rb_path, T_STRING);
+	FilePathValue(rb_path);
 
 	if (!NIL_P(rb_options)) {
 		/* Check for `:backend` */
@@ -474,7 +474,7 @@ static VALUE rb_git_repo_clone_at(int argc, VALUE *argv, VALUE klass)
 
 	rb_scan_args(argc, argv, "21", &url, &local_path, &rb_options_hash);
 	Check_Type(url, T_STRING);
-	Check_Type(local_path, T_STRING);
+	FilePathValue(local_path);
 
 	parse_clone_options(&options, rb_options_hash, &remote_payload);
 
@@ -1180,7 +1180,7 @@ static VALUE rb_git_repo_hashfile(VALUE self, VALUE rb_path, VALUE rb_type)
 	int error;
 	git_oid oid;
 
-	Check_Type(rb_path, T_STRING);
+	FilePathValue(rb_path);
 
 	error = git_odb_hashfile(&oid,
 		StringValueCStr(rb_path),
@@ -1455,7 +1455,7 @@ static VALUE rb_git_repo_discover(int argc, VALUE *argv, VALUE klass)
 		across_fs = rugged_parse_bool(rb_across_fs);
 	}
 
-	Check_Type(rb_path, T_STRING);
+	FilePathValue(rb_path);
 
 	error = git_repository_discover(
 		&repository_path,
@@ -1518,7 +1518,7 @@ static VALUE rb_git_repo_file_status(VALUE self, VALUE rb_path)
 	git_repository *repo;
 
 	Data_Get_Struct(self, git_repository, repo);
-	Check_Type(rb_path, T_STRING);
+	FilePathValue(rb_path);
 	error = git_status_file(&flags, repo, StringValueCStr(rb_path));
 	rugged_exception_check(error);
 
@@ -2365,7 +2365,7 @@ static VALUE rb_git_repo_attributes(int argc, VALUE *argv, VALUE self)
 	rb_scan_args(argc, argv, "12", &rb_path, &rb_names, &rb_options);
 
 	Data_Get_Struct(self, git_repository, repo);
-	Check_Type(rb_path, T_STRING);
+	FilePathValue(rb_path);
 
 	if (!NIL_P(rb_options)) {
 		Check_Type(rb_options, T_FIXNUM);

--- a/test/repo_test.rb
+++ b/test/repo_test.rb
@@ -503,6 +503,22 @@ class RepositoryInitTest < Rugged::TestCase
       repo.close
     end
   end
+
+  def test_init_with_pathname
+    require 'pathname'
+    repo = Rugged::Repository.init_at(Pathname(@tmppath))
+    begin
+      refute repo.bare?
+    ensure
+      repo.close
+    end
+  end
+
+  def test_init_with_wrong_argument
+    assert_raises(TypeError) do
+      Rugged::Repository.init_at(@tmppath.to_sym)
+    end
+  end
 end
 
 class RepositoryCloneTest < Rugged::TestCase


### PR DESCRIPTION
Rugged is currently too strict in not recognizing objects that `respond_to? :to_path`. In particular, this means we can't pass a `Pathname` object directly, contrary to all builtin methods accepting paths for example.

This PR fixes the cases.

I simply searched for all `Check_Type(.*_path, T_STRING)`, so I may have missed some.