### PR TITLE
settings: Expose GIT_OPT_SET_OWNER_VALIDATION option

### DIFF
--- a/ext/rugged/rugged_settings.c
+++ b/ext/rugged/rugged_settings.c
@@ -91,6 +91,11 @@ static VALUE rb_git_set_option(VALUE self, VALUE option, VALUE value)
 		git_libgit2_opts(GIT_OPT_ENABLE_FSYNC_GITDIR, fsync);
 	}
 
+	else if (strcmp(opt, "owner_validation") == 0) {
+		int validation = RTEST(value) ? 1 : 0;
+		git_libgit2_opts(GIT_OPT_SET_OWNER_VALIDATION, validation);
+	}
+
 	else {
 		rb_raise(rb_eArgError, "Unknown option specified");
 	}
@@ -133,6 +138,12 @@ static VALUE rb_git_get_option(VALUE self, VALUE option)
 
 	else if (strcmp(opt, "search_path_system") == 0) {
 		return get_search_path(GIT_CONFIG_LEVEL_SYSTEM);
+	}
+
+	else if (strcmp(opt, "owner_validation") == 0) {
+		int validation;
+		git_libgit2_opts(GIT_OPT_GET_OWNER_VALIDATION, &validation);
+		return validation ? Qtrue : Qfalse;
 	}
 
 	else {

--- a/test/lib_test.rb
+++ b/test/lib_test.rb
@@ -37,6 +37,23 @@ class RuggedTest < Rugged::TestCase
     Rugged::Settings['fsync_gitdir'] = false
   end
 
+  def test_owner_validation
+    before = Rugged::Settings['owner_validation']
+
+    begin
+      Rugged::Settings['owner_validation'] = false
+      assert_equal(false, Rugged::Settings['owner_validation'])
+
+      Rugged::Settings['owner_validation'] = true
+      assert_equal(true, Rugged::Settings['owner_validation'])
+
+      Rugged::Settings['owner_validation'] = false
+      assert_equal(false, Rugged::Settings['owner_validation'])
+    ensure
+      Rugged::Settings['owner_validation'] = before
+    end
+  end
+
   def test_search_path
     paths = [['search_path_global', '/tmp/global'],
              ['search_path_xdg', '/tmp/xdg'],


### PR DESCRIPTION
By default, `libgit2` will throw an error if you try to open a repository not owned by the current user. An option to disable this validation is available, but wasn't being exposed in `rugged`.

This commit exposes fetching and setting this option via a new `owner_validation` setting.

(My use case is using `rugged` in a ruby language AWS lambda function connected to EFS. In this scenario, the EFS access point is configured with a POSIX user ID and group ID `used for all file system operations using this access point`, but the lambda's execution environment's uid is not known upfront and won't match).