### PR TITLE
repo: catch exceptions when iterating through status

### DIFF
--- a/test/status_test.rb
+++ b/test/status_test.rb
@@ -33,6 +33,26 @@ class LibgitRepositoryStatusTest < Rugged::TestCase
     @repo = FixtureRepo.from_libgit2 "status"
   end
 
+  class TestException < RuntimeError
+  end
+
+  def test_status_block_raises
+    assert_raises(TestException) do
+      @repo.status do |file, status|
+        raise TestException, "wow"
+      end
+    end
+  end
+
+  def test_status_block_breaks
+    yielded = 0
+    @repo.status do |file, status|
+      yielded += 1
+      break
+    end
+    assert_equal 1, yielded
+  end
+
   def test_status_with_callback
     actual_statuses = {}
     @repo.status do |file, status|


### PR DESCRIPTION
When we call the block, an exception or even a call to `break` would cause us to
unwind the stack and skip any resource freeing that we may have. The solution is
to call `rb_protect` which will let us catch the exception and raise whenever we
need to.

Doing this as part of a `git_status_foreach` is unnecessarily awkward so move to
iterating over the status list ourselves and free the entry list as soon as we
notice there was an exception.

For example, this program will consume memory
indefinitely:

    require 'rugged'

    repo = Rugged::Repository.new ARGV[0]
    loop do
      repo.status do |file, status_data|
        break
      end
    end

Thanks to Aaron Patterson for discovering this and the original hacky fix.

---

This solves the same problem as #715 but in a less hacky and future-anti-proofing way.

/cc @tenderlove @arthurschreiber 