### PR TITLE
[Feature] Expose libgit2's git_diff_from_buffer in rugged through Rugged::Repository#diff_from_buffer(buffer)

### DIFF
--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -657,36 +657,9 @@ static VALUE rb_git_diff_sorted_icase_p(VALUE self)
 	return git_diff_is_sorted_icase(diff) ? Qtrue : Qfalse;
 }
 
-/*
- *  call-seq: Diff.from_buffer(buffer) -> Rugged::Diff object
- *  
- *  Where +buffer+ is a +String+.
- *  Returns A Rugged::Diff object
- */
-static VALUE rb_git_diff_from_buffer(VALUE self, VALUE rb_buffer)
-{
-  git_diff *diff = NULL;
-  const char *buffer;
-  size_t len;
-  VALUE rb_diff;
-  int error;
-
-  Check_Type(rb_buffer, T_STRING);
-  buffer = RSTRING_PTR(rb_buffer);
-  len = RSTRING_LEN(rb_buffer);
-
-  error = git_diff_from_buffer(&diff, buffer, len);
-  rugged_exception_check(error);
-
-  rb_diff = Data_Wrap_Struct(rb_cRuggedDiff, NULL, git_diff_free, diff);
-  return rb_diff;
-}
-
 void Init_rugged_diff(void)
 {
 	rb_cRuggedDiff = rb_define_class_under(rb_mRugged, "Diff", rb_cObject);
-
-	rb_define_singleton_method(rb_cRuggedDiff, "from_buffer", rb_git_diff_from_buffer, 1);
 
 	rb_define_method(rb_cRuggedDiff, "patch", rb_git_diff_patch, -1);
 	rb_define_method(rb_cRuggedDiff, "write_patch", rb_git_diff_write_patch, -1);

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -657,9 +657,28 @@ static VALUE rb_git_diff_sorted_icase_p(VALUE self)
 	return git_diff_is_sorted_icase(diff) ? Qtrue : Qfalse;
 }
 
+static VALUE rb_git_diff_from_string(VALUE contents)
+{
+	git_diff *diff;
+	const char *buffer;
+	size_t len;
+	VALUE rb_diff;
+
+	buffer = StringValuePtr(contents);
+	len = strlen(buffer);
+
+	git_diff_from_buffer(&diff, buffer, len);
+
+	Data_Wrap_Struct(rb_cRuggedDiff, NULL, git_diff_free, diff);
+
+	return rb_diff;
+}
+
 void Init_rugged_diff(void)
 {
 	rb_cRuggedDiff = rb_define_class_under(rb_mRugged, "Diff", rb_cObject);
+
+	rb_define_singleton_method(rb_cRuggedDiff, "new_from_string", rb_git_diff_from_string, 1);
 
 	rb_define_method(rb_cRuggedDiff, "patch", rb_git_diff_patch, -1);
 	rb_define_method(rb_cRuggedDiff, "write_patch", rb_git_diff_write_patch, -1);

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -667,7 +667,6 @@ static VALUE rb_git_diff_from_buffer(VALUE self, VALUE rb_buffer)
 {
 	git_diff *diff = NULL;
   const char *buffer;
-  // const char *buffer = "diff --git a/file b/file\nnew file mode 100644\nindex 0000000..d5f7fc3\n--- /dev/null\n+++ b/file\n@@ -0,0 +1 @@\n+added\n" ;
 	size_t len;
 	VALUE rb_diff;
 	int error;

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -657,28 +657,37 @@ static VALUE rb_git_diff_sorted_icase_p(VALUE self)
 	return git_diff_is_sorted_icase(diff) ? Qtrue : Qfalse;
 }
 
-static VALUE rb_git_diff_from_string(VALUE contents)
+/*
+ *  call-seq: Diff.from_buffer(buffer) -> Rugged::Diff object
+ *  
+ *  Where +buffer+ is a +String+.
+ *  Returns A Rugged::Diff object
+ */
+static VALUE rb_git_diff_from_buffer(VALUE self, VALUE rb_buffer)
 {
-	git_diff *diff;
-	const char *buffer;
+	git_diff *diff = NULL;
+  const char *buffer;
+  // const char *buffer = "diff --git a/file b/file\nnew file mode 100644\nindex 0000000..d5f7fc3\n--- /dev/null\n+++ b/file\n@@ -0,0 +1 @@\n+added\n" ;
 	size_t len;
 	VALUE rb_diff;
+	int error;
 
-	buffer = StringValuePtr(contents);
-	len = strlen(buffer);
+  Check_Type(rb_buffer, T_STRING);
+  buffer = RSTRING_PTR(rb_buffer);
+  len = RSTRING_LEN(rb_buffer);
 
-	git_diff_from_buffer(&diff, buffer, len);
-
-	Data_Wrap_Struct(rb_cRuggedDiff, NULL, git_diff_free, diff);
-
-	return rb_diff;
+  error = git_diff_from_buffer(&diff, buffer, len);
+  rugged_exception_check(error);
+  
+  rb_diff = Data_Wrap_Struct(rb_cRuggedDiff, NULL, git_diff_free, diff);
+  return rb_diff;
 }
 
 void Init_rugged_diff(void)
 {
 	rb_cRuggedDiff = rb_define_class_under(rb_mRugged, "Diff", rb_cObject);
 
-	rb_define_singleton_method(rb_cRuggedDiff, "new_from_string", rb_git_diff_from_string, 1);
+	rb_define_singleton_method(rb_cRuggedDiff, "from_buffer", rb_git_diff_from_buffer, 1);
 
 	rb_define_method(rb_cRuggedDiff, "patch", rb_git_diff_patch, -1);
 	rb_define_method(rb_cRuggedDiff, "write_patch", rb_git_diff_write_patch, -1);

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -665,11 +665,11 @@ static VALUE rb_git_diff_sorted_icase_p(VALUE self)
  */
 static VALUE rb_git_diff_from_buffer(VALUE self, VALUE rb_buffer)
 {
-	git_diff *diff = NULL;
+  git_diff *diff = NULL;
   const char *buffer;
-	size_t len;
-	VALUE rb_diff;
-	int error;
+  size_t len;
+  VALUE rb_diff;
+  int error;
 
   Check_Type(rb_buffer, T_STRING);
   buffer = RSTRING_PTR(rb_buffer);
@@ -677,7 +677,7 @@ static VALUE rb_git_diff_from_buffer(VALUE self, VALUE rb_buffer)
 
   error = git_diff_from_buffer(&diff, buffer, len);
   rugged_exception_check(error);
-  
+
   rb_diff = Data_Wrap_Struct(rb_cRuggedDiff, NULL, git_diff_free, diff);
   return rb_diff;
 }

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -2718,19 +2718,19 @@ static VALUE rb_git_repo_cherrypick_commit(int argc, VALUE *argv, VALUE self)
  */
 static VALUE rb_git_diff_from_buffer(VALUE self, VALUE rb_buffer)
 {
-  git_diff *diff = NULL;
-  const char *buffer;
-  size_t len;
-  int error;
+	git_diff *diff = NULL;
+	const char *buffer;
+	size_t len;
+	int error;
 
-  Check_Type(rb_buffer, T_STRING);
-  buffer = RSTRING_PTR(rb_buffer);
-  len = RSTRING_LEN(rb_buffer);
+	Check_Type(rb_buffer, T_STRING);
+	buffer = RSTRING_PTR(rb_buffer);
+	len = RSTRING_LEN(rb_buffer);
 
-  error = git_diff_from_buffer(&diff, buffer, len);
-  rugged_exception_check(error);
+	error = git_diff_from_buffer(&diff, buffer, len);
+	rugged_exception_check(error);
 
-  return rugged_diff_new(rb_cRuggedDiff, self, diff);
+	return rugged_diff_new(rb_cRuggedDiff, self, diff);
 }
 
 void Init_rugged_repo(void)

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -2710,6 +2710,29 @@ static VALUE rb_git_repo_cherrypick_commit(int argc, VALUE *argv, VALUE self)
 	return rugged_index_new(rb_cRuggedIndex, self, index);
 }
 
+/*
+ *  call-seq: repo.diff_from_buffer(buffer) -> Rugged::Diff object
+ *  
+ *  Where +buffer+ is a +String+.
+ *  Returns A Rugged::Diff object
+ */
+static VALUE rb_git_diff_from_buffer(VALUE self, VALUE rb_buffer)
+{
+  git_diff *diff = NULL;
+  const char *buffer;
+  size_t len;
+  int error;
+
+  Check_Type(rb_buffer, T_STRING);
+  buffer = RSTRING_PTR(rb_buffer);
+  len = RSTRING_LEN(rb_buffer);
+
+  error = git_diff_from_buffer(&diff, buffer, len);
+  rugged_exception_check(error);
+
+  return rugged_diff_new(rb_cRuggedDiff, self, diff);
+}
+
 void Init_rugged_repo(void)
 {
 	id_call = rb_intern("call");
@@ -2768,6 +2791,8 @@ void Init_rugged_repo(void)
 	rb_define_method(rb_cRuggedRepo, "apply", rb_git_repo_apply, -1);
 
 	rb_define_method(rb_cRuggedRepo, "revert_commit", rb_git_repo_revert_commit, -1);
+	
+	rb_define_method(rb_cRuggedRepo, "diff_from_buffer", rb_git_diff_from_buffer, 1);
 
 	rb_define_method(rb_cRuggedRepo, "path_ignored?", rb_git_repo_is_path_ignored, 1);
 

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -66,14 +66,14 @@ end
 
 class RepoDiffTest < Rugged::TestCase
   def test_new_from_buffer
+    repo    = FixtureRepo.from_libgit2("attr")
     patch1  = Rugged::Patch.from_strings("deleted\n", "added\n", old_path: "old", new_path: "new").to_s
-    diff1   = Rugged::Diff.from_buffer(patch1)
+    diff1   = repo.diff_from_buffer(patch1)
     assert_equal diff1.patch, patch1
     
-    repo    = FixtureRepo.from_libgit2("attr")
     diff2   = repo.diff("605812a", "370fe9ec22", :context_lines => 1, :interhunk_lines => 1)
     patch2  = diff2.patch
-    diff3   = Rugged::Diff.from_buffer(patch2)
+    diff3   = repo.diff_from_buffer(patch2)
     assert_equal diff3.patch, patch2
   end
   

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -1,14 +1,6 @@
 require "test_helper"
 
 class PatchFromStringsTest < Rugged::TestCase
-  def test_new_from_string
-    repo = FixtureRepo.from_libgit2("attr")
-    diff = repo.diff("605812a", nil)
-    patch = diff.patch
-    diff2 = Rugged::Diff.new_from_string(patch)
-    assert_equal diff2.patch, patch
-  end
-
   def test_from_strings_no_args
     patch = Rugged::Patch.from_strings()
     assert_equal 0, patch.size
@@ -73,6 +65,18 @@ EOS
 end
 
 class RepoDiffTest < Rugged::TestCase
+  def test_new_from_buffer
+    repo = FixtureRepo.from_libgit2("attr")
+    diff = repo.diff("605812a", nil)
+    patch = diff.patch
+    diff2 = Rugged::Diff.from_buffer(patch)
+    puts diff2.inspect
+    puts diff2.patch.inspect
+    puts "----------------"
+    puts patch
+    #assert_equal diff2.patch, patch
+  end
+  
   def test_with_oid_string
     repo = FixtureRepo.from_libgit2("attr")
     diff = repo.diff("605812a", "370fe9ec22", :context_lines => 1, :interhunk_lines => 1)

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -66,15 +66,16 @@ end
 
 class RepoDiffTest < Rugged::TestCase
   def test_new_from_buffer
-    repo = FixtureRepo.from_libgit2("attr")
-    diff = repo.diff("605812a", nil)
-    patch = diff.patch
-    diff2 = Rugged::Diff.from_buffer(patch)
-    puts diff2.inspect
-    puts diff2.patch.inspect
-    puts "----------------"
-    puts patch
-    #assert_equal diff2.patch, patch
+    patch1  = Rugged::Patch.from_strings("deleted\n", "added\n", old_path: "old", new_path: "new").to_s
+    diff1   = Rugged::Diff.from_buffer(patch1)
+    assert_equal diff1.patch, patch1
+    
+    # This currently breaks
+    repo    = FixtureRepo.from_libgit2("attr")
+    diff2   = repo.diff("605812a", nil)
+    patch2  = diff2.patch
+    diff3   = Rugged::Diff.from_buffer(patch2)
+    assert_equal diff3.patch, patch2
   end
   
   def test_with_oid_string

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -70,9 +70,8 @@ class RepoDiffTest < Rugged::TestCase
     diff1   = Rugged::Diff.from_buffer(patch1)
     assert_equal diff1.patch, patch1
     
-    # This currently breaks
     repo    = FixtureRepo.from_libgit2("attr")
-    diff2   = repo.diff("605812a", nil)
+    diff2   = repo.diff("605812a", "370fe9ec22", :context_lines => 1, :interhunk_lines => 1)
     patch2  = diff2.patch
     diff3   = Rugged::Diff.from_buffer(patch2)
     assert_equal diff3.patch, patch2

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -1,6 +1,14 @@
 require "test_helper"
 
 class PatchFromStringsTest < Rugged::TestCase
+  def test_new_from_string
+    repo = FixtureRepo.from_libgit2("attr")
+    diff = repo.diff("605812a", nil)
+    patch = diff.patch
+    diff2 = Rugged::Diff.new_from_string(patch)
+    assert_equal diff2.patch, patch
+  end
+
   def test_from_strings_no_args
     patch = Rugged::Patch.from_strings()
     assert_equal 0, patch.size


### PR DESCRIPTION
This PR exposes libgit2's `git_diff_from_buffer(git_diff **out, const char *content, size_t content_len)` [function](https://github.com/libgit2/libgit2/blob/master/src/diff_parse.c#L68-L107) in rugged by adding a class method `Rugged::Diff::from_buffer(buffer)`. This allows for creating Rugged::Diff objects from patches in String format. Please have a look at the code and let @dometto and myself know if this PR is on the right track.

BTW, one peculiar thing we noticed while writing the tests for this PR is that `git_diff_from_buffer` rejects patches that are created with `Rugged::Repository#diff(left, right, options={})` if either `left` or `right` is set to `nil`. According to [the test suite](https://github.com/libgit2/rugged/blob/master/test/diff_test.rb#L108-L157) this is allowed, but as I said, the resulting patches are rejected with error code `-1`. For example, the following creates three patches, the first two of which are rejected by `git_diff_from_buffer`, but the third works fine:
```ruby
repo = FixtureRepo.from_libgit2("attr")
patch1 = repo.diff(nil, "370fe9ec22").patch
patch2 = repo.diff("605812a", nil).patch
patch3 = repo.diff("605812a", "370fe9ec22").patch
puts patch1.inspect
puts patch2.inspect
puts patch3.inspect
```

Can anyone (@ethomson ?) help explain this behavior? Does it make sense or is this a bug?