### PR TITLE
Fix build error on Windows related to pgroup option being used in Pro…

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -31,7 +31,7 @@ end
 
 def self.run_cmake(timeout, args)
   # Set to process group so we can kill it and its children
-  pid = Process.spawn("cmake #{args}", pgroup: true)
+  pid = Process.spawn("cmake #{args}", pgroup: !Gem.win_platform?, new_pgroup: Gem.win_platform?)
 
   Timeout.timeout(timeout) do
     Process.waitpid(pid)


### PR DESCRIPTION
…cess.spawn in extconf.rb instead of new_pgroup. Fixes issue #791.

Proof that it works on Windows:

```
C:\Users\preet\Projects\rugged>gem build rugged.gemspec
WARNING:  open-ended dependency on rake-compiler (>= 0.9.0, development) is not recommended
  if rake-compiler is semantically versioned, use:
    add_development_dependency 'rake-compiler', '~> 0.9', '>= 0.9.0'
WARNING:  open-ended dependency on pry (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: rugged
  Version: 0.28.0
  File: rugged-0.28.0.gem

C:\Users\preet\Projects\rugged>gem install rugged-0.28.0.gem
Temporarily enhancing PATH for MSYS/MINGW...
Building native extensions. This could take a while...
Successfully installed rugged-0.28.0
1 gem installed

C:\Users\preet\Projects\rugged>cd ext

C:\Users\preet\Projects\rugged\ext>irb
irb(main):001:0> require 'rugged'
=> true
irb(main):002:0> Rugged::Repository.discover('.')
=> #<Rugged::Repository:57862520 {path: "C:/Users/preet/Projects/rugged/.git/"}>
irb(main):003:0> exit

C:\Users\preet\Projects\rugged\ext>git log -n 2
commit 6cd5b4dbb908ec4891397609917bb633d5ac3cec (HEAD -> master, origin/master, origin/HEAD)
Author: Preetpal Sohal <preetpal.sohal@gmail.com>
Date:   Sat Nov 23 10:49:03 2019 -0800

    Fix build error on Windows related to pgroup option being used in Process.spawn in extconf.rb instead of new_pgroup. Fixes issue #791.

commit 30e06a9ca93f2c2188e2bbd56eacc1b55a1dc6ce
Merge: 0fabffb dd5806d
Author: Aaron Patterson <tenderlove@github.com>
Date:   Wed Nov 20 22:24:08 2019 -0600

    Merge pull request #820 from ioquatix/master

    Ensure exception is initialized, in case nentries is zero.

C:\Users\preet\Projects\rugged\ext>
```