### PR TITLE
Supply custom headers in calls to clone_at

### DIFF
--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -535,6 +535,9 @@ static void parse_clone_options(git_clone_options *ret, VALUE rb_options, struct
 		ret->fetch_opts.proxy_opts.url = StringValueCStr(val);
 	}
 
+	val = rb_hash_aref(rb_options, CSTR2SYM("headers"));
+	rugged_rb_ary_to_strarray(val, &(ret->fetch_opts.custom_headers));
+
 	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &ret->fetch_opts.callbacks, remote_payload);
 }
 


### PR DESCRIPTION
> ℹ️ Note: I'm basing this against `maint/v1.4` because that seems to be the branch the latest version of Rugged is from, and `master` is currently behind. I can change the base on this PR once `master` is back up to date.

Some git servers, namely Azure DevOps, don't treat PATs like normal git auth credentials. Azure DevOps specifically requests [providing the PAT as an auth header](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Linux#use-a-pat) when doing actions like git clone. There used to be a workaround that allowed providing the path in the URL for the repo, but that also recently broke for Azure DevOps Server (the on-premises version) and the official guidance is that the header is now the only supported way of auth'ing via PAT. For this reason, we can't use Rugged's (and libgit2's) convention for credentials in these scenarios.

This PR adds the ability for Rugged to supply custom headers to libgit2 during `clone_at` calls, similar to `git -c http.extraHeader`. I followed the same conventions as were followed for `push` in `rugged_remote` (via [`init_custom_headers`](https://github.com/libgit2/rugged/blob/061653057eba93d5b836cb5569c7a7da38c385db/ext/rugged/rugged_remote.c#L205)). I have verified the behavior works as expected with headers supplied, and that things still work as expected without headers.