### PR TITLE
Upgrade libgit2 to v1.0.1

### DIFF
--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '1.0.0'
+  Version = VERSION = '1.0.1'
 end


### PR DESCRIPTION
There's several bugfixes released in v1.0.1, so Rugged should upgrade and probably pull a release itself. The most important fix is that cloning from Google Source now works again.