### PR TITLE
ci: enable SSH support

### DIFF
--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -722,6 +722,7 @@ static VALUE rb_git_remote_push(int argc, VALUE *argv, VALUE self)
 
 	Data_Get_Struct(self, git_remote, remote);
 
+	rugged_remote_init_callbacks_and_payload_from_options(rb_options, &opts.callbacks, &payload);
 	rugged_remote_init_custom_headers(rb_options, &opts.custom_headers);
 	rugged_remote_init_proxy_options(rb_options, &opts.proxy_opts);
 	init_pb_parallelism(rb_options, &opts);

--- a/script/travisbuild
+++ b/script/travisbuild
@@ -70,4 +70,4 @@ echo 'PasswordAuthentication yes' | sudo tee -a /etc/sshd_config
 eval $(ssh-agent)
 ssh-add $GITTEST_REMOTE_SSH_KEY
 
-bundle exec rake || exit $?
+bundle exec rake -- --with-ssh || exit $?

--- a/test/online/push_test.rb
+++ b/test/online/push_test.rb
@@ -29,7 +29,7 @@ end
 
 class OnlineSshPushTest < Rugged::OnlineTestCase
   def setup
-    skip unless Rugged.features.include?(:ssh)
+    skip unless Rugged.features.include?(:ssh) && git_creds?
 
     @repo = FixtureRepo.from_libgit2("push_src")
     @remote = @repo.remotes.create("test", ENV['GITTEST_REMOTE_SSH_URL'])


### PR DESCRIPTION
This turned off by default in the library so we've been running without SSH tests.