### PR TITLE
Move away from some deprecated structures

### DIFF
--- a/ext/rugged/rugged_object.c
+++ b/ext/rugged/rugged_object.c
@@ -400,7 +400,7 @@ static VALUE rb_git_object_read_raw(VALUE self)
 
 void Init_rugged_object(void)
 {
-	rb_cRuggedObject = rb_define_class_under(rb_mRugged, "Object", rb_cData);
+	rb_cRuggedObject = rb_define_class_under(rb_mRugged, "Object", rb_cObject);
 	rb_define_singleton_method(rb_cRuggedObject, "lookup", rb_git_object_lookup, 2);
 	rb_define_singleton_method(rb_cRuggedObject, "rev_parse", rb_git_object_rev_parse, 2);
 	rb_define_singleton_method(rb_cRuggedObject, "rev_parse_oid", rb_git_object_rev_parse_oid, 2);

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -2845,7 +2845,7 @@ void Init_rugged_repo(void)
 	rb_define_method(rb_cRuggedRepo, "cherrypick_commit", rb_git_repo_cherrypick_commit, -1);
 	rb_define_method(rb_cRuggedRepo, "fetch_attributes", rb_git_repo_attributes, -1);
 
-	rb_cRuggedOdbObject = rb_define_class_under(rb_mRugged, "OdbObject", rb_cData);
+	rb_cRuggedOdbObject = rb_define_class_under(rb_mRugged, "OdbObject", rb_cObject);
 	rb_define_method(rb_cRuggedOdbObject, "data",  rb_git_odbobj_data,  0);
 	rb_define_method(rb_cRuggedOdbObject, "len",  rb_git_odbobj_size,  0);
 	rb_define_method(rb_cRuggedOdbObject, "type",  rb_git_odbobj_type,  0);


### PR DESCRIPTION
With Ruby 3.0 we're getting a warning about using `rb_cData` so let's move to `rb_cObject`. By the same, `rb_iterate` was superseded by `rb_block_call` all the way back in Ruby 1.9 so let's move forward while avoiding some warnings during compilation.