### PR TITLE
Expose methods to detect .gitignore and .gitattributes files

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -515,6 +515,48 @@ VALUE rb_merge_file_result_fromC(const git_merge_file_result *result)
 	return rb_result;
 }
 
+static VALUE rb_git_path_is_dotgit_modules(VALUE self, VALUE rb_path)
+{
+	const char *path;
+	int is_dotgit;
+
+	Check_Type(rb_path, T_STRING);
+
+	path = StringValueCStr(rb_path);
+
+	is_dotgit = git_path_is_gitfile(path, strlen(path), GIT_PATH_GITFILE_GITMODULES, GIT_PATH_FS_GENERIC);
+
+	return is_dotgit ? Qtrue : Qfalse;
+}
+
+static VALUE rb_git_path_is_dotgit_ignore(VALUE self, VALUE rb_path)
+{
+	const char *path;
+	int is_dotgit;
+
+	Check_Type(rb_path, T_STRING);
+
+	path = StringValueCStr(rb_path);
+
+	is_dotgit = git_path_is_gitfile(path, strlen(path), GIT_PATH_GITFILE_GITIGNORE, GIT_PATH_FS_GENERIC);
+
+	return is_dotgit ? Qtrue : Qfalse;
+}
+
+static VALUE rb_git_path_is_dotgit_attributes(VALUE self, VALUE rb_path)
+{
+	const char *path;
+	int is_dotgit;
+
+	Check_Type(rb_path, T_STRING);
+
+	path = StringValueCStr(rb_path);
+
+	is_dotgit = git_path_is_gitfile(path, strlen(path), GIT_PATH_GITFILE_GITATTRIBUTES, GIT_PATH_FS_GENERIC);
+
+	return is_dotgit ? Qtrue : Qfalse;
+}
+
 void Init_rugged(void)
 {
 	rb_mRugged = rb_define_module("Rugged");
@@ -544,6 +586,9 @@ void Init_rugged(void)
 	rb_define_module_function(rb_mRugged, "prettify_message", rb_git_prettify_message, -1);
 	rb_define_module_function(rb_mRugged, "__cache_usage__", rb_git_cache_usage, 0);
 	rb_define_module_function(rb_mRugged, "signature_from_buffer", rb_git_signature_from_buffer, -1);
+	rb_define_module_function(rb_mRugged, "dotgit_modules?", rb_git_path_is_dotgit_modules, 1);
+	rb_define_module_function(rb_mRugged, "dotgit_ignore?", rb_git_path_is_dotgit_ignore, 1);
+	rb_define_module_function(rb_mRugged, "dotgit_attributes?", rb_git_path_is_dotgit_attributes, 1);
 
 	Init_rugged_reference();
 	Init_rugged_reference_collection();

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -25,6 +25,7 @@
 #include <assert.h>
 #include <git2.h>
 #include <git2/odb_backend.h>
+#include <git2/sys/path.h>
 
 #define rb_str_new_utf8(str) rb_enc_str_new(str, strlen(str), rb_utf8_encoding())
 #define CSTR2SYM(s) (ID2SYM(rb_intern((s))))

--- a/test/dotgit_test.rb
+++ b/test/dotgit_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class DotgitTest < Rugged::TestCase
+  def test_dotgit
+    assert Rugged.dotgit_modules?(".gitmodules")
+    assert Rugged.dotgit_modules?(".git\xe2\x80\x8cmodules")
+    assert Rugged.dotgit_modules?("GITMOD~1")
+    assert Rugged.dotgit_modules?("gi7eba~9")
+
+    refute Rugged.dotgit_modules?("gitmodules")
+    refute Rugged.dotgit_modules?("GI7EBA~0")
+
+    assert Rugged.dotgit_ignore?(".gitignore")
+    refute Rugged.dotgit_ignore?(".gitignores")
+
+    assert Rugged.dotgit_attributes?(".gitattributes")
+    refute Rugged.dotgit_attributes?(".gittattributtes")
+
+  end
+end


### PR DESCRIPTION
These can be used to see whether a file would be read as `.gitignore` or
`.gitattributes` when read from the filesystem.