### PR TITLE
Isolate the configuration in the tests

### DIFF
--- a/script/travisbuild
+++ b/script/travisbuild
@@ -26,6 +26,4 @@ echo 'PasswordAuthentication yes' | sudo tee -a /etc/sshd_config
 eval $(ssh-agent)
 ssh-add $GITTEST_REMOTE_SSH_KEY
 
-# We need the config so the tests don't fail
-git config --global user.name 'The rugged tests are fragile'
 bundle exec rake || exit $?

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -3,6 +3,16 @@ require "test_helper"
 class ConfigTest < Rugged::TestCase
   def setup
     @repo = FixtureRepo.from_rugged("testrepo.git")
+
+    path = Dir.mktmpdir("rugged-global-config")
+    cfg = Rugged::Config.new(File.join(path, ".gitconfig"))
+    cfg['user.name'] = "The test suite"
+    Rugged::Settings['search_path_global'] = path
+    @glocalconfigdir = path
+  end
+
+  def cleanup
+    FileUtils.remove_entry_secure(@globalconfigdir)
   end
 
   def test_multi_fetch

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,9 +6,22 @@ require 'pp'
 
 module Rugged
   class TestCase < Minitest::Test
+    # Set up some isolation for our tests so we don't try to touch any
+    # configuration from the user running the tests
+    def before_setup
+      @configdir ||= begin
+        path = Dir.mktmpdir("rugged-config")
+        Rugged::Settings['search_path_global'] = path
+        Rugged::Settings['search_path_xdg'] = path
+        Rugged::Settings['search_path_system'] = path
+      end
+      super
+    end
+
     # Automatically clean up created fixture repos after each test run
     def after_teardown
       Rugged::TestCase::FixtureRepo.teardown
+      FileUtils.remove_entry_secure(@configdir)
       super
     end
 


### PR DESCRIPTION
It doesn't actually make much sense to rely on whatever Git configuration exists on the system we're running on. It could have anything in there.

Set up a sandboxed empty dir for us to look up above-local configuration and set it up where we do need it.