### PR TITLE
Unlock GVL callback should be `void *(*)(void *)`

### DIFF
--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -204,12 +204,14 @@ struct nogvl_diff_patch_args {
 	VALUE rb_str;
 };
 
-static void rb_git_diff_patch_nogvl(void * _args)
+static void * rb_git_diff_patch_nogvl(void * _args)
 {
 	struct nogvl_diff_patch_args * args;
 
 	args = (struct nogvl_diff_patch_args *)_args;
 	git_diff_print(args->diff, args->format, diff_print_cb, (void*) args->rb_str);
+
+        return NULL;
 }
 
 /*


### PR DESCRIPTION
I use strict compiler flags on my version of Ruby.  Since the callback
signature didn't match correctly, compilation would fail.  This fixes
the nogvl callback signature.