### PR TITLE
Add Rugged::Config#add

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,32 @@ repo.config['user.name'] = true
 repo.config.delete('user.name')
 ```
 
+#### Targeting a specific config file
+
+You can also target a specific config file to perform the same actions
+as above.
+
+```ruby
+# Target a specific git-config file
+config = Rugged::Config.new "absolute/path/to/file"
+
+# Read values from the above file
+repo.config['core.bare']
+```
+
+#### Working with multiple values
+
+Rugged also makes it easy to work with configurations that have multiple values
+for the same key (`multivar`s).
+
+```ruby
+# Read all values for the 'remote.origin.fetch' key
+repo.config.get_all('remote.origin.fetch')
+
+# Add a new value to the 'remote.origin.fetch' key
+repo.config.add('remote.origin.fetch', '+refs/pull/*:refs/prs/*')
+```
+
 ---
 
 ### General methods

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -85,6 +85,22 @@ class ConfigWriteTest < Rugged::TestCase
     assert_match(/value = my value/, content)
   end
 
+  def test_write_multivar_config_values
+    config = @repo.config
+    config.add('custom.multivalue', 'my value')
+    config.add('custom.multivalue', true)
+    config.add('custom.multivalue', 42)
+
+    config2 = @repo.config
+    custom_multivar = ['my value', 'true', '42']
+    assert_equal custom_multivar, config2.get_all('custom.multivalue')
+
+    content = File.read(File.join(@repo.path, 'config'))
+    assert_match(/multivalue = my value/, content)
+    assert_match(/multivalue = true/, content)
+    assert_match(/multivalue = 42/, content)
+  end
+
   def test_delete_config_values
     config = @repo.config
     config.delete('core.bare')

--- a/test/fixtures/text_file.md
+++ b/test/fixtures/text_file.md
@@ -418,6 +418,32 @@ repo.config['user.name'] = true
 repo.config.delete('user.name')
 ```
 
+#### Targeting a specific config file
+
+You can also target a specific config file to perform the same actions
+as above.
+
+```ruby
+# Target a specific git-config file
+config = Rugged::Config.new "absolute/path/to/file"
+
+# Read values from the above file
+repo.config['core.bare']
+```
+
+#### Working with multiple values
+
+Rugged also makes it easy to work with configurations that have multiple values
+for the same key (`multivar`s).
+
+```ruby
+# Read all values for the 'remote.origin.fetch' key
+repo.config.get_all('remote.origin.fetch')
+
+# Add a new value to the 'remote.origin.fetch' key
+repo.config.add('remote.origin.fetch', '+refs/pull/*:refs/prs/*')
+```
+
 ---
 
 ### General methods


### PR DESCRIPTION
This method allows you to set multiple values for the same key in a
particular config, similar to `git config --add "include.path" some/path`.

For example, I have a git config with an existing `include.path` value:

```
$ cat ~/src/opensource/rugged/.git/config
[core]
        repositoryformatversion = 0
        filemode = true
        bare = false
        logallrefupdates = true
        ignorecase = true
        precomposeunicode = true
[remote "origin"]
        url = git@github.com:codenamev/rugged.git
        fetch = +refs/heads/*:refs/remotes/origin/*
[branch "master"]
        remote = origin
        merge = refs/heads/master
[submodule "vendor/libgit2"]
        active = true
        url = https://github.com/libgit2/libgit2.git
[include]
        path = /Users/codenamev/.gitconfig.reflow
```

With `Rugged::Config#add` I can set another value for `include.path`
without overwriting the existing value:

```
ruby -I lib -rrugged -e'\
config = Rugged::Repository.new("/Users/codenamev/src/opensource/rugged").config;
config.add("include.path", "/Users/codenamev/.gitconfig.extras");
p config.get_all("include.path")'
["/Users/codenamev/.gitconfig.reflow", "/Users/codenamev/.gitconfig.extras"]
```

References #725