### PR TITLE
Expose 'recursion_limit' option for merges

### DIFF
--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -467,6 +467,12 @@ void rugged_parse_merge_options(git_merge_options *opts, VALUE rb_options)
 			opts->target_limit = FIX2UINT(rb_value);
 		}
 
+		rb_value = rb_hash_aref(rb_options, CSTR2SYM("recursion_limit"));
+		if (!NIL_P(rb_value)) {
+			Check_Type(rb_value, T_FIXNUM);
+			opts->recursion_limit = FIX2UINT(rb_value);
+		}
+
 		rb_value = rb_hash_aref(rb_options, CSTR2SYM("favor"));
 		if (!NIL_P(rb_value)) {
 			ID id_favor;


### PR DESCRIPTION
libgit2 has a `recursion_limit` option in `git_merge_options` to
control the potential cost of recursive merging, but this is not
currently exposed in rugged.

This change makes `recursion_limit` available for use in rugged.