### PR TITLE
Add dependency to cmake on Windows

### DIFF
--- a/rugged.gemspec
+++ b/rugged.gemspec
@@ -31,5 +31,5 @@ desc
   s.add_development_dependency "rake-compiler", ">= 0.9.0"
   s.add_development_dependency "pry"
   s.add_development_dependency "minitest", "~> 5.0"
-  s.metadata["msys2_mingw_dependencies"] = "libssh2"
+  s.metadata["msys2_mingw_dependencies"] = "libssh2 cmake"
 end


### PR DESCRIPTION
This adds MINGW package as an additional dependency on Windows.

With this addition in the gemspec the rugged gem installs on a plain RubyInstaller setup.