### PR TITLE
Adds Ruby 3.2 to the CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
         os: [ macOS-latest ]
     runs-on: ${{ matrix.os }}
 
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
         os: [ ubuntu-18.04 ]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Runs green on my fork.

Please note that when making this change I initially upgraded the ubuntu-18.04 to a more recent ubuntu, but this causes all of the ubuntu jobs to fail.  There are ~7 failed specs, all of which look OpenSSL related, so I suspect a change in OpenSSL version causes them to fail.  This may require additional investigation.