### PR TITLE
helper methods to get actual Objects, not just information about them

### DIFF
--- a/lib/rugged/diff/delta.rb
+++ b/lib/rugged/diff/delta.rb
@@ -50,6 +50,14 @@ module Rugged
         status == :typechange
       end
 
+      def old_blob
+        owner.owner.lookup(old_file[:oid]) unless added?
+      end
+
+      def new_blob
+        owner.owner.lookup(new_file[:oid]) unless deleted?
+      end
+
       def inspect
         "#<#{self.class.name}:#{object_id} {old_file: #{old_file.inspect}, new_file: #{new_file.inspect}, similarity: #{similarity.inspect}, status: #{status.inspect}>"
       end

--- a/lib/rugged/tree.rb
+++ b/lib/rugged/tree.rb
@@ -164,6 +164,11 @@ module Rugged
       Tree.diff(repo, self, other, options)
     end
 
+    def lookup(entry_id)
+      entry = get_entry(entry_id)
+      owner.lookup(entry[:oid]) if entry
+    end
+
     def inspect
       data = "#<Rugged::Tree:#{object_id} {oid: #{oid}}>\n"
       self.each { |e| data << "  <\"#{e[:name]}\" #{e[:oid]}>\n" }


### PR DESCRIPTION
avoids having to have the caller keep looking up objects directly from
the repo