### PR TITLE
config: deal with an empty value for a malformed config file

### DIFF
--- a/ext/rugged/rugged_config.c
+++ b/ext/rugged/rugged_config.c
@@ -181,17 +181,22 @@ static int cb_config__each_key(const git_config_entry *entry, void *payload)
 static int cb_config__each_pair(const git_config_entry *entry, void *payload)
 {
 	int *exception = (int *) payload;
+	VALUE value;
 
-	rb_protect(rb_yield, rb_ary_new3(2, rb_str_new_utf8(entry->name), rb_str_new_utf8(entry->value)), exception);
+	value = entry->value ? rb_str_new_utf8(entry->value) : Qnil;
+	rb_protect(rb_yield, rb_ary_new3(2, rb_str_new_utf8(entry->name), value), exception);
 
 	return (*exception != 0) ? GIT_EUSER : GIT_OK;
 }
 
 static int cb_config__to_hash(const git_config_entry *entry, void *opaque)
 {
+	VALUE value;
+
+	value = entry->value ? rb_str_new_utf8(entry->value) : Qnil;
 	rb_hash_aset((VALUE)opaque,
 		rb_str_new_utf8(entry->name),
-		rb_str_new_utf8(entry->value)
+		value
 	);
 
 	return GIT_OK;

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -117,4 +117,25 @@ class ConfigWriteTest < Rugged::TestCase
     config2 = @repo.config
     assert_nil config2.get('core.bare')
   end
+
+  def test_invalid_values
+    Tempfile.open("config-value") do |file|
+      file.write(<<-CONFIG)
+      [section "subsection"]
+      line1 = string1
+      line2
+      line3 = string2
+      CONFIG
+      file.flush
+
+      config = Rugged::Config.new(file.path)
+      config.each_pair.to_a # just checking it doesn't crash
+      config.to_hash
+
+      # We expect an empty string due to how we look up specific keys
+      assert_equal "string1", config["section.subsection.line1"]
+      assert_equal "", config["section.subsection.line2"]
+      assert_equal "string2", config["section.subsection.line3"]
+    end
+  end
 end


### PR DESCRIPTION
If you don't specfiy a value for a line of configuration, the library deals with
this by storing a `NULL` value for it. We must be ready for it to appear.

Change the `#each_pair` and `#to_hash` methods to handle this and avoid
dereferencing the `NULL` pointer.