### PR TITLE
ci: use ruby/setup-ruby for both builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4.9', '2.5.7', '2.6.5', '2.7.0' ]
+        ruby: [ '2.6', '2.7', '3.0' ]
         os: [ macOS-latest ]
     runs-on: ${{ matrix.os }}
 
@@ -24,10 +24,10 @@ jobs:
     - name: Install macOS packages
       run: ./vendor/libgit2/ci/setup-osx.sh
     - name: Set up Ruby on macOS
-      run: |
-        brew install rbenv
-        rbenv install ${{ matrix.ruby }}
-        rbenv local ${{ matrix.ruby }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: run build
       run: |
         eval "$(rbenv init -)"
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.6', '2.7', '3.0' ]
         os: [ ubuntu-18.04 ]
     runs-on: ${{ matrix.os }}
 
@@ -54,9 +54,10 @@ jobs:
         sudo apt update
         sudo apt install -y cmake libssh2-1-dev openssh-client openssh-server
     - name: Set up Ruby on Linux
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: run build
       run: |
         ruby --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,7 @@ jobs:
         bundler-cache: true
     - name: run build
       run: |
-        eval "$(rbenv init -)"
         ruby --version
-        gem install bundler
-        bundle install --path vendor
         ./script/travisbuild
 
   ubuntu:
@@ -61,6 +58,4 @@ jobs:
     - name: run build
       run: |
         ruby --version
-        gem install bundler
-        bundle install --path vendor
         ./script/travisbuild

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source "http://rubygems.org"
 
-platforms :rbx do
-  gem 'rubysl', '~> 2.0'
+if RUBY_VERSION <= '2.7'
+  platforms :rbx do
+    gem 'rubysl', '~> 2.0'
+  end
 end
 
 gemspec

--- a/test/online/fetch_test.rb
+++ b/test/online/fetch_test.rb
@@ -84,7 +84,7 @@ class OnlineFetchTest < Rugged::OnlineTestCase
 
     @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
 
-    @repo.fetch("origin", {
+    @repo.fetch("origin", **{
                   credentials: ssh_key_credential
                 })
   end
@@ -94,7 +94,7 @@ class OnlineFetchTest < Rugged::OnlineTestCase
 
     @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
 
-    @repo.fetch("origin", {
+    @repo.fetch("origin", **{
                   credentials: ssh_key_credential_from_agent
                 })
   end

--- a/test/online/push_test.rb
+++ b/test/online/push_test.rb
@@ -45,7 +45,7 @@ class OnlineSshPushTest < Rugged::OnlineTestCase
                    "refs/heads/b3:refs/heads/b3",
                    "refs/heads/b4:refs/heads/b4",
                    "refs/heads/b5:refs/heads/b5"
-                 ], {
+                 ], **{
                    credentials: ssh_key_credential
                  })
 


### PR DESCRIPTION
Currently macOS is using rvm as the previous `actions/setup-ruby` did not work
there at the time were building this. This change should speed up and unify the
versions we run for our tests.