### PR TITLE
Update to libgit2 v1.3.2

### DIFF
--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '1.3.2.1'
+  Version = VERSION = '1.3.2.2'
 end


### PR DESCRIPTION
The rugged version number continues to be silly due to some issues we had previously.