### PR TITLE
each_key returns individual keys not wrapped in an internal array

### DIFF
--- a/ext/rugged/rugged_config.c
+++ b/ext/rugged/rugged_config.c
@@ -173,7 +173,7 @@ static int cb_config__each_key(const git_config_entry *entry, void *payload)
 {
 	int *exception = (int *) payload;
 
-	rb_protect(rb_yield, rb_ary_new3(1, rb_str_new_utf8(entry->name)), exception);
+	rb_protect(rb_yield, rb_str_new_utf8(entry->name), exception);
 
 	return (*exception != 0) ? GIT_EUSER : GIT_OK;
 }

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -50,6 +50,14 @@ class ConfigTest < Rugged::TestCase
     end
   end
 
+  def test_each_pair_is_pairs
+    config = @repo.config
+    config.each_pair do |key, value|
+      assert key.is_a?(String)
+      assert value.is_a?(String)
+    end
+  end
+
   def test_transaction
     config = Rugged::Config.new(File.join(@repo.path, 'config'))
     config['section.name'] = 'value'

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -43,6 +43,13 @@ class ConfigTest < Rugged::TestCase
     assert_nil snapshot['new.value']
   end
 
+  def test_each_key_is_a_string
+    config = @repo.config
+    config.each_key do |key|
+      assert key.is_a?(String)
+    end
+  end
+
   def test_transaction
     config = Rugged::Config.new(File.join(@repo.path, 'config'))
     config['section.name'] = 'value'


### PR DESCRIPTION
Previously keys where returned in nested arrays i.e. `[["user.email"]...]` this returns the behavior to just returning keys
The behavior changed in #803 likely due to a copy paste mistake. This returns this to the previous behavior