### PR TITLE
settings: add ability to enable fsyncing of Git objects

### DIFF
--- a/ext/rugged/rugged_settings.c
+++ b/ext/rugged/rugged_settings.c
@@ -86,6 +86,11 @@ static VALUE rb_git_set_option(VALUE self, VALUE option, VALUE value)
 		git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, strict);
 	}
 
+	else if (strcmp(opt, "fsync_gitdir") == 0) {
+		int fsync = RTEST(value) ? 1 : 0;
+		git_libgit2_opts(GIT_OPT_ENABLE_FSYNC_GITDIR, fsync);
+	}
+
 	else {
 		rb_raise(rb_eArgError, "Unknown option specified");
 	}

--- a/test/lib_test.rb
+++ b/test/lib_test.rb
@@ -28,6 +28,15 @@ class RuggedTest < Rugged::TestCase
     assert_raises(TypeError) { Rugged::Settings['mwindow_size'] = nil }
   end
 
+  def test_fsync_gitdir
+    # We can only really test whether this does _something_. libgit2 doesn't
+    # provide any way to query the state of this configuration, and we have no
+    # easy way to verify whether data is now synchronized or not.
+    Rugged::Settings['fsync_gitdir'] = true
+
+    Rugged::Settings['fsync_gitdir'] = false
+  end
+
   def test_search_path
     paths = [['search_path_global', '/tmp/global'],
              ['search_path_xdg', '/tmp/xdg'],


### PR DESCRIPTION
libgit2 exposes the ability to globally enable fsyncing of Git objects
via the `GIT_OPT_ENABLE_FSYNC_GITDIR` option, but we provide no way of
actually setting this value in Rugged. Add this ability via a new
"fsync_gitdir" option.