### PR TITLE
Merge master into maintenance branch and bump version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: Rugged CI
+
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+    - maint/*
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.3.7', '2.4.6', '2.5.5', '2.6.3' ]
+        os: [ ubuntu-18.04, macOS-10.14 ]
+
+    runs-on: ${{ matrix.os }}
+
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@master
+    - name: update submodule
+      run: git submodule update --init
+    - name: Install Linux packages
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt update
+        sudo apt install -y cmake libssh2-1-dev openssh-client openssh-server
+    - name: Install macOS packages
+      if: runner.os == 'macOS'
+      run: ./vendor/libgit2/azure-pipelines/setup-osx.sh
+    - name: Set up Ruby on Linux
+      if: runner.os == 'Linux'
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Set up Ruby on macOS
+      if: runner.os == 'macOS'
+      run: |
+        brew install rbenv
+        rbenv install ${{ matrix.ruby }}
+        rbenv local ${{ matrix.ruby }}
+    - name: run build
+      run: |
+        if [ -x rbenv ]; then eval "$(rbenv init -)"; fi
+        ruby --version
+        gem install bundler
+        bundle install --path vendor
+        ./script/travisbuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,7 @@ os:
   - osx
 
 rvm:
-  - 2.3.3
-  - 2.4.0
-  - 2.5.0
-  - 2.6
   - ruby-head
-  - rbx-2
 
 addons:
   apt:
@@ -38,6 +33,6 @@ git:
 before_install:
   - git submodule update --init
   - gem update --system
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./vendor/libgit2/ci/setup-osx.sh; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./vendor/libgit2/azure-pipelines/setup-osx.sh; fi
 
 script: script/travisbuild

--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -14,6 +14,7 @@ $CFLAGS << " -O3" unless $CFLAGS[/-O\d/]
 $CFLAGS << " -Wall -Wno-comment"
 
 cmake_flags = [ ENV["CMAKE_FLAGS"] ]
+cmake_flags << "-DREGEX_BACKEND=builtin"
 cmake_flags << "-DUSE_SHA1DC=ON" if with_config("sha1dc")
 
 def sys(cmd)
@@ -30,7 +31,8 @@ end
 
 def self.run_cmake(timeout, args)
   # Set to process group so we can kill it and its children
-  pid = Process.spawn("cmake #{args}", pgroup: true)
+  pgroup = Gem.win_platform? ? :new_pgroup : :pgroup
+  pid = Process.spawn("cmake #{args}", pgroup => true)
 
   Timeout.timeout(timeout) do
     Process.waitpid(pid)

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -104,6 +104,12 @@ VALUE rugged_signature_from_buffer(const char *buffer, const char *encoding_name
 void rugged_rb_ary_to_strarray(VALUE rb_array, git_strarray *str_array);
 VALUE rugged_strarray_to_rb_ary(git_strarray *str_array);
 
+#define CALLABLE_OR_RAISE(ret, name) \
+	do { \
+		if (!rb_respond_to(ret, rb_intern("call"))) \
+			rb_raise(rb_eArgError, "Expected a Proc or an object that responds to #call (:" name " )."); \
+	} while (0);
+
 static inline void rugged_set_owner(VALUE object, VALUE owner)
 {
 	rb_iv_set(object, "@owner", owner);
@@ -133,6 +139,13 @@ static inline int rugged_parse_bool(VALUE boolean)
 extern VALUE rb_cRuggedRepo;
 
 VALUE rugged__block_yield_splat(VALUE args);
+
+struct rugged_apply_cb_payload
+{
+	VALUE delta_cb;
+	VALUE hunk_cb;
+	int exception;
+};
 
 struct rugged_cb_payload
 {

--- a/ext/rugged/rugged_blob.c
+++ b/ext/rugged/rugged_blob.c
@@ -17,6 +17,8 @@ static ID id_read;
 VALUE rb_cRuggedBlob;
 VALUE rb_cRuggedBlobSig;
 
+extern const rb_data_type_t rugged_object_type;
+
 /*
  *  call-seq:
  *    blob.text(max_lines = -1, encoding = Encoding.default_external) -> string
@@ -38,7 +40,7 @@ static VALUE rb_git_blob_text_GET(int argc, VALUE *argv, VALUE self)
 	const char *content;
 	VALUE rb_max_lines, rb_encoding;
 
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 	rb_scan_args(argc, argv, "02", &rb_max_lines, &rb_encoding);
 
 	content = git_blob_rawcontent(blob);
@@ -85,7 +87,7 @@ static VALUE rb_git_blob_content_GET(int argc, VALUE *argv, VALUE self)
 	const char *content;
 	VALUE rb_max_bytes;
 
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 	rb_scan_args(argc, argv, "01", &rb_max_bytes);
 
 	content = git_blob_rawcontent(blob);
@@ -119,7 +121,7 @@ static VALUE rb_git_blob_content_GET(int argc, VALUE *argv, VALUE self)
 static VALUE rb_git_blob_rawsize(VALUE self)
 {
 	git_blob *blob;
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 
 	return INT2FIX(git_blob_rawsize(blob));
 }
@@ -304,7 +306,7 @@ static VALUE rb_git_blob_loc(VALUE self)
 	const char *data, *data_end;
 	size_t loc = 0;
 
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 
 	data = git_blob_rawcontent(blob);
 	data_end = data + git_blob_rawsize(blob);
@@ -343,7 +345,7 @@ static VALUE rb_git_blob_sloc(VALUE self)
 	const char *data, *data_end;
 	size_t sloc = 0;
 
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 
 	data = git_blob_rawcontent(blob);
 	data_end = data + git_blob_rawsize(blob);
@@ -383,7 +385,7 @@ static VALUE rb_git_blob_sloc(VALUE self)
 static VALUE rb_git_blob_is_binary(VALUE self)
 {
 	git_blob *blob;
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 	return git_blob_is_binary(blob) ? Qtrue : Qfalse;
 }
 
@@ -467,14 +469,14 @@ static VALUE rb_git_blob_diff(int argc, VALUE *argv, VALUE self)
 		rugged_parse_diff_options(&opts, rb_options);
 	}
 
-	Data_Get_Struct(self, git_blob, blob);
+	TypedData_Get_Struct(self, git_blob, &rugged_object_type, blob);
 
 	if (NIL_P(rb_other)) {
 		error = git_patch_from_blobs(&patch, blob, old_path, NULL, new_path, &opts);
 	} else if (rb_obj_is_kind_of(rb_other, rb_cRuggedBlob)) {
 		git_blob *other_blob;
 
-		Data_Get_Struct(rb_other, git_blob, other_blob);
+		TypedData_Get_Struct(rb_other, git_blob, &rugged_object_type, other_blob);
 
 		error = git_patch_from_blobs(&patch, blob, old_path, other_blob, new_path, &opts);
 	} else if (TYPE(rb_other) == T_STRING) {
@@ -649,7 +651,7 @@ static VALUE rb_git_blob_sig_new(int argc, VALUE *argv, VALUE klass)
 
 	if (rb_obj_is_kind_of(rb_blob, rb_cRuggedBlob)) {
 		git_blob *blob;
-		Data_Get_Struct(rb_blob, git_blob, blob);
+		TypedData_Get_Struct(rb_blob, git_blob, &rugged_object_type, blob);
 
 		error = git_hashsig_create(&sig,
 				git_blob_rawcontent(blob),

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -15,6 +15,8 @@ extern VALUE rb_cRuggedRepo;
 extern VALUE rb_cRuggedSignature;
 VALUE rb_cRuggedCommit;
 
+extern const rb_data_type_t rugged_object_type;
+
 /*
  *  call-seq:
  *    commit.message -> msg
@@ -35,7 +37,7 @@ static VALUE rb_git_commit_message_GET(VALUE self)
 	const char *encoding_name;
 	const char *message;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	message = git_commit_message(commit);
 	encoding_name = git_commit_message_encoding(commit);
@@ -68,7 +70,7 @@ static VALUE rb_git_commit_trailers_GET(VALUE self)
 	int error;
 	size_t i;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	encoding_name = git_commit_message_encoding(commit);
 	if (encoding_name != NULL)
@@ -118,7 +120,7 @@ static VALUE rb_git_commit_summary_GET(VALUE self)
 	const char *encoding_name;
 	const char *summary;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	summary = git_commit_summary(commit);
 	encoding_name = git_commit_message_encoding(commit);
@@ -147,7 +149,7 @@ static VALUE rb_git_commit_summary_GET(VALUE self)
 static VALUE rb_git_commit_committer_GET(VALUE self)
 {
 	git_commit *commit;
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	return rugged_signature_new(
 		git_commit_committer(commit),
@@ -172,7 +174,7 @@ static VALUE rb_git_commit_committer_GET(VALUE self)
 static VALUE rb_git_commit_author_GET(VALUE self)
 {
 	git_commit *commit;
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	return rugged_signature_new(
 		git_commit_author(commit),
@@ -192,7 +194,7 @@ static VALUE rb_git_commit_author_GET(VALUE self)
 static VALUE rb_git_commit_epoch_time_GET(VALUE self)
 {
 	git_commit *commit;
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	return ULONG2NUM(git_commit_time(commit));
 }
@@ -213,7 +215,7 @@ static VALUE rb_git_commit_tree_GET(VALUE self)
 	VALUE owner;
 	int error;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 	owner = rugged_owner(self);
 
 	error = git_commit_tree(&tree, commit);
@@ -236,7 +238,7 @@ static VALUE rb_git_commit_tree_id_GET(VALUE self)
 	git_commit *commit;
 	const git_oid *tree_id;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	tree_id = git_commit_tree_id(commit);
 
@@ -262,7 +264,7 @@ static VALUE rb_git_commit_parents_GET(VALUE self)
 	VALUE ret_arr, owner;
 	int error;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 	owner = rugged_owner(self);
 
 	parent_count = git_commit_parentcount(commit);
@@ -295,7 +297,7 @@ static VALUE rb_git_commit_parent_ids_GET(VALUE self)
 	unsigned int n, parent_count;
 	VALUE ret_arr;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	parent_count = git_commit_parentcount(commit);
 	ret_arr = rb_ary_new2((long)parent_count);
@@ -352,7 +354,7 @@ static VALUE rb_git_commit_amend(VALUE self, VALUE rb_data)
 
 	Check_Type(rb_data, T_HASH);
 
-	Data_Get_Struct(self, git_commit, commit_to_amend);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit_to_amend);
 
 	owner = rugged_owner(self);
 	Data_Get_Struct(owner, git_repository, repo);
@@ -474,7 +476,7 @@ static VALUE parse_commit_options(struct commit_data *out, git_repository *repo,
 			if (error < GIT_OK)
 				goto out;
 		} else if (rb_obj_is_kind_of(p, rb_cRuggedCommit)) {
-			Data_Get_Struct(p, git_commit, tmp);
+			TypedData_Get_Struct(p, git_commit, &rugged_object_type, tmp);
 			if ((error = git_object_dup((git_object **) &parent, (git_object *) tmp)) < 0)
 				goto out;
 		} else {
@@ -614,7 +616,7 @@ static VALUE rb_git_commit_to_mbox(int argc, VALUE *argv, VALUE self)
 	rugged_check_repo(rb_repo);
 	Data_Get_Struct(rb_repo, git_repository, repo);
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	if (!NIL_P(rb_options)) {
 		Check_Type(rb_options, T_HASH);
@@ -673,7 +675,7 @@ static VALUE rb_git_commit_header_field(VALUE self, VALUE rb_field)
 	int error;
 
 	Check_Type(rb_field, T_STRING);
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	error = git_commit_header_field(&header_field, commit, StringValueCStr(rb_field));
 
@@ -704,7 +706,7 @@ static VALUE rb_git_commit_header(VALUE self)
 	git_commit *commit;
 	const char *raw_header;
 
-	Data_Get_Struct(self, git_commit, commit);
+	TypedData_Get_Struct(self, git_commit, &rugged_object_type, commit);
 
 	raw_header = git_commit_raw_header(commit);
 	return rb_str_new_utf8(raw_header);

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -13,6 +13,8 @@ extern VALUE rb_cRuggedCommit;
 extern VALUE rb_cRuggedDiff;
 extern VALUE rb_cRuggedTree;
 
+extern const rb_data_type_t rugged_object_type;
+
 static void rb_git_indexentry_toC(git_index_entry *entry, VALUE rb_entry);
 static VALUE rb_git_indexentry_fromC(const git_index_entry *entry);
 
@@ -658,7 +660,7 @@ static VALUE rb_git_index_readtree(VALUE self, VALUE rb_tree)
 	int error;
 
 	Data_Get_Struct(self, git_index, index);
-	Data_Get_Struct(rb_tree, git_tree, tree);
+	TypedData_Get_Struct(rb_tree, git_tree, &rugged_object_type, tree);
 
 	if (!rb_obj_is_kind_of(rb_tree, rb_cRuggedTree)) {
 		rb_raise(rb_eTypeError, "A Rugged::Tree instance is required");
@@ -690,7 +692,7 @@ static VALUE rb_git_diff_tree_to_index(VALUE self, VALUE rb_other, VALUE rb_opti
 	// the "old file" side of the diff.
 	opts.flags ^= GIT_DIFF_REVERSE;
 
-	Data_Get_Struct(rb_other, git_tree, other_tree);
+	TypedData_Get_Struct(rb_other, git_tree, &rugged_object_type, other_tree);
 	error = git_diff_tree_to_index(&diff, repo, other_tree, index, &opts);
 
 	xfree(opts.pathspec.strings);

--- a/ext/rugged/rugged_note.c
+++ b/ext/rugged/rugged_note.c
@@ -10,6 +10,8 @@
 extern VALUE rb_cRuggedRepo;
 extern VALUE rb_cRuggedObject;
 
+extern const rb_data_type_t rugged_object_type;
+
 static VALUE rugged_git_note_message(const git_note *note)
 {
 	const char *message;
@@ -59,7 +61,7 @@ static VALUE rb_git_note_lookup(int argc, VALUE *argv, VALUE self)
 		notes_ref = StringValueCStr(rb_notes_ref);
 	}
 
-	Data_Get_Struct(self, git_object, object);
+	TypedData_Get_Struct(self, git_object, &rugged_object_type, object);
 
 	owner = rugged_owner(self);
 	Data_Get_Struct(owner, git_repository, repo);
@@ -124,7 +126,7 @@ static VALUE rb_git_note_create(VALUE self, VALUE rb_data)
 
 	Check_Type(rb_data, T_HASH);
 
-	Data_Get_Struct(self, git_object, target);
+	TypedData_Get_Struct(self, git_object, &rugged_object_type, target);
 
 	owner = rugged_owner(self);
 	Data_Get_Struct(owner, git_repository, repo);
@@ -207,7 +209,7 @@ static VALUE rb_git_note_remove(int argc, VALUE *argv, VALUE self)
 	VALUE rb_committer = Qnil;
 	VALUE owner;
 
-	Data_Get_Struct(self, git_object, target);
+	TypedData_Get_Struct(self, git_object, &rugged_object_type, target);
 
 	owner = rugged_owner(self);
 	Data_Get_Struct(owner, git_repository, repo);

--- a/ext/rugged/rugged_rebase.c
+++ b/ext/rugged/rugged_rebase.c
@@ -15,6 +15,8 @@ extern VALUE rb_cRuggedReference;
 
 VALUE rb_cRuggedRebase;
 
+extern const rb_data_type_t rugged_object_type;
+
 static VALUE rebase_operation_type(git_rebase_operation *operation);
 
 static void parse_rebase_options(git_rebase_options *ret, VALUE rb_options)
@@ -70,7 +72,7 @@ static void get_annotated_commit(git_annotated_commit **annotated_commit, VALUE 
 		const git_commit * commit;
 		const git_oid * oid;
 
-		Data_Get_Struct(rb_value, git_commit, commit);
+		TypedData_Get_Struct(rb_value, git_commit, &rugged_object_type, commit);
 
 		oid = git_commit_id(commit);
 		error = git_annotated_commit_lookup(annotated_commit, repo, oid);

--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -157,12 +157,6 @@ static int credentials_cb(
 	return payload->exception ? GIT_ERROR : GIT_OK;
 }
 
-#define CALLABLE_OR_RAISE(ret, name) \
-	do { \
-		if (!rb_respond_to(ret, rb_intern("call"))) \
-			rb_raise(rb_eArgError, "Expected a Proc or an object that responds to #call (:" name " )."); \
-	} while (0);
-
 void rugged_remote_init_callbacks_and_payload_from_options(
 	VALUE rb_options,
 	git_remote_callbacks *callbacks,

--- a/ext/rugged/rugged_tag.c
+++ b/ext/rugged/rugged_tag.c
@@ -15,6 +15,8 @@ extern VALUE rb_cRuggedReference;
 VALUE rb_cRuggedTag;
 VALUE rb_cRuggedTagAnnotation;
 
+extern const rb_data_type_t rugged_object_type;
+
 /*
  *  call-seq:
  *    annotation.target -> object
@@ -31,7 +33,7 @@ static VALUE rb_git_tag_annotation_target(VALUE self)
 	int error;
 	VALUE owner;
 
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 	owner = rugged_owner(self);
 
 	error = git_tag_target(&target, tag);
@@ -55,7 +57,7 @@ static VALUE rb_git_tag_annotation_target_id(VALUE self)
 	git_tag *tag;
 	const git_oid *target_oid;
 
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 
 	target_oid = git_tag_target_id(tag);
 
@@ -77,7 +79,7 @@ static VALUE rb_git_tag_annotation_target_id(VALUE self)
 static VALUE rb_git_tag_annotation_target_type(VALUE self)
 {
 	git_tag *tag;
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 
 	return rugged_otype_new(git_tag_target_type(tag));
 }
@@ -93,7 +95,7 @@ static VALUE rb_git_tag_annotation_target_type(VALUE self)
 static VALUE rb_git_tag_annotation_name(VALUE self)
 {
 	git_tag *tag;
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 
 	return rb_str_new_utf8(git_tag_name(tag));
 }
@@ -113,7 +115,7 @@ static VALUE rb_git_tag_annotation_tagger(VALUE self)
 	git_tag *tag;
 	const git_signature *tagger;
 
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 	tagger = git_tag_tagger(tag);
 
 	if (!tagger)
@@ -136,7 +138,7 @@ static VALUE rb_git_tag_annotation_message(VALUE self)
 	git_tag *tag;
 	const char *message;
 
-	Data_Get_Struct(self, git_tag, tag);
+	TypedData_Get_Struct(self, git_tag, &rugged_object_type, tag);
 	message = git_tag_message(tag);
 
 	if (!message)

--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '0.28.4.1'
+  Version = VERSION = '0.28.4.2'
 end

--- a/rugged.gemspec
+++ b/rugged.gemspec
@@ -31,4 +31,5 @@ desc
   s.add_development_dependency "rake-compiler", ">= 0.9.0"
   s.add_development_dependency "pry"
   s.add_development_dependency "minitest", "~> 5.0"
+  s.metadata["msys2_mingw_dependencies"] = "libssh2"
 end

--- a/script/travisbuild
+++ b/script/travisbuild
@@ -1,9 +1,14 @@
 #!/bin/sh
 
+set -ex
+
 # Create a test repo which we can use for the online tests
 mkdir $HOME/_temp
 git init --bare $HOME/_temp/test.git
 git daemon --listen=localhost --export-all --enable=receive-pack --base-path=$HOME/_temp $HOME/_temp 2>/dev/null &
+
+# On Actions we start with 777 which means sshd won't let us in
+chmod 750 $HOME
 
 ssh-keygen -t rsa -f ~/.ssh/rugged_test_rsa -N "" -q
 cat ~/.ssh/rugged_test_rsa.pub >>~/.ssh/authorized_keys

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -283,8 +283,8 @@ SIGNEDDATA
 
   def test_create_with_signature
     signed_commit = <<-COMMIT
-tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6
-parent 34734e478d6cf50c27c9d69026d93974d052c454
+tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+parent 8496071c1b46c854b31185ea97743be6a8774479
 author Ben Burkert <ben@benburkert.com> 1358451456 -0800
 committer Ben Burkert <ben@benburkert.com> 1358451456 -0800
 gpgsig -----BEGIN PGP SIGNATURE-----
@@ -329,8 +329,8 @@ cpxtDQQMGYFpXK/71stq
 SIGNATURE
 
     base_data = <<-SIGNEDDATA
-tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6
-parent 34734e478d6cf50c27c9d69026d93974d052c454
+tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+parent 8496071c1b46c854b31185ea97743be6a8774479
 author Ben Burkert <ben@benburkert.com> 1358451456 -0800
 committer Ben Burkert <ben@benburkert.com> 1358451456 -0800
 

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -65,6 +65,18 @@ EOS
 end
 
 class RepoDiffTest < Rugged::TestCase
+  def test_new_from_buffer
+    repo    = FixtureRepo.from_libgit2("attr")
+    patch1  = Rugged::Patch.from_strings("deleted\n", "added\n", old_path: "old", new_path: "new").to_s
+    diff1   = repo.diff_from_buffer(patch1)
+    assert_equal diff1.patch, patch1
+    
+    diff2   = repo.diff("605812a", "370fe9ec22", :context_lines => 1, :interhunk_lines => 1)
+    patch2  = diff2.patch
+    diff3   = repo.diff_from_buffer(patch2)
+    assert_equal diff3.patch, patch2
+  end
+  
   def test_with_oid_string
     repo = FixtureRepo.from_libgit2("attr")
     diff = repo.diff("605812a", "370fe9ec22", :context_lines => 1, :interhunk_lines => 1)

--- a/test/repo_apply_test.rb
+++ b/test/repo_apply_test.rb
@@ -1,0 +1,169 @@
+require 'test_helper'
+
+module RepositoryApplyTestHelpers
+  def assert_workdir_content(path, test_value, repo = nil)
+    repo = @repo if repo.nil?
+    assert_equal File.read(File.join(repo.workdir, path)), test_value
+  end
+
+  def assert_index_content(path, test_value, repo = nil)
+    repo = @repo if repo.nil?
+    assert_equal repo.lookup(repo.index[path][:oid]).content, test_value
+  end
+
+  def blob_contents(repo, path)
+    repo.lookup(repo.head.target.tree[path][:oid]).content
+  end
+
+  def update_file(repo, path)
+    original = blob_contents(repo, path)
+    content = new_content(original)
+    blob = repo.write(content, :blob)
+
+    index = repo.index
+    index.read_tree(repo.head.target.tree)
+    index.add(:path => path, :oid => blob, :mode => 0100644)
+    new_tree = index.write_tree(repo)
+
+    oid = do_commit(repo, new_tree, "Update #{path}")
+
+    return repo.lookup(oid), content, original
+  end
+
+  def do_commit(repo, tree, message)
+    Rugged::Commit.create(repo,
+      :tree => tree,
+      :author => person,
+      :committer => person,
+      :message => message,
+      :parents => repo.empty? ? [] : [ repo.head.target ].compact,
+      :update_ref => 'HEAD',
+    )
+  end
+
+  def new_content(original)
+    "#{original}Some new line\n"
+  end
+
+  def person
+    {:name => 'Scott', :email => 'schacon@gmail.com', :time => Time.now }
+  end
+end
+
+class RepositoryApplyTest < Rugged::TestCase
+  include RepositoryApplyTestHelpers
+
+  def setup
+    @repo = FixtureRepo.from_libgit2("testrepo")
+    @original_commit = @repo.head.target.oid
+  end
+
+  def test_apply_index
+    new_commit, new_content, original_content = update_file(@repo, 'README')
+
+    assert_index_content 'README', new_content
+
+    diff = @repo.diff(new_commit, @original_commit)
+
+    assert_equal true, @repo.apply(diff, {:location => :index})
+    assert_index_content 'README', original_content
+  end
+
+  def test_apply_workdir
+    new_commit, new_content, original_content = update_file(@repo, 'README')
+
+    @repo.checkout_head(:strategy => :force)
+    assert_workdir_content 'README', new_content
+
+    diff = @repo.diff(new_commit, @original_commit)
+
+    assert_equal true, @repo.apply(diff)
+    assert_workdir_content 'README', original_content
+  end
+
+  def test_apply_both
+    new_commit, new_content, original_content = update_file(@repo, 'README')
+
+    @repo.checkout_head(:strategy => :force)
+    assert_index_content 'README', new_content
+    assert_workdir_content 'README', new_content
+
+    diff = @repo.diff(new_commit, @original_commit)
+
+    assert_equal true, @repo.apply(diff, :location => :both)
+    assert_index_content 'README', original_content
+    assert_workdir_content 'README', original_content
+  end
+
+  def test_bare_repository_defaults_to_index
+    bare_repo = Rugged::Repository.clone_at(@repo.path, Dir.mktmpdir('rugged-apply_bare'), :bare => true)
+    original_commit = bare_repo.head.target.oid
+
+    new_commit, new_content, original_content = update_file(bare_repo, 'README')
+    assert_index_content 'README', new_content, bare_repo
+
+    diff = bare_repo.diff(new_commit, original_commit)
+    
+    assert_equal true, bare_repo.apply(diff)
+    assert_index_content 'README', original_content, bare_repo
+  end
+
+  def test_location_option
+    new_commit, new_content, original_content = update_file(@repo, 'README')
+
+    diff = @repo.diff(new_commit, @original_commit)
+
+    assert_raises TypeError do
+      @repo.apply(diff, :location => :invalid)
+    end
+  end
+
+  def test_callbacks
+    new_commit, new_content, original_content = update_file(@repo, 'README')
+
+    assert_equal @repo.lookup(@repo.index["README"][:oid]).content, new_content
+
+    diff = @repo.diff(new_commit, @original_commit)
+
+    callsback = 0
+
+    hunk_cb = Proc.new { |hunk|
+      callsback += 1
+      assert hunk.is_a?(Rugged::Diff::Hunk)
+    }
+
+    delta_cb = Proc.new { |delta|
+      callsback += 1
+      assert delta.is_a?(Rugged::Diff::Delta)
+    }
+
+    assert_equal true, @repo.apply(diff, {:location => :index, :hunk_callback => hunk_cb, :delta_callback => delta_cb})
+    assert_index_content 'README', original_content
+    assert_equal callsback, 2
+
+    hunk_skip_all = Proc.new {
+      false
+    }
+
+    new_commit, new_content, original_content = update_file(@repo, 'README')
+    diff = @repo.diff(new_commit, @original_commit)
+    assert_equal true, @repo.apply(diff, {:location => :index, :hunk_callback => hunk_skip_all})
+    assert_index_content 'README', new_content
+
+    delta_fail = Proc.new {
+      nil
+    }
+
+    assert_raises RuntimeError do
+      @repo.apply(diff, {:location => :index, :delta_callback => delta_fail})
+    end
+
+    assert_raises ArgumentError do
+      @repo.apply(diff, {:location => :index, :delta_callback => 'this is not a callable object'})
+    end
+
+    assert_raises ArgumentError do
+      @repo.apply(diff, {:location => :index, :hunk_callback => 'this is not a callable object'})
+    end
+  end
+end

--- a/test/repo_test.rb
+++ b/test/repo_test.rb
@@ -87,7 +87,7 @@ class RepositoryTest < Rugged::TestCase
   def test_return_all_ref_names
     refs = @repo.ref_names
     refs.each {|name| assert name.kind_of?(String)}
-    assert_equal 21, refs.count
+    assert_equal 22, refs.count
   end
 
   def test_return_all_tags


### PR DESCRIPTION
Please see #818. New versions have been created off the `maint/v0.28` branch (and its counterpart for `v0.27`), causing new features and fixes in `master` from the past year to be absent in new releases. This PR merges `master` into `maint/v0.28` and bumps the `rugged` version. It would be great if this could be merged, and a new release be made on the basis of it.

cc @tenderlove @vmg @carlosmn 