### PR TITLE
Fix pushing/hiding objects into the walker

### DIFF
--- a/ext/rugged/rugged_revwalk.c
+++ b/ext/rugged/rugged_revwalk.c
@@ -11,6 +11,8 @@ extern VALUE rb_mRugged;
 extern VALUE rb_cRuggedObject;
 VALUE rb_cRuggedWalker;
 
+extern const rb_data_type_t rugged_object_type;
+
 static void rb_git_walk__free(git_revwalk *walk)
 {
 	git_revwalk_free(walk);
@@ -43,7 +45,7 @@ static void push_commit_1(git_revwalk *walk, VALUE rb_commit, int hide)
 {
 	if (rb_obj_is_kind_of(rb_commit, rb_cRuggedObject)) {
 		git_object *object;
-		Data_Get_Struct(rb_commit, git_object, object);
+		TypedData_Get_Struct(rb_commit, git_object, &rugged_object_type, object);
 
 		push_commit_oid(walk, git_object_id(object), hide);
 		return;

--- a/test/walker_test.rb
+++ b/test/walker_test.rb
@@ -167,6 +167,17 @@ class WalkerTest < Rugged::TestCase
 
     assert_equal 1, amount
   end
+
+  def test_push_hide_commit
+    @walker.push(@repo.lookup("9fd738e8f7967c078dceed8190330fc8648ee56a"))
+    @walker.hide(@repo.lookup("5b5b025afb0b4c913b4c338a42934a3863bf3644"))
+
+    amount = @walker.count do |commit|
+      commit.oid == "9fd738e8f7967c078dceed8190330fc8648ee56a"
+    end
+
+    assert_equal 1, amount
+  end
 end
 
 # testrepo (the non-bare repo) is the one with non-linear history,


### PR DESCRIPTION
We accept objects instead of their string oid but we were using `Data_Get_Struct` instead of the `TypedData_Get_Struct` we moved to use so this conversion from `VALUE` to `git_object*` would always fail.

Fixes #860 