### PR TITLE
config: test that we iterate over string keys

### DIFF
--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -92,4 +92,11 @@ class ConfigWriteTest < Rugged::TestCase
     config2 = @repo.config
     assert_nil config2.get('core.bare')
   end
+
+  def test_iterate_keys
+    config = @repo.config
+    config.each_key do |key|
+      assert key.is_a?(String)
+    end
+  end
 end


### PR DESCRIPTION
We identified that #803 has changed the `Config#each_key` yielded values from strings to single-value arrays. This is not what was intended and breaks code that wants a string.

I'm opening this up with just the test to see if older ruby versions did treat a single-element array here as a single value, or if we really messed up.