### PR TITLE
Update to libgit2 v0.27.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,6 @@ git:
 before_install:
   - git submodule update --init
   - gem update --system
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./vendor/libgit2/script/install-deps-osx.sh; fi
+  - if [ "$TRAVIfS_OS_NAME" = "osx" ]; then ./vendor/libgit2/ci/setup-osx.sh; fi
 
 script: script/travisbuild

--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '0.27.7'
+  Version = VERSION = '0.27.9'
 end


### PR DESCRIPTION
This is a security release. See the libgit2 release notes for details. https://github.com/libgit2/libgit2/releases/tag/v0.27.9