### PR TITLE
ci: be less precise with our ruby version with setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,43 +8,57 @@ on:
     - maint/*
 
 jobs:
-  build:
+  macOS:
     strategy:
       fail-fast: false
       matrix:
-        ruby-mac: [ '2.4.9', '2.5.7', '2.6.5', '2.7.0' ]
-        ruby-linux: [ '2.4', '2.5', '2.6', '2.7' ]
-        os: [ ubuntu-18.04, macOS-latest ]
-
+        ruby: [ '2.4.9', '2.5.7', '2.6.5', '2.7.0' ]
+        os: [ macOS-latest ]
     runs-on: ${{ matrix.os }}
 
-    name: Ruby ${{ matrix.ruby-mac }} ${{ matrix.ruby-linux }} on ${{ matrix.os }}
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@master
+    - name: update submodule
+      run: git submodule update --init
+    - name: Install macOS packages
+      run: ./vendor/libgit2/azure-pipelines/setup-osx.sh
+    - name: Set up Ruby on macOS
+      run: |
+        brew install rbenv
+        rbenv install ${{ matrix.ruby }}
+        rbenv local ${{ matrix.ruby }}
+    - name: run build
+      run: |
+        eval "$(rbenv init -)"
+        ruby --version
+        gem install bundler
+        bundle install --path vendor
+        ./script/travisbuild
+
+  ubuntu:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        os: [ ubuntu-18.04 ]
+    runs-on: ${{ matrix.os }}
+
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@master
     - name: update submodule
       run: git submodule update --init
     - name: Install Linux packages
-      if: runner.os == 'Linux'
       run: |
         sudo apt update
         sudo apt install -y cmake libssh2-1-dev openssh-client openssh-server
-    - name: Install macOS packages
-      if: runner.os == 'macOS'
-      run: ./vendor/libgit2/azure-pipelines/setup-osx.sh
     - name: Set up Ruby on Linux
-      if: runner.os == 'Linux'
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-linux }}
-    - name: Set up Ruby on macOS
-      if: runner.os == 'macOS'
-      run: |
-        brew install rbenv
-        rbenv install ${{ matrix.ruby-mac }}
-        rbenv local ${{ matrix.ruby-mac }}
+        ruby-version: ${{ matrix.ruby }}
     - name: run build
       run: |
-        if [ -x rbenv ]; then eval "$(rbenv init -)"; fi
         ruby --version
         gem install bundler
         bundle install --path vendor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4.9', '2.5.7', '2.6.5', '2.7.0' ]
-        os: [ ubuntu-18.04, macOS-10.14 ]
+        ruby-mac: [ '2.4.9', '2.5.7', '2.6.5', '2.7.0' ]
+        ruby-linux: [ '2.4', '2.5', '2.6', '2.7' ]
+        os: [ ubuntu-18.04, macOS-latest ]
 
     runs-on: ${{ matrix.os }}
 
-    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    name: Ruby ${{ matrix.ruby-mac }} ${{ matrix.ruby-linux }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@master
     - name: update submodule
@@ -34,13 +35,13 @@ jobs:
       if: runner.os == 'Linux'
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: ${{ matrix.ruby-linux }}
     - name: Set up Ruby on macOS
       if: runner.os == 'macOS'
       run: |
         brew install rbenv
-        rbenv install ${{ matrix.ruby }}
-        rbenv local ${{ matrix.ruby }}
+        rbenv install ${{ matrix.ruby-mac }}
+        rbenv local ${{ matrix.ruby-mac }}
     - name: run build
       run: |
         if [ -x rbenv ]; then eval "$(rbenv init -)"; fi


### PR DESCRIPTION
We constantly are fighting updating these minor versions because rbenv wants us
to be precise. But the ruby-setup action we rely on for the Ubuntu builds
has a much more restricted list of versions which are available.

Keeping both as the same list means CI breaks constantly for no reason so create
two different lists to try to stop us having to do busywork.