### PR TITLE
fix: search at first system header for git2 then vendor's one

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -70,7 +70,10 @@ if arg_config("--use-system-libraries", !!ENV['RUGGED_USE_SYSTEM_LIBRARIES'])
 
   major = minor = nil
 
-  File.readlines(File.join(LIBGIT2_DIR, "include", "git2", "version.h")).each do |line|
+  git2_include_dir = Dir.glob("#{RbConfig::CONFIG["includedir"]}/**/git2").first ||
+    File.join(LIBGIT2_DIR, "include", "git2")
+
+  File.readlines(File.join(git2_include_dir, "version.h")).each do |line|
     if !major && (matches = line.match(/^#define LIBGIT2_VER_MAJOR\s+([0-9]+)$/))
       major = matches[1]
       next


### PR DESCRIPTION
- [x] ! search at first system header for git2 then vendor's one. please refer to [patch](https://git.altlinux.org/gears/g/gem-rugged.git?p=gem-rugged.git;a=blob;f=system_git2.patch;h=c6bd3b1e899522250c1fcfefdec51cb210531c6b;hb=f63322fa19292a2968e883e7870acac74aeff3e8)