### PR TITLE
Introduce Rugged::Submodule.valid_name?

### DIFF
--- a/ext/rugged/rugged_submodule.c
+++ b/ext/rugged/rugged_submodule.c
@@ -778,6 +778,26 @@ static VALUE rb_git_submodule_finalize_add(VALUE self)
 	return self;
 }
 
+/*
+ *  call-seq:
+ *    Submdule.valid_name? -> bool
+ *
+ *  Check whether the given name is a valid name for a submdule i.e. check that
+ *  it's not trying to escape from its directory.
+ *
+ *  The path must the canonicalised into slashes as directory separators.
+ */
+static VALUE rb_git_submodule_name_is_valid(VALUE klass, VALUE rb_name)
+{
+	int valid;
+
+	Check_Type(rb_name, T_STRING);
+
+	valid = git_submodule_name_is_valid(NULL, StringValueCStr(rb_name), 0);
+
+	return valid ? Qtrue : Qfalse;
+}
+
 void Init_rugged_submodule(void)
 {
 	init_status_list();
@@ -832,4 +852,5 @@ void Init_rugged_submodule(void)
 	rb_define_method(rb_cRuggedSubmodule, "reload", rb_git_submodule_reload, 0);
 	rb_define_method(rb_cRuggedSubmodule, "sync", rb_git_submodule_sync, 0);
 	rb_define_method(rb_cRuggedSubmodule, "init", rb_git_submodule_init, -1);
+	rb_define_singleton_method(rb_cRuggedSubmodule, "valid_name?", rb_git_submodule_name_is_valid, 1);
 }

--- a/test/submodule_test.rb
+++ b/test/submodule_test.rb
@@ -316,4 +316,15 @@ class SubmoduleTest < Rugged::TestCase
     assert submodule.repository.branches['master']
     assert_equal 'origin/master', submodule.repository.branches['master'].upstream.name
   end
+
+  def test_submodule_valid_name?
+    assert Rugged::Submodule.valid_name?("mysubmodule")
+    assert Rugged::Submodule.valid_name?("mysubmodule/.git/foo")
+
+    refute Rugged::Submodule.valid_name?("../mysubmodule")
+    refute Rugged::Submodule.valid_name?("my/../submodule")
+
+    refute Rugged::Submodule.valid_name?("..\\mysubmodule")
+    refute Rugged::Submodule.valid_name?("my\\..\\submodule")
+  end
 end


### PR DESCRIPTION
This allows checking if a submodule has a valid name and isn't trying to escape the repository.