### PR TITLE
Update to libgit2 v1.4.3

### DIFF
--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '1.4.2'
+  Version = VERSION = '1.4.3'
 end

--- a/script/travisbuild
+++ b/script/travisbuild
@@ -48,9 +48,16 @@ mkdir $HOME/_temp
 git init --bare $HOME/_temp/test.git
 git daemon --listen=localhost --export-all --enable=receive-pack --base-path=$HOME/_temp $HOME/_temp 2>/dev/null &
 
+# Also copy a test repo in there for read tests; we check that we correctly
+# detect when a push isn't allowed so we need a different instance running there
+mkdir $HOME/_temp_ro
+cp -r ./test/fixtures/testrepo.git $HOME/_temp_ro/
+git daemon --listen=localhost --port=9419 --export-all --base-path=$HOME/_temp_ro $HOME/_temp_ro 2>/dev/null &
+
 # On Actions we start with 777 which means sshd won't let us in
 chmod 750 $HOME
 
+export GITTEST_REMOTE_GIT_RO_URL="git://localhost:9419/testrepo.git"
 export GITTEST_REMOTE_GIT_URL="git://localhost/test.git"
 export GITTEST_REMOTE_SSH_URL="ssh://localhost:2222/$HOME/_temp/test.git"
 export GITTEST_REMOTE_SSH_USER=$USER

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -6,29 +6,25 @@ class RemoteNetworkTest < Rugged::OnlineTestCase
     @repo = FixtureRepo.from_rugged("testrepo.git")
   end
 
-  def skip_if_unreachable
-    begin
-      Net::HTTP.new('github.com').head('/')
-    rescue SocketError => msg
-      skip "github is not reachable: #{msg}"
-    end
+  def skip_if_no_test_url
+    skip "no local git-daemon" unless ENV["GITTEST_REMOTE_GIT_RO_URL"]
   end
 
   def test_remote_network_connect
-    skip_if_unreachable
-    remote = @repo.remotes.create_anonymous('git://github.com/libgit2/libgit2.git')
+    skip_if_no_test_url
+    remote = @repo.remotes.create_anonymous(ENV["GITTEST_REMOTE_GIT_RO_URL"])
     assert remote.ls.any?
   end
 
   def test_remote_check_connection_fetch
-    skip_if_unreachable
-    remote = @repo.remotes.create_anonymous('git://github.com/libgit2/libgit2.git')
+    skip_if_no_test_url
+    remote = @repo.remotes.create_anonymous(ENV["GITTEST_REMOTE_GIT_RO_URL"])
     assert remote.check_connection(:fetch)
   end
 
   def test_remote_check_connection_push
-    skip_if_unreachable
-    remote = @repo.remotes.create_anonymous('git://github.com/libgit2/libgit2.git')
+    skip_if_no_test_url
+    remote = @repo.remotes.create_anonymous(ENV["GITTEST_REMOTE_GIT_RO_URL"])
     assert !remote.check_connection(:push)
   end
 
@@ -41,7 +37,7 @@ class RemoteNetworkTest < Rugged::OnlineTestCase
   end
 
   def test_remote_check_connection_invalid
-    skip_if_unreachable
+    skip_if_no_test_url
     remote = @repo.remotes.create_anonymous('git://github.com/libgit2/libgit2.git')
     assert_raises(TypeError) { remote.check_connection(:pull) }
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,13 +38,7 @@ module Rugged
         path = Dir.mktmpdir("rugged-#{name}")
         ensure_cleanup(path)
 
-        FileUtils.cp_r(File.join(TestCase::TEST_DIR, "fixtures", name, "."), path)
-
-        prepare(path)
-
-        Rugged::Repository.new(path, *args).tap do |repo|
-          rewrite_gitmodules(repo) unless repo.bare?
-        end
+        copy_fixture(path, name, File.join(TestCase::TEST_DIR, "fixtures", name, "."), *args)
       end
 
       # Create a repository based on a libgit2 fixture repo.
@@ -52,11 +46,16 @@ module Rugged
         path = Dir.mktmpdir("rugged-libgit2-#{name}")
         ensure_cleanup(path)
 
-        FileUtils.cp_r(File.join(TestCase::LIBGIT2_FIXTURE_DIR, name, "."), path)
+        copy_fixture(path, name, File.join(TestCase::LIBGIT2_FIXTURE_DIR, name, "."), *args)
+      end
 
-        prepare(path)
+      def self.copy_fixture(path, name, fixture_prefix, *args)
+        repo_path = File.join(path, name)
+        FileUtils.cp_r(fixture_prefix, repo_path)
 
-        Rugged::Repository.new(path, *args).tap do |repo|
+        prepare(repo_path)
+
+        Rugged::Repository.new(repo_path, *args).tap do |repo|
           rewrite_gitmodules(repo) unless repo.bare?
         end
       end


### PR DESCRIPTION
This updates to a version which provides compatibility with git's changes to address [CVE 2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/).

libgit2 and its bindings are not affected as they do not execute programs.