### PR TITLE
Add Repository#apply

### DIFF
--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -85,7 +85,7 @@ VALUE rb_merge_file_result_fromC(const git_merge_file_result *results);
 
 void rugged_parse_diff_options(git_diff_options *opts, VALUE rb_options);
 void rugged_parse_merge_options(git_merge_options *opts, VALUE rb_options);
-void rugged_parse_apply_options(git_apply_options *opts, git_apply_location_t *location, VALUE rb_options);
+
 void rugged_parse_checkout_options(git_checkout_options *opts, VALUE rb_options);
 void rugged_parse_merge_file_options(git_merge_file_options *opts, VALUE rb_options);
 
@@ -103,6 +103,12 @@ VALUE rugged_signature_from_buffer(const char *buffer, const char *encoding_name
 
 void rugged_rb_ary_to_strarray(VALUE rb_array, git_strarray *str_array);
 VALUE rugged_strarray_to_rb_ary(git_strarray *str_array);
+
+#define CALLABLE_OR_RAISE(ret, name) \
+	do { \
+		if (!rb_respond_to(ret, rb_intern("call"))) \
+			rb_raise(rb_eArgError, "Expected a Proc or an object that responds to #call (:" name " )."); \
+	} while (0);
 
 static inline void rugged_set_owner(VALUE object, VALUE owner)
 {
@@ -133,6 +139,13 @@ static inline int rugged_parse_bool(VALUE boolean)
 extern VALUE rb_cRuggedRepo;
 
 VALUE rugged__block_yield_splat(VALUE args);
+
+struct rugged_apply_cb_payload
+{
+	VALUE delta_cb;
+	VALUE hunk_cb;
+	int exception;
+};
 
 struct rugged_cb_payload
 {

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -85,6 +85,7 @@ VALUE rb_merge_file_result_fromC(const git_merge_file_result *results);
 
 void rugged_parse_diff_options(git_diff_options *opts, VALUE rb_options);
 void rugged_parse_merge_options(git_merge_options *opts, VALUE rb_options);
+void rugged_parse_apply_options(git_apply_options *opts, git_apply_location_t *location, VALUE rb_options);
 void rugged_parse_checkout_options(git_checkout_options *opts, VALUE rb_options);
 void rugged_parse_merge_file_options(git_merge_file_options *opts, VALUE rb_options);
 

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -85,7 +85,6 @@ VALUE rb_merge_file_result_fromC(const git_merge_file_result *results);
 
 void rugged_parse_diff_options(git_diff_options *opts, VALUE rb_options);
 void rugged_parse_merge_options(git_merge_options *opts, VALUE rb_options);
-
 void rugged_parse_checkout_options(git_checkout_options *opts, VALUE rb_options);
 void rugged_parse_merge_file_options(git_merge_file_options *opts, VALUE rb_options);
 

--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -157,12 +157,6 @@ static int credentials_cb(
 	return payload->exception ? GIT_ERROR : GIT_OK;
 }
 
-#define CALLABLE_OR_RAISE(ret, name) \
-	do { \
-		if (!rb_respond_to(ret, rb_intern("call"))) \
-			rb_raise(rb_eArgError, "Expected a Proc or an object that responds to #call (:" name " )."); \
-	} while (0);
-
 void rugged_remote_init_callbacks_and_payload_from_options(
 	VALUE rb_options,
 	git_remote_callbacks *callbacks,

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -970,8 +970,9 @@ static VALUE rb_git_repo_revert_commit(int argc, VALUE *argv, VALUE self)
  *  The following options can be passed in the +options+ Hash:
  *
  *  :location ::
- *    Whether to apply the changes to the workdir (default),
- *    the index, or both. Valid values: +:index+, +:workdir+, +:both+.
+ *    Whether to apply the changes to the workdir (default for non-bare),
+ *    the index (default for bare) or both. Valid values: +:index+, +:workdir+,
+ *    +:both+.
  *
  *  :delta_callback ::
  *    While applying the patch, this callback will be executed per delta (file).

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -398,6 +398,98 @@ static VALUE rb_git_repo_init_at(int argc, VALUE *argv, VALUE klass)
 	return rugged_repo_new(klass, repo);
 }
 
+static int apply_cb_result(int exception, VALUE result)
+{
+	if (exception || result == Qnil) {
+		return GIT_EAPPLYFAIL;
+	} else {
+		if (RTEST(result)) {
+			return 0;
+		} else {
+			return 1;
+		}
+	}
+}
+
+static int apply_delta_cb(const git_diff_delta *delta, void *data)
+{
+	struct rugged_apply_cb_payload *payload = data;
+	VALUE args = rb_ary_new2(2);
+	VALUE result;
+
+	if (NIL_P(payload->delta_cb))
+		return 0;
+
+	VALUE rb_delta = rugged_diff_delta_new(Qnil, delta);
+
+	rb_ary_push(args, payload->delta_cb);
+	rb_ary_push(args, rb_delta);
+
+	result = rb_protect(rugged__block_yield_splat, args, &payload->exception);
+
+	return apply_cb_result(payload->exception, result);
+}
+
+static int apply_hunk_cb(const git_diff_hunk *hunk, void *data)
+{
+	struct rugged_apply_cb_payload *payload = data;
+	VALUE args = rb_ary_new2(2);
+	VALUE result;
+
+	if (NIL_P(payload->hunk_cb))
+		return 0;
+
+	VALUE rb_hunk = rugged_diff_hunk_new(Qnil, 0, hunk, 0);
+
+	rb_ary_push(args, payload->hunk_cb);
+	rb_ary_push(args, rb_hunk);
+
+	result = rb_protect(rugged__block_yield_splat, args, &payload->exception);
+
+	return apply_cb_result(payload->exception, result);
+}
+
+static void rugged_parse_apply_options(git_apply_options *opts, git_apply_location_t *location, VALUE rb_options, struct rugged_apply_cb_payload *payload)
+{
+	if (!NIL_P(rb_options)) {
+		VALUE rb_value;
+		Check_Type(rb_options, T_HASH);
+
+		rb_value = rb_hash_aref(rb_options, CSTR2SYM("location"));
+		if (!NIL_P(rb_value)) {
+			ID id_location;
+
+			Check_Type(rb_value, T_SYMBOL);
+			id_location = SYM2ID(rb_value);
+
+			if (id_location == rb_intern("both")) {
+				*location = GIT_APPLY_LOCATION_BOTH;
+			} else if (id_location == rb_intern("index")) {
+				*location = GIT_APPLY_LOCATION_INDEX;
+			} else if (id_location == rb_intern("workdir")) {
+				*location = GIT_APPLY_LOCATION_WORKDIR;
+			} else {
+				rb_raise(rb_eTypeError,
+					"Invalid location. Expected `:both`, `:index`, or `:workdir`");
+			}
+		}
+
+		opts->payload = payload;
+
+		payload->delta_cb = rb_hash_aref(rb_options, CSTR2SYM("delta_callback"));
+		if (!NIL_P(payload->delta_cb)) {
+			CALLABLE_OR_RAISE(payload->delta_cb, "delta_callback");
+			opts->delta_cb = apply_delta_cb;
+		}
+
+		payload->hunk_cb = rb_hash_aref(rb_options, CSTR2SYM("hunk_callback"));
+		if (!NIL_P(payload->hunk_cb)) {
+			CALLABLE_OR_RAISE(payload->hunk_cb, "hunk_callback");
+			opts->hunk_cb = apply_hunk_cb;
+		}
+	}
+}
+
 static void parse_clone_options(git_clone_options *ret, VALUE rb_options, struct rugged_remote_cb_payload *remote_payload)
 {
 	VALUE val;
@@ -875,6 +967,25 @@ static VALUE rb_git_repo_revert_commit(int argc, VALUE *argv, VALUE self)
  *    repo.apply(diff, options = {}) -> true or false
  *
  *	Applies the given diff to the repository.
+ *  The following options can be passed in the +options+ Hash:
+ *
+ *  :location ::
+ *    Whether to apply the changes to the workdir (default),
+ *    the index, or both. Valid values: +:index+, +:workdir+, +:both+.
+ *
+ *  :delta_callback ::
+ *    While applying the patch, this callback will be executed per delta (file).
+ *    The current +delta+ will be passed to the block. The block's return value
+ *    determines further behavior. When the block evaluates to:
+ *       - +true+: the hunk will be applied and the apply process will continue.
+ *       - +false+: the hunk will be skipped, but the apply process continues.
+ *       - +nil+: the hunk is not applied, and the apply process is aborted.
+ *
+ *  :hunk_callback ::
+ *    While applying the patch, this callback will be executed per hunk.
+ *    The current +hunk+ will be passed to the block. The block's return value
+ *    determines further behavior, as per :delta_callback.
+ *
  */
 static VALUE rb_git_repo_apply(int argc, VALUE *argv, VALUE self)
 {
@@ -882,7 +993,8 @@ static VALUE rb_git_repo_apply(int argc, VALUE *argv, VALUE self)
 	git_diff *diff;
 	git_repository *repo;
 	git_apply_options opts = GIT_APPLY_OPTIONS_INIT;
-	git_apply_location_t location = GIT_APPLY_LOCATION_BOTH;
+	git_apply_location_t location = GIT_APPLY_LOCATION_WORKDIR;
+	struct rugged_apply_cb_payload payload = { Qnil, Qnil, 0 };
 	int error;
 
 	rb_scan_args(argc, argv, "11", &rb_diff, &rb_options);
@@ -893,7 +1005,7 @@ static VALUE rb_git_repo_apply(int argc, VALUE *argv, VALUE self)
 
 	if (!NIL_P(rb_options)) {
 		Check_Type(rb_options, T_HASH);
-		rugged_parse_apply_options(&opts, &location, rb_options);
+		rugged_parse_apply_options(&opts, &location, rb_options, &payload);
 	}
 
 	Data_Get_Struct(self, git_repository, repo);
@@ -2579,33 +2691,6 @@ static VALUE rb_git_repo_cherrypick_commit(int argc, VALUE *argv, VALUE self)
 	rugged_exception_check(error);
 
 	return rugged_index_new(rb_cRuggedIndex, self, index);
-}
-
-void rugged_parse_apply_options(git_apply_options *opts, git_apply_location_t *location, VALUE rb_options)
-{
-	if (!NIL_P(rb_options)) {
-		VALUE rb_value;
-		Check_Type(rb_options, T_HASH);
-
-		rb_value = rb_hash_aref(rb_options, CSTR2SYM("location"));
-		if (!NIL_P(rb_value)) {
-			ID id_location;
-
-			Check_Type(rb_value, T_SYMBOL);
-			id_location = SYM2ID(rb_value);
-
-			if (id_location == rb_intern("both")) {
-				*location = GIT_APPLY_LOCATION_BOTH;
-			} else if (id_location == rb_intern("index")) {
-				*location = GIT_APPLY_LOCATION_INDEX;
-			} else if (id_location == rb_intern("workdir")) {
-				*location = GIT_APPLY_LOCATION_WORKDIR;
-			} else {
-				rb_raise(rb_eTypeError,
-					"Invalid location. Expected `:both`, `:index`, or `:workdir`");
-			}
-		}
-	}
 }
 
 void Init_rugged_repo(void)

--- a/test/repo_apply_test.rb
+++ b/test/repo_apply_test.rb
@@ -138,5 +138,13 @@ class RepositoryApplyTest < Rugged::TestCase
     assert_raises RuntimeError do
       @repo.apply(diff, {:location => :index, :delta_callback => delta_fail})
     end
+
+    assert_raises ArgumentError do
+      @repo.apply(diff, {:location => :index, :delta_callback => 'this is not a callable object'})
+    end
+
+    assert_raises ArgumentError do
+      @repo.apply(diff, {:location => :index, :hunk_callback => 'this is not a callable object'})
+    end
   end
 end

--- a/test/repo_apply_test.rb
+++ b/test/repo_apply_test.rb
@@ -1,0 +1,101 @@
+require 'test_helper'
+require 'base64'
+
+module RepositoryApplyTestHelpers
+  def blob_contents(repo, path)
+    repo.lookup(repo.head.target.tree[path][:oid]).content
+  end
+
+  def update_file(repo, path)
+    original = blob_contents(repo, path)
+    content = new_content(original)
+    blob = repo.write(content, :blob)
+
+    index = repo.index
+    index.read_tree(repo.head.target.tree)
+    index.add(:path => path, :oid => blob, :mode => 0100644)
+    new_tree = index.write_tree(repo)
+
+    oid = do_commit(repo, new_tree, "Update #{path}")
+
+    return repo.lookup(oid), content, original
+  end
+
+  def do_commit(repo, tree, message)
+    Rugged::Commit.create(repo,
+      :tree => tree,
+      :author => person,
+      :committer => person,
+      :message => message,
+      :parents => repo.empty? ? [] : [ repo.head.target ].compact,
+      :update_ref => 'HEAD',
+    )
+  end
+
+  def new_content(original)
+    "#{original}Some new line\n"
+  end
+
+  def person
+    {:name => 'Scott', :email => 'schacon@gmail.com', :time => Time.now }
+  end
+end
+
+class RepositoryApplyTest < Rugged::TestCase
+  include RepositoryApplyTestHelpers
+
+  def setup
+    @repo = FixtureRepo.from_libgit2("testrepo")
+  end
+
+  def test_apply_index
+    original_commit = @repo.head.target.oid
+    new_commit, new_content, original_content = update_file(@repo, 'README')
+
+    assert_equal @repo.lookup(@repo.index["README"][:oid]).content, new_content
+
+    diff = @repo.diff(new_commit, original_commit)
+
+    assert_equal true, @repo.apply(diff, {:location => :index})
+    assert_equal @repo.lookup(@repo.index["README"][:oid]).content, original_content
+  end
+
+  def test_apply_workdir
+    original_commit = @repo.head.target.oid
+    new_commit, new_content, original_content = update_file(@repo, 'README')
+
+    @repo.checkout_head(:strategy => :force)
+    assert_equal File.read(File.join(@repo.workdir, 'README')), new_content
+
+    diff = @repo.diff(new_commit, original_commit)
+
+    assert_equal true, @repo.apply(diff, {:location => :workdir})
+    assert_equal File.read(File.join(@repo.workdir, 'README')), original_content
+  end
+
+  def test_apply_both
+    original_commit = @repo.head.target.oid
+    new_commit, new_content, original_content = update_file(@repo, 'README')
+
+    @repo.checkout_head(:strategy => :force)
+    assert_equal @repo.lookup(@repo.index["README"][:oid]).content, new_content
+    assert_equal File.read(File.join(@repo.workdir, 'README')), new_content
+
+    diff = @repo.diff(new_commit, original_commit)
+
+    assert_equal true, @repo.apply(diff)
+    assert_equal @repo.lookup(@repo.index["README"][:oid]).content, original_content
+    assert_equal File.read(File.join(@repo.workdir, 'README')), original_content
+  end
+
+  def test_location_option
+    original_commit = @repo.head.target.oid
+    new_commit, new_content, original_content = update_file(@repo, 'README')
+
+    diff = @repo.diff(new_commit, original_commit)
+
+    assert_raises TypeError do
+      @repo.apply(diff, :location => :invalid)
+    end
+  end
+end


### PR DESCRIPTION
Initial support for the `git_apply` functionality added to `libgit2` in https://github.com/libgit2/libgit2/pull/4705/. This is my first time working on `rugged`, so I'm happy to do whatever is needed to get this PR up to standards for the project.

Call signature: `Repository#apply(diff, options = {})`.
Options:
```
:location - Whether to apply the changes to the index, the working directory, or both. Valid values: :index, :workdir, :both. Defaults to :both.
```

At the moment, `#apply` returns `true` on success. On failure, an exception will be thrown (because of the call to `rugged_exception_check(error)`), which means in practice `false` will never be returned. I thought about returning the modified index instead, but that doesn't make sense given the possibility of modifying only the workdir.

Since `options` at the moment only allows for `:location`, another way to go would be to change the second argument to an optional `location` parameter. However, if other options are to be added in the future, it would make sense to set `:location` in the options Hash. (I am not sure whether it would make sense to add support for the `hunk_cb` and `delta_cb` options implemented [here](https://github.com/libgit2/libgit2/blob/4e746d80d229a77b08c5689a64d880bde5fd960f/include/git2/apply.h#L67-L68))