### PR TITLE
fixed namespacing issue in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ You can store bare repositories in alternative backends instead of storing on di
 `redbadger/rugged-redis` for an example of how a rugged backend works).
 
 ```ruby
-a_backend = Rugged::InMemory::Backend.new(opt1: 'setting', opt2: 'setting')
+a_backend = Rugged::Backend.new(opt1: 'setting', opt2: 'setting')
 
 repo = Rugged::Repository.init_at('repo_name', :bare, backend: a_backend)
 


### PR DESCRIPTION
Hi, this is just a super simple documentation fix. The README refers to a namespace/module which no longer exists, so I corrected it. `Rugged::InMemory::Backend` is now just `Rugged::Backend`. Thanks for your time!