### PR TITLE
Stop mutating commit diff options

### DIFF
--- a/lib/rugged/commit.rb
+++ b/lib/rugged/commit.rb
@@ -34,7 +34,7 @@ module Rugged
       # then diff against the prior commit
       if args.empty? || args.first.is_a?(Hash)
         other = parents.first
-        opts[:reverse] = !opts[:reverse]
+        opts = opts.merge(:reverse => !opts[:reverse])
       end
       self.tree.diff(other, opts)
     end

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -362,6 +362,21 @@ SIGNEDDATA
     commit = Rugged::Commit.lookup(@repo, commit_id)
     assert_equal "This is the commit message", commit.summary
   end
+
+  def test_diff
+    oid = "5b5b025afb0b4c913b4c338a42934a3863bf3644"
+    obj = @repo.lookup(oid)
+
+    assert_equal <<-PATCH, obj.diff.patch
+diff --git b/new.txt a/new.txt
+new file mode 100644
+index 0000000..fa49b07
+--- /dev/null
++++ a/new.txt
+@@ -0,0 +1 @@
++new file
+    PATCH
+  end
 end
 
 class CommitWriteTest < Rugged::TestCase

--- a/test/commit_test.rb
+++ b/test/commit_test.rb
@@ -377,6 +377,15 @@ index 0000000..fa49b07
 +new file
     PATCH
   end
+
+  def test_diff_options_not_changing
+    oid = "5b5b025afb0b4c913b4c338a42934a3863bf3644"
+    obj = @repo.lookup(oid)
+
+    options = {}
+
+    assert_equal obj.diff(options).patch, obj.diff(options).patch
+  end
 end
 
 class CommitWriteTest < Rugged::TestCase


### PR DESCRIPTION
Noticed that passing same options object to `Commit#diff` causes strange behaviour of reversing diff every second usage.
This fixes the behaviour using same way as [`Repository#diff`](https://github.com/libgit2/rugged/blob/6379f23cedd5f527cf6a5c229627e366b590a22d/lib/rugged/repository.rb#L114).