### PR TITLE
Update libgit2 to 639702

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: update submodule
       run: git submodule update --init
     - name: Install macOS packages
-      run: ./vendor/libgit2/ci/setup-osx.sh
+      run: ./vendor/libgit2/ci/setup-osx-build.sh
     - name: Set up Ruby on macOS
       uses: ruby/setup-ruby@v1
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ git:
 before_install:
   - git submodule update --init
   - gem update --system
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./vendor/libgit2/ci/setup-osx.sh; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./vendor/libgit2/ci/setup-osx-build.sh; fi
 
 script: script/travisbuild

--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -77,6 +77,18 @@ static VALUE rb_git_libgit2_version(VALUE self)
 
 /*
  *  call-seq:
+ *     Rugged.libgit2_prerelease -> prerelease string
+ *
+ *  Returns a string with the prerelease string for libgit2. This will be empty
+ *  for tagged releases.
+ */
+static VALUE rb_git_libgit2_prerelease(VALUE self)
+{
+	return rb_str_new_utf8(git_libgit2_prerelease());
+}
+
+/*
+ *  call-seq:
  *     Rugged.features -> [feature, ...]
  *
  *  Returns an array representing the features that libgit2 was compiled
@@ -585,6 +597,7 @@ void Init_rugged(void)
 	}
 
 	rb_define_module_function(rb_mRugged, "libgit2_version", rb_git_libgit2_version, 0);
+	rb_define_module_function(rb_mRugged, "libgit2_prerelease", rb_git_libgit2_prerelease, 0);
 	rb_define_module_function(rb_mRugged, "features", rb_git_features, 0);
 	rb_define_module_function(rb_mRugged, "valid_full_oid?", rb_git_valid_full_oid, 1);
 	rb_define_module_function(rb_mRugged, "hex_to_raw", rb_git_hex_to_raw, 1);

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -529,7 +529,7 @@ index 94aaae8..af8f41d 100644
 +_file1.txt_
  file1.txt
 --
-libgit2 #{Rugged.libgit2_version.join('.')}
+libgit2 #{Rugged.libgit2_version.join('.')}#{Rugged.libgit2_prerelease ? "-" : ""}#{Rugged.libgit2_prerelease}
 
 EOS
   end
@@ -572,7 +572,7 @@ index 0000000..9435022
 +file3
 +file3
 --
-libgit2 #{Rugged.libgit2_version.join('.')}
+libgit2 #{Rugged.libgit2_version.join('.')}#{Rugged.libgit2_prerelease ? "-" : ""}#{Rugged.libgit2_prerelease}
 
 EOS
 
@@ -611,7 +611,7 @@ index 9435022..9a2d780 100644
  file3
  file3
 --
-libgit2 #{Rugged.libgit2_version.join('.')}
+libgit2 #{Rugged.libgit2_version.join('.')}#{Rugged.libgit2_prerelease ? "-" : ""}#{Rugged.libgit2_prerelease}
 
 EOS
 
@@ -655,7 +655,7 @@ index 94aaae8..af8f41d 100644
 +_file1.txt_
  file1.txt
 --
-libgit2 #{Rugged.libgit2_version.join('.')}
+libgit2 #{Rugged.libgit2_version.join('.')}#{Rugged.libgit2_prerelease ? "-" : ""}#{Rugged.libgit2_prerelease}
 
 EOS
   end
@@ -694,7 +694,7 @@ index 94aaae8..af8f41d 100644
 +_file1.txt_
  file1.txt
 --
-libgit2 #{Rugged.libgit2_version.join('.')}
+libgit2 #{Rugged.libgit2_version.join('.')}#{Rugged.libgit2_prerelease ? "-" : ""}#{Rugged.libgit2_prerelease}
 
 EOS
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,13 +38,7 @@ module Rugged
         path = Dir.mktmpdir("rugged-#{name}")
         ensure_cleanup(path)
 
-        FileUtils.cp_r(File.join(TestCase::TEST_DIR, "fixtures", name, "."), path)
-
-        prepare(path)
-
-        Rugged::Repository.new(path, *args).tap do |repo|
-          rewrite_gitmodules(repo) unless repo.bare?
-        end
+        copy_fixture(path, name, File.join(TestCase::TEST_DIR, "fixtures", name, "."), *args)
       end
 
       # Create a repository based on a libgit2 fixture repo.
@@ -52,11 +46,16 @@ module Rugged
         path = Dir.mktmpdir("rugged-libgit2-#{name}")
         ensure_cleanup(path)
 
-        FileUtils.cp_r(File.join(TestCase::LIBGIT2_FIXTURE_DIR, name, "."), path)
+        copy_fixture(path, name, File.join(TestCase::LIBGIT2_FIXTURE_DIR, name, "."), *args)
+      end
 
-        prepare(path)
+      def self.copy_fixture(path, name, fixture_prefix, *args)
+        repo_path = File.join(path, name)
+        FileUtils.cp_r(fixture_prefix, repo_path)
 
-        Rugged::Repository.new(path, *args).tap do |repo|
+        prepare(repo_path)
+
+        Rugged::Repository.new(repo_path, *args).tap do |repo|
           rewrite_gitmodules(repo) unless repo.bare?
         end
       end


### PR DESCRIPTION
It includes a fix for the behaviour of libgit2 where it now checks ownership of a parent repository as part of  changes to address [CVE 2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/).