### PR TITLE
Remove ruby 2.7 warnings

### DIFF
--- a/lib/rugged/commit.rb
+++ b/lib/rugged/commit.rb
@@ -5,7 +5,6 @@
 
 module Rugged
   class Commit
-
     def self.prettify_message(msg, strip_comments = true)
       Rugged::prettify_message(msg, strip_comments)
     end
@@ -30,7 +29,7 @@ module Rugged
     #
     # See Rugged::Tree#diff_workdir for more details.
     def diff_workdir(options = {})
-      self.tree.diff_workdir(options)
+      self.tree.diff_workdir(**options)
     end
 
     # The time when this commit was made effective. This is the same value

--- a/lib/rugged/repository.rb
+++ b/lib/rugged/repository.rb
@@ -30,7 +30,7 @@ module Rugged
       options[:strategy] ||= :safe
       options.delete(:paths)
 
-      return checkout_head(options) if target == "HEAD"
+      return checkout_head(**options) if target == "HEAD"
 
       if target.kind_of?(Rugged::Branch)
         branch = target
@@ -39,7 +39,7 @@ module Rugged
       end
 
       if branch
-        self.checkout_tree(branch.target, options)
+        self.checkout_tree(branch.target, **options)
 
         if branch.remote?
           references.create("HEAD", branch.target_id, force: true)
@@ -49,7 +49,7 @@ module Rugged
       else
         commit = Commit.lookup(self, self.rev_parse_oid(target))
         references.create("HEAD", commit.oid, force: true)
-        self.checkout_tree(commit, options)
+        self.checkout_tree(commit, **options)
       end
     end
 
@@ -250,12 +250,11 @@ module Rugged
       (blob.type == :blob) ? blob : nil
     end
 
-    def fetch(remote_or_url, *args)
+    def fetch(remote_or_url, *args, **kwargs)
       unless remote_or_url.kind_of? Remote
         remote_or_url = remotes[remote_or_url] || remotes.create_anonymous(remote_or_url)
       end
-
-      remote_or_url.fetch(*args)
+      remote_or_url.fetch(*args, **kwargs)
     end
 
     # Push a list of refspecs to the given remote.

--- a/lib/rugged/submodule_collection.rb
+++ b/lib/rugged/submodule_collection.rb
@@ -26,8 +26,8 @@ module Rugged
     #
     # Returns the newly created +submodule+
     def add(url, path, options = {})
-      submodule = setup_add(url, path, options)
-      clone_submodule(submodule.repository, options)
+      submodule = setup_add(url, path, **options)
+      clone_submodule(submodule.repository, **options)
       submodule.finalize_add
     end
 
@@ -40,9 +40,9 @@ module Rugged
     # 1. fetches the remote
     # 2. sets up a master branch to be tracking origin/master
     # 3. checkouts the submodule
-    def clone_submodule(repo, fetch_options)
+    def clone_submodule(repo, **fetch_options)
       # the remote was just added by setup_add, no need to check presence
-      repo.remotes['origin'].fetch(fetch_options)
+      repo.remotes['origin'].fetch(**fetch_options)
 
       repo.branches.create('master','origin/master')
       repo.branches['master'].upstream = repo.branches['origin/master']

--- a/test/online/fetch_test.rb
+++ b/test/online/fetch_test.rb
@@ -33,14 +33,14 @@ class OnlineFetchTest < Rugged::OnlineTestCase
       @repo.remotes.create("origin", "https://github.com/libgit2/TestGitRepository.git")
 
       args = {}
-      @repo.fetch("origin", {
+      @repo.fetch(
+        "origin",
         certificate_check: lambda { |valid, host|
           args[:valid] = valid
           args[:host] = host
-
           true
         }
-      })
+      )
 
       assert_equal({ valid: true, host: "github.com" }, args)
     end
@@ -49,9 +49,10 @@ class OnlineFetchTest < Rugged::OnlineTestCase
       @repo.remotes.create("origin", "https://github.com/libgit2/TestGitRepository.git")
 
       exception = assert_raises Rugged::HTTPError do
-        @repo.fetch("origin", {
+        @repo.fetch(
+          "origin",
           certificate_check: lambda { |valid, host| false }
-        })
+        )
       end
 
       assert_equal "user rejected certificate for github.com", exception.message
@@ -61,11 +62,12 @@ class OnlineFetchTest < Rugged::OnlineTestCase
       @repo.remotes.create("origin", "https://github.com/libgit2/TestGitRepository.git")
 
       exception = assert_raises RuntimeError do
-        @repo.fetch("origin", {
+        @repo.fetch(
+          "origin",
           certificate_check: lambda { |valid, host|
             raise "Exception from callback"
           }
-        })
+        )
       end
 
       assert_equal "Exception from callback", exception.message
@@ -92,11 +94,11 @@ class OnlineFetchTest < Rugged::OnlineTestCase
     def test_fetch_over_ssh_with_credentials_callback
       @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
 
-      @repo.fetch("origin", {
+      @repo.fetch("origin",
         credentials: lambda { |url, username, allowed_types|
           return ssh_key_credential
         }
-      })
+      )
     end
   end
 end

--- a/test/rebase_test.rb
+++ b/test/rebase_test.rb
@@ -172,10 +172,10 @@ class TestRebase < Rugged::TestCase
     rebase = Rugged::Rebase.new(@repo, "refs/heads/gravy", "refs/heads/veal")
 
     assert rebase.next
-    assert rebase.commit({ committer: { :email => "rebaser@rebaser.com", :name => "Rebaser" } })
+    assert rebase.commit(committer: { :email => "rebaser@rebaser.com", :name => "Rebaser" })
 
     assert rebase.next
-    assert rebase.commit({ committer: { :email => "rebaser@rebaser.com", :name => "Rebaser" } })
+    assert rebase.commit(committer: { :email => "rebaser@rebaser.com", :name => "Rebaser" })
   end
 
   def test_inmemory_rebase_does_not_lose_files
@@ -197,9 +197,9 @@ class TestRebase < Rugged::TestCase
     rebase = Rugged::Rebase.new(@repo, "refs/heads/gravy", "refs/heads/veal", inmemory: true)
 
     assert rebase.next
-    assert rebase.commit({ committer: { :email => "rebaser@rebaser.com", :name => "Rebaser" } })
+    assert rebase.commit(committer: { :email => "rebaser@rebaser.com", :name => "Rebaser" })
 
     assert rebase.next
-    assert rebase.commit({ committer: { :email => "rebaser@rebaser.com", :name => "Rebaser" } })
+    assert rebase.commit(committer: { :email => "rebaser@rebaser.com", :name => "Rebaser" })
   end
 end

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -336,9 +336,9 @@ class ReflogTest < Rugged::TestCase
   def test_create_default_log_custom_log_message
     ref = @repo.references.create(
       "refs/heads/test-reflog-default",
-      "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", {
-        message: "reference created"
-      })
+      "a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
+      message: "reference created"
+      )
     reflog = ref.log
 
     assert_equal reflog.size, 1
@@ -359,9 +359,9 @@ class ReflogTest < Rugged::TestCase
 
     ref = @repo.references.create(
       "refs/heads/test-reflog-default",
-      "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", {
-        message: "reference created"
-      })
+      "a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
+      message: "reference created"
+    )
     reflog = ref.log
 
     assert_equal reflog.size, 1
@@ -408,9 +408,11 @@ class ReflogTest < Rugged::TestCase
   end
 
   def test_set_target_default_log_custom_log_message
-    @repo.references.update(@ref, "5b5b025afb0b4c913b4c338a42934a3863bf3644", {
+    @repo.references.update(
+      @ref,
+      "5b5b025afb0b4c913b4c338a42934a3863bf3644",
       message: "reference updated"
-    })
+    )
 
     reflog = @ref.log
     assert_equal reflog.size, 2

--- a/test/tag_test.rb
+++ b/test/tag_test.rb
@@ -158,10 +158,12 @@ end
 class AnnotatedTagTest < Rugged::TestCase
   def setup
     @repo = FixtureRepo.from_libgit2("testrepo.git")
-    @tag = @repo.tags.create('annotated_tag', "5b5b025afb0b4c913b4c338a42934a3863bf3644", {
+    @tag = @repo.tags.create(
+      'annotated_tag',
+      "5b5b025afb0b4c913b4c338a42934a3863bf3644",
       :message => "test tag message\n",
       :tagger  => { :name => 'Scott', :email => 'schacon@gmail.com', :time => Time.now }
-    })
+    )
   end
 
   def test_is_annotated
@@ -242,10 +244,12 @@ class TagWriteTest < Rugged::TestCase
   end
 
   def test_writing_a_tag
-    tag = @repo.tags.create('tag', "5b5b025afb0b4c913b4c338a42934a3863bf3644", {
+    tag = @repo.tags.create(
+      'tag',
+      "5b5b025afb0b4c913b4c338a42934a3863bf3644",
       :message => "test tag message\n",
       :tagger  => { :name => 'Scott', :email => 'schacon@gmail.com', :time => Time.now }
-    })
+    )
 
     annotation = tag.annotation
     assert_equal :tag, annotation.type
@@ -261,9 +265,11 @@ class TagWriteTest < Rugged::TestCase
     @repo.config['user.name'] = name
     @repo.config['user.email'] = email
 
-    tag = @repo.tags.create('tag', "5b5b025afb0b4c913b4c338a42934a3863bf3644", {
+    tag = @repo.tags.create(
+      'tag',
+      "5b5b025afb0b4c913b4c338a42934a3863bf3644",
       :message => "test tag message\n"
-    })
+    )
 
     assert_equal name, tag.annotation.tagger[:name]
     assert_equal email, tag.annotation.tagger[:email]
@@ -271,10 +277,12 @@ class TagWriteTest < Rugged::TestCase
 
   def test_tag_invalid_message_type
     assert_raises TypeError do
-      @repo.tags.create('tag', "5b5b025afb0b4c913b4c338a42934a3863bf3644", {
+      @repo.tags.create(
+        'tag',
+        "5b5b025afb0b4c913b4c338a42934a3863bf3644",
         :message => :invalid_message,
         :tagger  => {:name => 'Scott', :email => 'schacon@gmail.com', :time => Time.now }
-      })
+      )
     end
   end
 


### PR DESCRIPTION
Ruby 2.7 is raising a bunch of,
`warning: Using the last argument as keyword parameters is deprecated`
warnings. we can resolve these these by using ** when we intend that last argument to be kwargs.