### PR TITLE
implement SshKeyFromMemory

### DIFF
--- a/ext/rugged/rugged_cred.c
+++ b/ext/rugged/rugged_cred.c
@@ -11,6 +11,7 @@ extern VALUE rb_mRugged;
 VALUE rb_mRuggedCred;
 VALUE rb_cRuggedCredUserPassword;
 VALUE rb_cRuggedCredSshKey;
+VALUE rb_cRuggedCredSshKeyFromMemory;
 VALUE rb_cRuggedCredSshKeyFromAgent;
 VALUE rb_cRuggedCredDefault;
 
@@ -47,6 +48,31 @@ static void rugged_cred_extract_ssh_key(git_cred **cred, VALUE rb_credential)
 
 	rugged_exception_check(
 		git_cred_ssh_key_new(cred,
+			StringValueCStr(rb_username),
+			NIL_P(rb_publickey) ? NULL : StringValueCStr(rb_publickey),
+			StringValueCStr(rb_privatekey),
+			NIL_P(rb_passphrase) ? NULL : StringValueCStr(rb_passphrase)
+		)
+	);
+}
+
+static void rugged_cred_extract_ssh_key_from_memory(git_cred **cred, VALUE rb_credential)
+{
+	VALUE rb_username   = rb_iv_get(rb_credential, "@username");
+	VALUE rb_publickey  = rb_iv_get(rb_credential, "@publickey");
+	VALUE rb_privatekey = rb_iv_get(rb_credential, "@privatekey");
+	VALUE rb_passphrase = rb_iv_get(rb_credential, "@passphrase");
+
+	Check_Type(rb_username, T_STRING);
+	Check_Type(rb_privatekey, T_STRING);
+
+	if (!NIL_P(rb_publickey))
+		Check_Type(rb_publickey, T_STRING);
+	if (!NIL_P(rb_passphrase))
+		Check_Type(rb_passphrase, T_STRING);
+
+	rugged_exception_check(
+		git_cred_ssh_key_memory_new(cred,
 			StringValueCStr(rb_username),
 			NIL_P(rb_publickey) ? NULL : StringValueCStr(rb_publickey),
 			StringValueCStr(rb_privatekey),
@@ -101,6 +127,16 @@ void rugged_cred_extract(git_cred **cred, int allowed_types, VALUE rb_credential
 			rb_raise(rb_eArgError, "Invalid credential type");
 
 		rugged_cred_extract_ssh_key(cred, rb_credential);
+	} else if (rb_obj_is_kind_of(rb_credential, rb_cRuggedCredSshKeyFromMemory)) {
+		if (allowed_types & GIT_CREDTYPE_USERNAME) {
+			rugged_cred_extract_username(cred, rb_credential);
+			return;
+		}
+
+		if (!(allowed_types & GIT_CREDTYPE_SSH_KEY))
+			rb_raise(rb_eArgError, "Invalid credential type");
+
+		rugged_cred_extract_ssh_key_from_memory(cred, rb_credential);
 	} else if (rb_obj_is_kind_of(rb_credential, rb_cRuggedCredSshKeyFromAgent)) {
 		if (allowed_types & GIT_CREDTYPE_USERNAME) {
 			rugged_cred_extract_username(cred, rb_credential);
@@ -122,10 +158,11 @@ void rugged_cred_extract(git_cred **cred, int allowed_types, VALUE rb_credential
 
 void Init_rugged_cred(void)
 {
-	rb_mRuggedCred                = rb_define_module_under(rb_mRugged, "Credentials");
+	rb_mRuggedCred                 = rb_define_module_under(rb_mRugged, "Credentials");
 
-	rb_cRuggedCredUserPassword    = rb_define_class_under(rb_mRuggedCred, "UserPassword", rb_cObject);
-	rb_cRuggedCredSshKey          = rb_define_class_under(rb_mRuggedCred, "SshKey", rb_cObject);
-	rb_cRuggedCredSshKeyFromAgent = rb_define_class_under(rb_mRuggedCred, "SshKeyFromAgent", rb_cObject);
-	rb_cRuggedCredDefault         = rb_define_class_under(rb_mRuggedCred, "Default", rb_cObject);
+	rb_cRuggedCredUserPassword     = rb_define_class_under(rb_mRuggedCred, "UserPassword", rb_cObject);
+	rb_cRuggedCredSshKey           = rb_define_class_under(rb_mRuggedCred, "SshKey", rb_cObject);
+	rb_cRuggedCredSshKeyFromMemory = rb_define_class_under(rb_mRuggedCred, "SshKeyFromMemory", rb_cObject);
+	rb_cRuggedCredSshKeyFromAgent  = rb_define_class_under(rb_mRuggedCred, "SshKeyFromAgent", rb_cObject);
+	rb_cRuggedCredDefault          = rb_define_class_under(rb_mRuggedCred, "Default", rb_cObject);
 }

--- a/lib/rugged/credentials.rb
+++ b/lib/rugged/credentials.rb
@@ -17,12 +17,25 @@ module Rugged
     end
 
     # A ssh key credential object that can optionally be passphrase-protected
+    # publickey and privatekey are filenames that will be opened to load the key
     class SshKey
       def initialize(options)
         @username, @publickey, @privatekey, @passphrase = options[:username], options[:publickey], options[:privatekey], options[:passphrase]
       end
 
       def call(url, username_from_url, allowed_types)
+        self
+      end
+    end
+
+    # A ssh key credential object that can optionally be passphrase-protected
+    # publickey and privatekey are string that are the actual contents of the key
+    class SshKeyFromMemory
+      def initialize(options)
+        @username, @publickey, @privatekey, @passphrase = options[:username], options[:publickey], options[:privatekey], options[:passphrase]
+      end
+
+      def call(*)
         self
       end
     end

--- a/test/online/clone_test.rb
+++ b/test/online/clone_test.rb
@@ -22,6 +22,16 @@ class OnlineCloneTest < Rugged::OnlineTestCase
       end
     end
 
+    def test_clone_over_ssh_with_credentials
+      Dir.mktmpdir do |dir|
+        repo = Rugged::Repository.clone_at(ENV['GITTEST_REMOTE_SSH_URL'], dir, {
+            credentials: ssh_key_credential_from_memory
+        })
+
+        assert_instance_of Rugged::Repository, repo
+      end
+    end
+
     def test_clone_over_ssh_with_credentials_from_agent
       Dir.mktmpdir do |dir|
         repo = Rugged::Repository.clone_at(ENV['GITTEST_REMOTE_SSH_URL'], dir, {

--- a/test/online/fetch_test.rb
+++ b/test/online/fetch_test.rb
@@ -81,6 +81,14 @@ class OnlineFetchTest < Rugged::OnlineTestCase
       })
     end
 
+    def test_fetch_over_ssh_with_credentials_from_memory
+      @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
+
+      @repo.fetch("origin", {
+          credentials: ssh_key_credential_from_memory
+      })
+    end
+
     def test_fetch_over_ssh_with_credentials_from_agent
       @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -162,6 +162,15 @@ module Rugged
       })
     end
 
+    def ssh_key_credential_from_memory
+      Rugged::Credentials::SshKeyFromMemory.new({
+        username:   ENV["GITTEST_REMOTE_SSH_USER"],
+        publickey:  File.read(ENV["GITTEST_REMOTE_SSH_PUBKEY"]),
+        privatekey: File.read(ENV["GITTEST_REMOTE_SSH_KEY"]),
+        passphrase: ENV["GITTEST_REMOTE_SSH_PASSPHASE"],
+      })
+    end
+
     def ssh_key_credential_from_agent
       Rugged::Credentials::SshKeyFromAgent.new({
         username: ENV["GITTEST_REMOTE_SSH_USER"]


### PR DESCRIPTION
fixes gh-796

libgit2 already supports it.

I wrote the tests for it, but was unable to get _any_ of the OnlineTests to work. I'm guessing I probably just don't fully understand what I'm supposed to put in the environment variables. I did test it for reals. And I also tested it with libgit2 not having libssh2 support (since ssh key from memory is an optional feature), and Rugged's extensions still compiles. I did not test it with a libgit2 with libssh2 support, but _not_ support for ssh key from memory (presumably a crypto backend other than openssl?).