### PR TITLE
Fixups for the 1.3 maintenance series

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4.9', '2.5.7', '2.6.5', '2.7.0' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
         os: [ macOS-latest ]
     runs-on: ${{ matrix.os }}
 
@@ -24,23 +24,20 @@ jobs:
     - name: Install macOS packages
       run: ./vendor/libgit2/ci/setup-osx.sh
     - name: Set up Ruby on macOS
-      run: |
-        brew install rbenv
-        rbenv install ${{ matrix.ruby }}
-        rbenv local ${{ matrix.ruby }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: run build
       run: |
-        eval "$(rbenv init -)"
         ruby --version
-        gem install bundler
-        bundle install --path vendor
         ./script/travisbuild
 
   ubuntu:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
         os: [ ubuntu-18.04 ]
     runs-on: ${{ matrix.os }}
 
@@ -54,12 +51,11 @@ jobs:
         sudo apt update
         sudo apt install -y cmake libssh2-1-dev openssh-client openssh-server
     - name: Set up Ruby on Linux
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: run build
       run: |
         ruby --version
-        gem install bundler
-        bundle install --path vendor
         ./script/travisbuild

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source "http://rubygems.org"
 
-platforms :rbx do
-  gem 'rubysl', '~> 2.0'
+if RUBY_VERSION <= '2.7'
+  platforms :rbx do
+    gem 'rubysl', '~> 2.0'
+  end
 end
 
 gemspec

--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -98,7 +98,7 @@ else
   end
 
   Dir.chdir(LIBGIT2_DIR) do
-    Dir.mkdir("build") if !Dir.exists?("build")
+    Dir.mkdir("build") if !Dir.exist?("build")
 
     Dir.chdir("build") do
       # On Windows, Ruby-DevKit is MSYS-based, so ensure to use MSYS Makefiles.

--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '1.3.2'
+  Version = VERSION = '1.3.2.1'
 end

--- a/test/online/fetch_test.rb
+++ b/test/online/fetch_test.rb
@@ -84,7 +84,7 @@ class OnlineFetchTest < Rugged::OnlineTestCase
 
     @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
 
-    @repo.fetch("origin", {
+    @repo.fetch("origin", **{
                   credentials: ssh_key_credential
                 })
   end
@@ -94,7 +94,7 @@ class OnlineFetchTest < Rugged::OnlineTestCase
 
     @repo.remotes.create("origin", ENV['GITTEST_REMOTE_SSH_URL'])
 
-    @repo.fetch("origin", {
+    @repo.fetch("origin", **{
                   credentials: ssh_key_credential_from_agent
                 })
   end

--- a/test/online/push_test.rb
+++ b/test/online/push_test.rb
@@ -45,7 +45,7 @@ class OnlineSshPushTest < Rugged::OnlineTestCase
                    "refs/heads/b3:refs/heads/b3",
                    "refs/heads/b4:refs/heads/b4",
                    "refs/heads/b5:refs/heads/b5"
-                 ], {
+                 ], **{
                    credentials: ssh_key_credential
                  })
 


### PR DESCRIPTION
Due to the odd way 1.3.1 was tagged and released (lack of maintenance branch and a version not matching the libgit2 one) we missed out on some changes from that version here.

These are not functional changes so it's not so bad, but we should still want the compatibility fixes for newer rubies to be taken into consideration, so let's add a 1.3.2.1 version with these fixups, like we should have done instead of 1.3.1.