### PR TITLE
Use Dir.exist? instead of Dir.exists?

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -98,7 +98,7 @@ else
   end
 
   Dir.chdir(LIBGIT2_DIR) do
-    Dir.mkdir("build") if !Dir.exists?("build")
+    Dir.mkdir("build") if !Dir.exist?("build")
 
     Dir.chdir("build") do
       # On Windows, Ruby-DevKit is MSYS-based, so ensure to use MSYS Makefiles.


### PR DESCRIPTION
`Dir.exists?` has been deprecated since Ruby 2.2 and is being removed in Ruby 3.2