### PR TITLE
Move the bulk of CI to Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: Rugged CI
+
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+    - maint/*
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.3.7', '2.4.6', '2.5.5', '2.6.2' ]
+        os: [ ubuntu-18.04, macOS-10.14 ]
+
+    runs-on: ${{ matrix.os }}
+
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@master
+    - name: update submodule
+      run: git submodule update --init
+    - name: Install Linux packages
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt update
+        sudo apt install -y cmake libssh2-1-dev openssh-client openssh-server
+    - name: Install macOS packages
+      if: runner.os == 'macOS'
+      run: ./vendor/libgit2/azure-pipelines/setup-osx.sh
+    - name: Set up Ruby on Linux
+      if: runner.os == 'Linux'
+      uses: actions/setup-ruby@v1
+      with:
+        version: ${{ matrix.ruby }}
+    - name: Set up Ruby on macOS
+      if: runner.os == 'macOS'
+      run: |
+        brew install rbenv
+        rbenv install ${{ matrix.ruby }}
+        rbenv local ${{ matrix.ruby }}
+    - name: run build
+      run: |
+        if [ -x rbenv ]; then eval "$(rbenv init -)"; fi
+        ruby --version
+        gem install bundler
+        bundle install --path vendor
+        ./script/travisbuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,7 @@ os:
   - osx
 
 rvm:
-  - 2.3.3
-  - 2.4.0
-  - 2.5.0
-  - 2.6
   - ruby-head
-  - rbx-2
 
 addons:
   apt:

--- a/script/travisbuild
+++ b/script/travisbuild
@@ -1,9 +1,14 @@
 #!/bin/sh
 
+set -ex
+
 # Create a test repo which we can use for the online tests
 mkdir $HOME/_temp
 git init --bare $HOME/_temp/test.git
 git daemon --listen=localhost --export-all --enable=receive-pack --base-path=$HOME/_temp $HOME/_temp 2>/dev/null &
+
+# On Actions we start with 777 which means sshd won't let us in
+chmod 750 $HOME
 
 ssh-keygen -t rsa -f ~/.ssh/rugged_test_rsa -N "" -q
 cat ~/.ssh/rugged_test_rsa.pub >>~/.ssh/authorized_keys


### PR DESCRIPTION
Build the main portion on Actions. This gives us particularly a speedup on macOS builds. I've kept the `ruby-head` on Travis as it's more convenient there for the moment.