### PR TITLE
Ensure exception is initialized, in case nentries is zero.

### DIFF
--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -1696,7 +1696,7 @@ static VALUE rb_git_repo_file_status(VALUE self, VALUE rb_path)
 
 static VALUE rb_git_repo_file_each_status(VALUE self)
 {
-	int error, exception;
+	int error, exception = 0;
 	size_t i, nentries;
 	git_repository *repo;
 	git_status_list *list;


### PR DESCRIPTION
Fixes https://github.com/libgit2/rugged/issues/819.