### PR TITLE
extconf: do not build libgit2 tests or CLI

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -14,6 +14,8 @@ $CFLAGS << " -O3" unless $CFLAGS[/-O\d/]
 $CFLAGS << " -Wall -Wno-comment"
 
 cmake_flags = [ ENV["CMAKE_FLAGS"] ]
+cmake_flags << "-DBUILD_CLI=OFF"
+cmake_flags << "-DBUILD_TESTS=OFF"
 cmake_flags << "-DREGEX_BACKEND=builtin"
 cmake_flags << "-DUSE_SHA1DC=ON" if with_config("sha1dc")
 cmake_flags << "-DUSE_SSH=ON"    if with_config("ssh")


### PR DESCRIPTION
It takes extra time for something we're not going to use and in at least one
case it looks like the CLI might have some issues linking correctly.

This should fix #932 by not building the CLI which is the portion that was causing an issue though a proper fix probably still needs to happen.