### PR TITLE
Use TypedData when wrapping library objects

### DIFF
--- a/ext/rugged/rugged_blob.c
+++ b/ext/rugged/rugged_blob.c
@@ -17,6 +17,8 @@ static ID id_read;
 VALUE rb_cRuggedBlob;
 VALUE rb_cRuggedBlobSig;
 
+extern const rb_data_type_t rugged_object_type;
+
 /*
  *  call-seq:
  *    blob.text(max_lines = -1, encoding = Encoding.default_external) -> string
@@ -38,7 +40,7 @@ static VALUE rb_git_blob_text_GET(int argc, VALUE *argv, VALUE self)
 	const char *content;
 	VALUE rb_max_lines, rb_encoding;
 
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 	rb_scan_args(argc, argv, "02", &rb_max_lines, &rb_encoding);
 
 	content = git_blob_rawcontent(blob);
@@ -85,7 +87,7 @@ static VALUE rb_git_blob_content_GET(int argc, VALUE *argv, VALUE self)
 	const char *content;
 	VALUE rb_max_bytes;
 
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 	rb_scan_args(argc, argv, "01", &rb_max_bytes);
 
 	content = git_blob_rawcontent(blob);
@@ -119,7 +121,7 @@ static VALUE rb_git_blob_content_GET(int argc, VALUE *argv, VALUE self)
 static VALUE rb_git_blob_rawsize(VALUE self)
 {
 	git_blob *blob;
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 
 	return INT2FIX(git_blob_rawsize(blob));
 }
@@ -304,7 +306,7 @@ static VALUE rb_git_blob_loc(VALUE self)
 	const char *data, *data_end;
 	size_t loc = 0;
 
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 
 	data = git_blob_rawcontent(blob);
 	data_end = data + git_blob_rawsize(blob);
@@ -343,7 +345,7 @@ static VALUE rb_git_blob_sloc(VALUE self)
 	const char *data, *data_end;
 	size_t sloc = 0;
 
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 
 	data = git_blob_rawcontent(blob);
 	data_end = data + git_blob_rawsize(blob);
@@ -383,7 +385,7 @@ static VALUE rb_git_blob_sloc(VALUE self)
 static VALUE rb_git_blob_is_binary(VALUE self)
 {
 	git_blob *blob;
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 	return git_blob_is_binary(blob) ? Qtrue : Qfalse;
 }
 
@@ -467,14 +469,14 @@ static VALUE rb_git_blob_diff(int argc, VALUE *argv, VALUE self)
 		rugged_parse_diff_options(&opts, rb_options);
 	}
 
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 
 	if (NIL_P(rb_other)) {
 		error = git_patch_from_blobs(&patch, blob, old_path, NULL, new_path, &opts);
 	} else if (rb_obj_is_kind_of(rb_other, rb_cRuggedBlob)) {
 		git_blob *other_blob;
 
-		Data_Get_Struct(rb_other, git_blob, other_blob);
+		TypedData_Get_Struct(rb_other, git_blob, &rugged_object_type, other_blob);
 
 		error = git_patch_from_blobs(&patch, blob, old_path, other_blob, new_path, &opts);
 	} else if (TYPE(rb_other) == T_STRING) {
@@ -649,7 +651,7 @@ static VALUE rb_git_blob_sig_new(int argc, VALUE *argv, VALUE klass)
 
 	if (rb_obj_is_kind_of(rb_blob, rb_cRuggedBlob)) {
 		git_blob *blob;
-		Data_Get_Struct(rb_blob, git_blob, blob);
+		TypedData_Get_Struct(rb_blob, git_blob, &rugged_object_type, blob);
 
 		error = git_hashsig_create(&sig,
 				git_blob_rawcontent(blob),

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -15,6 +15,8 @@ extern VALUE rb_cRuggedRepo;
 extern VALUE rb_cRuggedSignature;
 VALUE rb_cRuggedCommit;
 
+extern const rb_data_type_t rugged_object_type;
+
 /*
  *  call-seq:
  *    commit.message -> msg
@@ -35,7 +37,7 @@ static VALUE rb_git_commit_message_GET(VALUE self)
 	const char *encoding_name;
 	const char *message;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	message = git_commit_message(commit);
 	encoding_name = git_commit_message_encoding(commit);
@@ -68,7 +70,7 @@ static VALUE rb_git_commit_trailers_GET(VALUE self)
 	int error;
 	size_t i;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	encoding_name = git_commit_message_encoding(commit);
 	if (encoding_name != NULL)
@@ -118,7 +120,7 @@ static VALUE rb_git_commit_summary_GET(VALUE self)
 	const char *encoding_name;
 	const char *summary;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	summary = git_commit_summary(commit);
 	encoding_name = git_commit_message_encoding(commit);
@@ -147,7 +149,7 @@ static VALUE rb_git_commit_summary_GET(VALUE self)
 static VALUE rb_git_commit_committer_GET(VALUE self)
 {
 	git_commit *commit;
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	return rugged_signature_new(
 		git_commit_committer(commit),
@@ -172,7 +174,7 @@ static VALUE rb_git_commit_committer_GET(VALUE self)
 static VALUE rb_git_commit_author_GET(VALUE self)
 {
 	git_commit *commit;
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	return rugged_signature_new(
 		git_commit_author(commit),
@@ -192,7 +194,7 @@ static VALUE rb_git_commit_author_GET(VALUE self)
 static VALUE rb_git_commit_epoch_time_GET(VALUE self)
 {
 	git_commit *commit;
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	return ULONG2NUM(git_commit_time(commit));
 }
@@ -213,7 +215,7 @@ static VALUE rb_git_commit_tree_GET(VALUE self)
 	VALUE owner;
 	int error;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 	owner = rugged_owner(self);
 
 	error = git_commit_tree(&tree, commit);
@@ -236,7 +238,7 @@ static VALUE rb_git_commit_tree_id_GET(VALUE self)
 	git_commit *commit;
 	const git_oid *tree_id;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	tree_id = git_commit_tree_id(commit);
 
@@ -262,7 +264,7 @@ static VALUE rb_git_commit_parents_GET(VALUE self)
 	VALUE ret_arr, owner;
 	int error;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 	owner = rugged_owner(self);
 
 	parent_count = git_commit_parentcount(commit);
@@ -295,7 +297,7 @@ static VALUE rb_git_commit_parent_ids_GET(VALUE self)
 	unsigned int n, parent_count;
 	VALUE ret_arr;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	parent_count = git_commit_parentcount(commit);
 	ret_arr = rb_ary_new2((long)parent_count);
@@ -352,7 +354,7 @@ static VALUE rb_git_commit_amend(VALUE self, VALUE rb_data)
 
 	Check_Type(rb_data, T_HASH);
 
-	Data_Get_Struct(self, git_commit, commit_to_amend);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit_to_amend);
 
 	owner = rugged_owner(self);
 	Data_Get_Struct(owner, git_repository, repo);
@@ -474,7 +476,7 @@ static VALUE parse_commit_options(struct commit_data *out, git_repository *repo,
 			if (error < GIT_OK)
 				goto out;
 		} else if (rb_obj_is_kind_of(p, rb_cRuggedCommit)) {
-			Data_Get_Struct(p, git_commit, tmp);
+			TypedData_Get_Struct(p, git_commit, &rugged_object_type, tmp);
 			if ((error = git_object_dup((git_object **) &parent, (git_object *) tmp)) < 0)
 				goto out;
 		} else {
@@ -614,7 +616,7 @@ static VALUE rb_git_commit_to_mbox(int argc, VALUE *argv, VALUE self)
 	rugged_check_repo(rb_repo);
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	if (!NIL_P(rb_options)) {
 		Check_Type(rb_options, T_HASH);
@@ -673,7 +675,7 @@ static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field)
 	int error;
 
 	Check_Type(rb_field, T_STRING);
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	error = git_commit_header_field(&header_field, commit, StringValueCStr(rb_field));
 
@@ -704,7 +706,7 @@ static VALUE rb_git_commit_header(VALUE self)
 	git_commit *commit;
 	const char *raw_header;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	raw_header = git_commit_raw_header(commit);
 	return rb_str_new_utf8(raw_header);

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -13,6 +13,8 @@ extern VALUE rb_cRuggedCommit;
 extern VALUE rb_cRuggedDiff;
 extern VALUE rb_cRuggedTree;
 
+extern const rb_data_type_t rugged_object_type;
+
 static void rb_git_indexentry_toC(git_index_entry *entry, VALUE rb_entry);
 static VALUE rb_git_indexentry_fromC(const git_index_entry *entry);
 
@@ -658,7 +660,7 @@ static VALUE rb_git_index_readtree(VALUE self, VALUE rb_tree)
 	int error;
 
 	Data_Get_Struct(self, git_index, index);
-	Data_Get_Struct(rb_tree, git_tree, tree);
+	TypedData_Get_Struct(rb_tree, git_tree, &rugged_object_type, tree);
 
 	if (!rb_obj_is_kind_of(rb_tree, rb_cRuggedTree)) {
 		rb_raise(rb_eTypeError, "A Rugged::Tree instance is required");
@@ -690,7 +692,7 @@ static VALUE rb_git_diff_tree_to_index(VALUE self, VALUE rb_other, VALUE rb_opti
 	// the "old file" side of the diff.
 	opts.flags ^= GIT_DIFF_REVERSE;
 
-	Data_Get_Struct(rb_other, git_tree, other_tree);
+	TypedData_Get_Struct(rb_other, git_tree, &rugged_object_type, other_tree);
 	error = git_diff_tree_to_index(&diff, repo, other_tree, index, &opts);
 
 	xfree(opts.pathspec.strings);

--- a/ext/rugged/rugged_note.c
+++ b/ext/rugged/rugged_note.c
@@ -10,6 +10,8 @@
 extern VALUE rb_cRuggedRepo;
 extern VALUE rb_cRuggedObject;
 
+extern const rb_data_type_t rugged_object_type;
+
 static VALUE rugged_git_note_message(const git_note *note)
 {
 	const char *message;
@@ -59,7 +61,7 @@ static VALUE rb_git_note_lookup(int argc, VALUE *argv, VALUE self)
 		notes_ref = StringValueCStr(rb_notes_ref);
 	}
 
-	Data_Get_Struct(self, git_object, object);
+	TypedData_Get_Struct(self, git_object, &rugged_object_type, object);
 
 	owner = rugged_owner(self);
 	Data_Get_Struct(owner, git_repository, repo);
@@ -124,7 +126,7 @@ static VALUE rb_git_note_create(VALUE self, VALUE rb_data)
 
 	Check_Type(rb_data, T_HASH);
 
-	Data_Get_Struct(self, git_object, target);
+	TypedData_Get_Struct(self, git_object, &rugged_object_type, target);
 
 	owner = rugged_owner(self);
 	Data_Get_Struct(owner, git_repository, repo);
@@ -207,7 +209,7 @@ static VALUE rb_git_note_remove(int argc, VALUE *argv, VALUE self)
 	VALUE rb_committer = Qnil;
 	VALUE owner;
 
-	Data_Get_Struct(self, git_object, target);
+	TypedData_Get_Struct(self, git_object, &rugged_object_type, target);
 
 	owner = rugged_owner(self);
 	Data_Get_Struct(owner, git_repository, repo);

--- a/ext/rugged/rugged_rebase.c
+++ b/ext/rugged/rugged_rebase.c
@@ -15,6 +15,8 @@ extern VALUE rb_cRuggedReference;
 
 VALUE rb_cRuggedRebase;
 
+extern const rb_data_type_t rugged_object_type;
+
 static VALUE rebase_operation_type(git_rebase_operation *operation);
 
 static void parse_rebase_options(git_rebase_options *ret, VALUE rb_options)
@@ -70,7 +72,7 @@ static void get_annotated_commit(git_annotated_commit **annotated_commit, VALUE 
 		const git_commit * commit;
 		const git_oid * oid;
 
-		Data_Get_Struct(rb_value, git_commit, commit);
+		TypedData_Get_Struct(rb_value, git_commit, &rugged_object_type, commit);
 
 		oid = git_commit_id(commit);
 		error = git_annotated_commit_lookup(annotated_commit, repo, oid);

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -34,6 +34,8 @@ VALUE rb_cRuggedOdbObject;
 
 static ID id_call;
 
+extern const rb_data_type_t rugged_object_type;
+
 /*
  *  call-seq:
  *    odb_obj.oid -> hex_oid
@@ -882,7 +884,7 @@ static VALUE rb_git_repo_merge_analysis(int argc, VALUE *argv, VALUE self)
 		rb_raise(rb_eArgError, "Expected a Rugged::Commit.");
 	}
 
-	Data_Get_Struct(rb_their_commit, git_commit, their_commit);
+	TypedData_Get_Struct(rb_their_commit, git_commit, &rugged_object_type, their_commit);
 
 	error = git_annotated_commit_lookup(&annotated_commit, repo, git_commit_id(their_commit));
 	rugged_exception_check(error);
@@ -950,8 +952,8 @@ static VALUE rb_git_repo_revert_commit(int argc, VALUE *argv, VALUE self)
 	}
 
 	Data_Get_Struct(self, git_repository, repo);
-	Data_Get_Struct(rb_revert_commit, git_commit, revert_commit);
-	Data_Get_Struct(rb_our_commit, git_commit, our_commit);
+	TypedData_Get_Struct(rb_revert_commit, git_commit, &rugged_object_type, revert_commit);
+	TypedData_Get_Struct(rb_our_commit, git_commit, &rugged_object_type, our_commit);
 
 	error = git_revert_commit(&index, repo, revert_commit, our_commit, mainline, &opts);
 	if (error == GIT_EMERGECONFLICT)
@@ -1068,8 +1070,8 @@ static VALUE rb_git_repo_merge_commits(int argc, VALUE *argv, VALUE self)
 	}
 
 	Data_Get_Struct(self, git_repository, repo);
-	Data_Get_Struct(rb_our_commit, git_commit, our_commit);
-	Data_Get_Struct(rb_their_commit, git_commit, their_commit);
+	TypedData_Get_Struct(rb_our_commit, git_commit, &rugged_object_type, our_commit);
+	TypedData_Get_Struct(rb_their_commit, git_commit, &rugged_object_type, their_commit);
 
 	error = git_merge_commits(&index, repo, our_commit, their_commit, &opts);
 	if (error == GIT_EMERGECONFLICT)
@@ -2183,7 +2185,7 @@ void rugged_parse_checkout_options(git_checkout_options *opts, VALUE rb_options)
 	rb_value = rb_hash_aref(rb_options, CSTR2SYM("baseline"));
 	if (!NIL_P(rb_value)) {
 		if (rb_obj_is_kind_of(rb_value, rb_cRuggedTree)) {
-			Data_Get_Struct(rb_value, git_tree, opts->baseline);
+			TypedData_Get_Struct(rb_value, git_tree, &rugged_object_type, opts->baseline);
 		} else {
 			rb_raise(rb_eTypeError, "Expected a Rugged::Tree.");
 		}
@@ -2347,7 +2349,7 @@ static VALUE rb_git_checkout_tree(int argc, VALUE *argv, VALUE self)
 	}
 
 	Data_Get_Struct(self, git_repository, repo);
-	Data_Get_Struct(rb_treeish, git_object, treeish);
+	TypedData_Get_Struct(rb_treeish, git_object, &rugged_object_type, treeish);
 
 	rugged_parse_checkout_options(&opts, rb_options);
 
@@ -2645,7 +2647,7 @@ static VALUE rb_git_repo_cherrypick(int argc, VALUE *argv, VALUE self)
 	}
 
 	Data_Get_Struct(self, git_repository, repo);
-	Data_Get_Struct(rb_commit, git_commit, commit);
+	TypedData_Get_Struct(rb_commit, git_commit, &rugged_object_type, commit);
 
 	rugged_parse_cherrypick_options(&opts, rb_options);
 
@@ -2698,8 +2700,8 @@ static VALUE rb_git_repo_cherrypick_commit(int argc, VALUE *argv, VALUE self)
 	}
 
 	Data_Get_Struct(self, git_repository, repo);
-	Data_Get_Struct(rb_commit, git_commit, commit);
-	Data_Get_Struct(rb_our_commit, git_commit, our_commit);
+	TypedData_Get_Struct(rb_commit, git_commit, &rugged_object_type, commit);
+	TypedData_Get_Struct(rb_our_commit, git_commit, &rugged_object_type, our_commit);
 
 	rugged_parse_merge_options(&opts, rb_options);
 

--- a/ext/rugged/rugged_tag.c
+++ b/ext/rugged/rugged_tag.c
@@ -15,6 +15,8 @@ extern VALUE rb_cRuggedReference;
 VALUE rb_cRuggedTag;
 VALUE rb_cRuggedTagAnnotation;
 
+extern const rb_data_type_t rugged_object_type;
+
 /*
  *  call-seq:
  *    annotation.target -> object
@@ -31,7 +33,7 @@ static VALUE rb_git_tag_annotation_target(VALUE self)
 	int error;
 	VALUE owner;
 
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 	owner = rugged_owner(self);
 
 	error = git_tag_target(&target, tag);
@@ -55,7 +57,7 @@ static VALUE rb_git_tag_annotation_target_id(VALUE self)
 	git_tag *tag;
 	const git_oid *target_oid;
 
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 
 	target_oid = git_tag_target_id(tag);
 
@@ -77,7 +79,7 @@ static VALUE rb_git_tag_annotation_target_id(VALUE self)
 static VALUE rb_git_tag_annotation_target_type(VALUE self)
 {
 	git_tag *tag;
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 
 	return rugged_otype_new(git_tag_target_type(tag));
 }
@@ -93,7 +95,7 @@ static VALUE rb_git_tag_annotation_target_type(VALUE self)
 static VALUE rb_git_tag_annotation_name(VALUE self)
 {
 	git_tag *tag;
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 
 	return rb_str_new_utf8(git_tag_name(tag));
 }
@@ -113,7 +115,7 @@ static VALUE rb_git_tag_annotation_tagger(VALUE self)
 	git_tag *tag;
 	const git_signature *tagger;
 
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 	tagger = git_tag_tagger(tag);
 
 	if (!tagger)
@@ -136,7 +138,7 @@ static VALUE rb_git_tag_annotation_message(VALUE self)
 	git_tag *tag;
 	const char *message;
 
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 	message = git_tag_message(tag);
 
 	if (!message)


### PR DESCRIPTION
This lets us provide more information to the ruby VM about what our objects look
like including information about how much memory they use up.