### PR TITLE
ext: Fix the build with system libgit2 1.9.0

### DIFF
--- a/ext/rugged/extconf.rb
+++ b/ext/rugged/extconf.rb
@@ -71,12 +71,12 @@ if arg_config("--use-system-libraries", !!ENV['RUGGED_USE_SYSTEM_LIBRARIES'])
   major = minor = nil
 
   File.readlines(File.join(LIBGIT2_DIR, "include", "git2", "version.h")).each do |line|
-    if !major && (matches = line.match(/^#define LIBGIT2_VER_MAJOR\s+([0-9]+)$/))
+    if !major && (matches = line.match(/^#define LIBGIT2_VERSION_MAJOR\s+([0-9]+)$/))
       major = matches[1]
       next
     end
 
-    if !minor && (matches = line.match(/^#define LIBGIT2_VER_MINOR\s+([0-9]+)$/))
+    if !minor && (matches = line.match(/^#define LIBGIT2_VERSION_MINOR\s+([0-9]+)$/))
       minor = matches[1]
       next
     end
@@ -85,9 +85,9 @@ if arg_config("--use-system-libraries", !!ENV['RUGGED_USE_SYSTEM_LIBRARIES'])
   end
 
   try_compile(<<-SRC) or abort "libgit2 version is not compatible, expected ~> #{major}.#{minor}.0"
-#include <git2/version.h>
+#include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != #{major} || LIBGIT2_VER_MINOR != #{minor}
+#if LIBGIT2_VERSION_MAJOR != #{major} || LIBGIT2_VERSION_MINOR != #{minor}
 #error libgit2 version is not compatible
 #endif
   SRC


### PR DESCRIPTION
Update version.h parsing regexes for 1.9.0 and fix compilation test by including git2.h instead of directly including git2/version.h, which is no longer supported.