### PR TITLE
Updates for LICENSE and README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License
 
 Copyright (c) 2016 GitHub, Inc
+Copyright (c) Rugged Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ You can store bare repositories in alternative backends instead of storing on di
 `redbadger/rugged-redis` for an example of how a rugged backend works).
 
 ```ruby
-a_backend = Rugged::InMemory::Backend.new(opt1: 'setting', opt2: 'setting')
+a_backend = MyProject::CustomObjectDB(opt1: 'setting', opt2: 'setting')
 
 repo = Rugged::Repository.init_at('repo_name', :bare, backend: a_backend)
 


### PR DESCRIPTION
A small update to indicate the copyright isn't just for 2016 and make it clearer that we don't have an in-memory backend in this codebase.

Closes #862 
Closes #681 