### PR TITLE
allow tree methods to return Enumerator when called without block

### DIFF
--- a/lib/rugged/tree.rb
+++ b/lib/rugged/tree.rb
@@ -172,21 +172,25 @@ module Rugged
 
     # Walks the tree but only yields blobs
     def walk_blobs(mode=:postorder)
+      return to_enum(__method__) unless block_given?
       self.walk(mode) { |root, e| yield root, e if e[:type] == :blob }
     end
 
     # Walks the tree but only yields subtrees
     def walk_trees(mode=:postorder)
+      return to_enum(__method__) unless block_given?
       self.walk(mode) { |root, e| yield root, e if e[:type] == :tree }
     end
 
     # Iterate over the blobs in this tree
     def each_blob
+      return to_enum(__method__) unless block_given?
       self.each { |e| yield e if e[:type] == :blob }
     end
 
     # Iterate over the subtrees in this tree
     def each_tree
+      return to_enum(__method__) unless block_given?
       self.each { |e| yield e if e[:type] == :tree }
     end
   end

--- a/test/tree_test.rb
+++ b/test/tree_test.rb
@@ -98,16 +98,32 @@ class TreeTest < Rugged::TestCase
     @tree.walk_trees {|root, entry| assert_equal :tree, entry[:type]}
   end
 
+  def test_tree_walk_only_trees_without_block
+    assert_equal [:tree], @tree.walk_trees.map { |_root, entry| entry[:type] }.uniq
+  end
+
   def test_tree_walk_only_blobs
     @tree.walk_blobs {|root, entry| assert_equal :blob, entry[:type]}
+  end
+
+  def test_tree_walk_only_blobs_without_block
+    assert_equal [:blob], @tree.walk_blobs.map { |_root, entry| entry[:type] }.uniq
   end
 
   def test_iterate_subtrees
     @tree.each_tree {|tree| assert_equal :tree, tree[:type]}
   end
 
+  def test_iterate_subtrees_without_block
+    assert_equal [:tree], @tree.each_tree.map { |tree| tree[:type] }.uniq
+  end
+
   def test_iterate_subtree_blobs
     @tree.each_blob {|tree| assert_equal :blob, tree[:type]}
+  end
+
+  def test_iterate_subtree_blobs_without_block
+    assert_equal [:blob], @tree.each_blob.map { |tree| tree[:type] }.uniq
   end
 end
 


### PR DESCRIPTION
It is possible to call `walk` and `each` without block and get an `Enumerator`, unlike methods `each_blob`, `each_tree`, `walk_blobs` and `walk_trees`.