### PR TITLE
extconf: fix regexps for use-system-libraries

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -71,12 +71,12 @@ if arg_config("--use-system-libraries", !!ENV['RUGGED_USE_SYSTEM_LIBRARIES'])
   major = minor = nil
 
   File.readlines(File.join(LIBGIT2_DIR, "include", "git2", "version.h")).each do |line|
-    if !major && (matches = line.match(/^#define LIBGIT2_VER_MAJOR ([0-9]+)$/))
+    if !major && (matches = line.match(/^#define LIBGIT2_VER_MAJOR\s+([0-9]+)$/))
       major = matches[1]
       next
     end
 
-    if !minor && (matches = line.match(/^#define LIBGIT2_VER_MINOR ([0-9]+)$/))
+    if !minor && (matches = line.match(/^#define LIBGIT2_VER_MINOR\s+([0-9]+)$/))
       minor = matches[1]
       next
     end


### PR DESCRIPTION
after **libgit2** update to `1.5` in defines of `LIBGIT2_VER` [added more spaces](https://github.com/libgit2/libgit2/blob/fbea439d4b6fc91c6b619d01b85ab3b7746e4c19/include/git2/version.h#L16-L20), so old regexp not works anymore