### PR TITLE
test: remove obsolete `tee` to global config

### DIFF
--- a/script/travisbuild
+++ b/script/travisbuild
@@ -74,7 +74,6 @@ export GITTEST_REMOTE_SSH_PUBKEY="$HOME/.ssh/id_rsa.pub"
 export GITTEST_REMOTE_SSH_PASSPHRASE=""
 export GITTEST_REMOTE_REPO_PATH="$HOME/_temp/test.git"
 
-echo 'PasswordAuthentication yes' | sudo tee -a /etc/sshd_config
 eval $(ssh-agent)
 ssh-add $GITTEST_REMOTE_SSH_KEY
 


### PR DESCRIPTION
We use to modify the global sshd but we haven't done that for a few years. We still did have this `tee` to allow password logins that we don't need anymore. Remove this single instance of a `sudo`.