### PR TITLE
Fix Windows builds

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -30,7 +30,8 @@ end
 
 def self.run_cmake(timeout, args)
   # Set to process group so we can kill it and its children
-  pid = Process.spawn("cmake #{args}", pgroup: true)
+  pgroup = Gem.win_platform? ? :new_pgroup : :pgroup
+  pid = Process.spawn("cmake #{args}", pgroup => true)
 
   Timeout.timeout(timeout) do
     Process.waitpid(pid)

--- a/rugged.gemspec
+++ b/rugged.gemspec
@@ -31,4 +31,5 @@ desc
   s.add_development_dependency "rake-compiler", ">= 0.9.0"
   s.add_development_dependency "pry"
   s.add_development_dependency "minitest", "~> 5.0"
+  s.metadata["msys2_mingw_dependencies"] = "libssh2"
 end


### PR DESCRIPTION
This pull request addresses two issues preventing rugged 0.28 from installing successfully on Windows:

- `pgroup` is not available on Windows (the alternative is `new_pgroup`)
- The mingw `libssh2` package, which is required for building rugged, is not installed out of the box on RubyInstaller with MSYS2