### PR TITLE
Update libgit2 to v1.4.2

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -103,7 +103,7 @@ else
     Dir.chdir("build") do
       # On Windows, Ruby-DevKit is MSYS-based, so ensure to use MSYS Makefiles.
       generator = "-G \"MSYS Makefiles\"" if Gem.win_platform?
-      run_cmake(5 * 60, ".. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo #{cmake_flags.join(' ')} #{generator}")
+      run_cmake(5 * 60, ".. -DBUILD_TESTS=OFF -DUSE_THREADS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo #{cmake_flags.join(' ')} #{generator}")
       sys(MAKE)
 
       # "normal" libraries (and libgit2 builds) get all these when they build but we're doing it

--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '1.3.1'
+  Version = VERSION = '1.4.2'
 end

--- a/test/repo_test.rb
+++ b/test/repo_test.rb
@@ -81,13 +81,13 @@ class RepositoryTest < Rugged::TestCase
 
   def test_match_all_refs
     refs = @repo.refs 'refs/heads/*'
-    assert_equal 12, refs.count
+    assert_equal 13, refs.count
   end
 
   def test_return_all_ref_names
     refs = @repo.ref_names
     refs.each {|name| assert name.kind_of?(String)}
-    assert_equal 22, refs.count
+    assert_equal 23, refs.count
   end
 
   def test_return_all_tags


### PR DESCRIPTION
The test checking the `update_tips` behaviour is failing due to a regression upstream. There is a patch available in libgit2/libgit2#6226 so we may need to update to something in the mainline depending on how that goes.