### PR TITLE
Update to 1.7.1

### DIFF
--- a/ext/rugged/rugged_allocator.c
+++ b/ext/rugged/rugged_allocator.c
@@ -13,56 +13,9 @@ static void *rugged_gmalloc(size_t n, const char *file, int line)
 	return xmalloc(n);
 }
 
-static void *rugged_gcalloc(size_t nelem, size_t elsize, const char *file, int line)
-{
-	return xcalloc(nelem, elsize);
-}
-
-static char *rugged_gstrdup(const char *str, const char *file, int line)
-{
-	return ruby_strdup(str);
-}
-
-static char *rugged_gstrndup(const char *str, size_t n, const char *file, int line)
-{
-	size_t len;
-	char *newstr;
-
-	len = strnlen(str, n);
-	if (len < n)
-		n = len;
-
-	newstr = xmalloc(n+1);
-	memcpy(newstr, str, n);
-	newstr[n] = '\0';
-
-	return newstr;
-}
-
-static char *rugged_gsubstrdup(const char *str, size_t n, const char *file, int line)
-{
-	char *newstr;
-
-	newstr = xmalloc(n+1);
-	memcpy(newstr, str, n);
-	newstr[n] = '\0';
-
-	return newstr;
-}
-
 static void *rugged_grealloc(void *ptr, size_t size, const char *file, int line)
 {
 	return xrealloc(ptr, size);
-}
-
-static void *rugged_greallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
-{
-	return xrealloc2(ptr, nelem, elsize);
-}
-
-static void *rugged_gmallocarray(size_t nelem, size_t elsize, const char *file, int line)
-{
-	return xmalloc2(nelem, elsize);
 }
 
 static void rugged_gfree(void *ptr)
@@ -75,14 +28,7 @@ void rugged_set_allocator(void)
 	git_allocator allocator;
 
 	allocator.gmalloc = rugged_gmalloc;
-	allocator.gcalloc = rugged_gcalloc;
-	allocator.gstrdup = rugged_gstrdup;
-	allocator.gstrndup = rugged_gstrndup;
-	allocator.gstrndup = rugged_gstrndup;
-	allocator.gsubstrdup = rugged_gsubstrdup;
 	allocator.grealloc = rugged_grealloc;
-	allocator.greallocarray = rugged_greallocarray;
-	allocator.gmallocarray = rugged_gmallocarray;
 	allocator.gfree = rugged_gfree;
 
 	git_libgit2_opts(GIT_OPT_SET_ALLOCATOR, &allocator);

--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '1.7.0'
+  Version = VERSION = '1.7.1'
 end

--- a/lib/rugged/version.rb
+++ b/lib/rugged/version.rb
@@ -4,5 +4,5 @@
 # For full terms see the included LICENSE file.
 
 module Rugged
-  Version = VERSION = '1.5.0'
+  Version = VERSION = '1.7.0'
 end


### PR DESCRIPTION
Unfortunately we segfault but I'm not sure if this is something in rugged or libgit2 or elsewhere. We still segfault even without the custom allocator setup so presumably it's not something inside rugged.

Deeper testing would have to go through building a custom ruby that uses the system allocator so valgrind or gdb can see what is going on. Running a single test doesn't trigger this so it seems to be something larger, and it fails with a NULL pointer dereference somewhere deep in fileutils during the helper, which is quite odd.