### PR TITLE
Bump version to v0.28.3.1

### DIFF
--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '0.28.3'
+  Version = VERSION = '0.28.3.1'
 end


### PR DESCRIPTION
Both the v0.28.3 tag and uploaded gem were wrong, in different ways. The tag
pointed to v0.28.2 and the gem was made off of master.

Bump the version so we can create a new tag and upload.