### PR TITLE
Check for strings before attempting to xfree them

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -438,7 +438,8 @@ void rugged_rb_ary_to_strarray(VALUE rb_array, git_strarray *str_array)
 	if (TYPE(rb_array) == T_STRING) {
 		const char *s = StringValueCStr(rb_array);
 		str_array->count = 1;
-		str_array->strings = xmalloc(sizeof(char *));
+		/* use malloc so git_strarray_dispose/free can clean up */
+		str_array->strings = malloc(sizeof(char *));
 		/* duplicate the string so it can be freed later */
 		str_array->strings[0] = strdup(s);
 		return;
@@ -450,7 +451,8 @@ void rugged_rb_ary_to_strarray(VALUE rb_array, git_strarray *str_array)
 		Check_Type(rb_ary_entry(rb_array, i), T_STRING);
 
 	str_array->count = RARRAY_LEN(rb_array);
-	str_array->strings = xmalloc(str_array->count * sizeof(char *));
+	/* allocate with malloc rather than xmalloc to allow free() to work */
+	str_array->strings = malloc(str_array->count * sizeof(char *));
 
 	for (i = 0; i < RARRAY_LEN(rb_array); ++i) {
 		VALUE rb_string = rb_ary_entry(rb_array, i);

--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -436,9 +436,11 @@ void rugged_rb_ary_to_strarray(VALUE rb_array, git_strarray *str_array)
 		return;
 
 	if (TYPE(rb_array) == T_STRING) {
+		const char *s = StringValueCStr(rb_array);
 		str_array->count = 1;
 		str_array->strings = xmalloc(sizeof(char *));
-		str_array->strings[0] = StringValueCStr(rb_array);
+		/* duplicate the string so it can be freed later */
+		str_array->strings[0] = strdup(s);
 		return;
 	}
 
@@ -452,7 +454,9 @@ void rugged_rb_ary_to_strarray(VALUE rb_array, git_strarray *str_array)
 
 	for (i = 0; i < RARRAY_LEN(rb_array); ++i) {
 		VALUE rb_string = rb_ary_entry(rb_array, i);
-		str_array->strings[i] = StringValueCStr(rb_string);
+		const char *s = StringValueCStr(rb_string);
+		/* copy so the array owns its contents */
+		str_array->strings[i] = strdup(s);
 	}
 }
 

--- a/ext/rugged/rugged.h
+++ b/ext/rugged/rugged.h
@@ -27,6 +27,17 @@
 #include <git2/odb_backend.h>
 #include <git2/sys/path.h>
 
+/*
+ * Older libgit2 versions may not provide git_strarray_dispose.  The
+ * semantics we require are identical to git_strarray_free, so fall back
+ * if necessary.  Using the git allocator keeps us in sync with the
+ * library and avoids mixing with Ruby's xfree unless we explicitly
+ * allocate via the Ruby allocator.
+ */
+#ifndef git_strarray_dispose
+#define git_strarray_dispose git_strarray_free
+#endif
+
 #define rb_str_new_utf8(str) rb_enc_str_new(str, strlen(str), rb_utf8_encoding())
 #define CSTR2SYM(s) (ID2SYM(rb_intern((s))))
 

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -650,7 +650,7 @@ static VALUE rb_git_commit_to_mbox(int argc, VALUE *argv, VALUE self)
 
 	cleanup:
 
-	xfree(opts.pathspec.strings);
+	git_strarray_dispose(&opts.pathspec);
 	git_buf_dispose(&email_patch);
 	rugged_exception_check(error);
 

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -124,19 +124,10 @@ void rugged_parse_diff_options(git_diff_options *opts, VALUE rb_options)
 
 		rb_value = rb_hash_aref(rb_options, CSTR2SYM("paths"));
 		if (!NIL_P(rb_value)) {
-			int i;
-			Check_Type(rb_value, T_ARRAY);
-
-			for (i = 0; i < RARRAY_LEN(rb_value); ++i)
-				Check_Type(rb_ary_entry(rb_value, i), T_STRING);
-
-			opts->pathspec.count = RARRAY_LEN(rb_value);
-			opts->pathspec.strings = xmalloc(opts->pathspec.count * sizeof(char *));
-
-			for (i = 0; i < RARRAY_LEN(rb_value); ++i) {
-				VALUE rb_path = rb_ary_entry(rb_value, i);
-				opts->pathspec.strings[i] = StringValueCStr(rb_path);
-			}
+			/* convert a Ruby array of strings into a git_strarray
+			   making sure each element is duplicated so that
+			   git_strarray_dispose can safely free them later */
+			rugged_rb_ary_to_strarray(rb_value, &opts->pathspec);
 		}
 
 		rb_value = rb_hash_aref(rb_options, CSTR2SYM("context_lines"));

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -398,7 +398,7 @@ static VALUE rb_git_index_add_all(int argc, VALUE *argv, VALUE self)
 	error = git_index_add_all(index, &pathspecs, flags,
 		rb_block_given_p() ? rugged__index_matched_path_cb : NULL, &exception);
 
-	git_strarray_dispose(	xfree(pathspecs.strings);pathspecs);
+git_strarray_dispose(&pathspecs);
 
 	if (exception)
 		rb_jump_tag(exception);
@@ -448,7 +448,7 @@ static VALUE rb_git_index_update_all(int argc, VALUE *argv, VALUE self)
 	error = git_index_update_all(index, &pathspecs,
 		rb_block_given_p() ? rugged__index_matched_path_cb : NULL, &exception);
 
-	git_strarray_dispose(	xfree(pathspecs.strings);pathspecs);
+git_strarray_dispose(&pathspecs);
 
 	if (exception)
 		rb_jump_tag(exception);
@@ -494,7 +494,7 @@ static VALUE rb_git_index_remove_all(int argc, VALUE *argv, VALUE self)
 	error = git_index_remove_all(index, &pathspecs,
 		rb_block_given_p() ? rugged__index_matched_path_cb : NULL, &exception);
 
-	git_strarray_dispose(	xfree(pathspecs.strings);pathspecs);
+git_strarray_dispose(&pathspecs);
 
 	if (exception)
 		rb_jump_tag(exception);
@@ -695,7 +695,7 @@ static VALUE rb_git_diff_tree_to_index(VALUE self, VALUE rb_other, VALUE rb_opti
 	TypedData_Get_Struct(rb_other, git_tree, &rugged_object_type, other_tree);
 	error = git_diff_tree_to_index(&diff, repo, other_tree, index, &opts);
 
-	git_strarray_dispose(	xfree(opts.pathspec.strings);opts.pathspec);
+git_strarray_dispose(&opts.pathspec);
 	rugged_exception_check(error);
 
 	return rugged_diff_new(rb_cRuggedDiff, owner, diff);
@@ -718,7 +718,7 @@ static VALUE rb_git_diff_index_to_workdir(VALUE self, VALUE rb_options)
 
 	error = git_diff_index_to_workdir(&diff, repo, index, &opts);
 
-	git_strarray_dispose(	xfree(opts.pathspec.strings);opts.pathspec);
+git_strarray_dispose(&opts.pathspec);
 	rugged_exception_check(error);
 
 	return rugged_diff_new(rb_cRuggedDiff, owner, diff);

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -398,7 +398,7 @@ static VALUE rb_git_index_add_all(int argc, VALUE *argv, VALUE self)
 	error = git_index_add_all(index, &pathspecs, flags,
 		rb_block_given_p() ? rugged__index_matched_path_cb : NULL, &exception);
 
-	xfree(pathspecs.strings);
+	git_strarray_dispose(	xfree(pathspecs.strings);pathspecs);
 
 	if (exception)
 		rb_jump_tag(exception);
@@ -448,7 +448,7 @@ static VALUE rb_git_index_update_all(int argc, VALUE *argv, VALUE self)
 	error = git_index_update_all(index, &pathspecs,
 		rb_block_given_p() ? rugged__index_matched_path_cb : NULL, &exception);
 
-	xfree(pathspecs.strings);
+	git_strarray_dispose(	xfree(pathspecs.strings);pathspecs);
 
 	if (exception)
 		rb_jump_tag(exception);
@@ -494,7 +494,7 @@ static VALUE rb_git_index_remove_all(int argc, VALUE *argv, VALUE self)
 	error = git_index_remove_all(index, &pathspecs,
 		rb_block_given_p() ? rugged__index_matched_path_cb : NULL, &exception);
 
-	xfree(pathspecs.strings);
+	git_strarray_dispose(	xfree(pathspecs.strings);pathspecs);
 
 	if (exception)
 		rb_jump_tag(exception);
@@ -695,7 +695,7 @@ static VALUE rb_git_diff_tree_to_index(VALUE self, VALUE rb_other, VALUE rb_opti
 	TypedData_Get_Struct(rb_other, git_tree, &rugged_object_type, other_tree);
 	error = git_diff_tree_to_index(&diff, repo, other_tree, index, &opts);
 
-	xfree(opts.pathspec.strings);
+	git_strarray_dispose(	xfree(opts.pathspec.strings);opts.pathspec);
 	rugged_exception_check(error);
 
 	return rugged_diff_new(rb_cRuggedDiff, owner, diff);
@@ -718,7 +718,7 @@ static VALUE rb_git_diff_index_to_workdir(VALUE self, VALUE rb_options)
 
 	error = git_diff_index_to_workdir(&diff, repo, index, &opts);
 
-	xfree(opts.pathspec.strings);
+	git_strarray_dispose(	xfree(opts.pathspec.strings);opts.pathspec);
 	rugged_exception_check(error);
 
 	return rugged_diff_new(rb_cRuggedDiff, owner, diff);

--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -343,8 +343,7 @@ static VALUE rb_git_remote_ls(int argc, VALUE *argv, VALUE self)
 	cleanup:
 
 	git_remote_disconnect(remote);
-	if (custom_headers.strings)
-		xfree(custom_headers.strings);
+	git_strarray_dispose(&custom_headers);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);
@@ -542,8 +541,7 @@ static VALUE rb_git_remote_check_connection(int argc, VALUE *argv, VALUE self)
 	error = git_remote_connect(remote, direction, &callbacks, &proxy_options, &custom_headers);
 	git_remote_disconnect(remote);
 
-	if (custom_headers.strings)
-		xfree(custom_headers.strings);
+	git_strarray_dispose(&custom_headers);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);
@@ -646,10 +644,8 @@ static VALUE rb_git_remote_fetch(int argc, VALUE *argv, VALUE self)
 
 	error = git_remote_fetch(remote, &refspecs, &opts, log_message);
 
-	if (refspecs.strings)
-		xfree(refspecs.strings);
-	if (opts.custom_headers.strings)
-		xfree(opts.custom_headers.strings);
+	git_strarray_dispose(&refspecs);
+	git_strarray_dispose(&opts.custom_headers);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);
@@ -733,10 +729,8 @@ static VALUE rb_git_remote_push(int argc, VALUE *argv, VALUE self)
 
 	error = git_remote_push(remote, &refspecs, &opts);
 
-	if (refspecs.strings)
-		xfree(refspecs.strings);
-	if (opts.custom_headers.strings)
-		xfree(opts.custom_headers.strings);
+	git_strarray_dispose(&refspecs);
+	git_strarray_dispose(&opts.custom_headers);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);

--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -343,7 +343,8 @@ static VALUE rb_git_remote_ls(int argc, VALUE *argv, VALUE self)
 	cleanup:
 
 	git_remote_disconnect(remote);
-	xfree(custom_headers.strings);
+	if (custom_headers.strings)
+		xfree(custom_headers.strings);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);
@@ -541,7 +542,8 @@ static VALUE rb_git_remote_check_connection(int argc, VALUE *argv, VALUE self)
 	error = git_remote_connect(remote, direction, &callbacks, &proxy_options, &custom_headers);
 	git_remote_disconnect(remote);
 
-	xfree(custom_headers.strings);
+	if (custom_headers.strings)
+		xfree(custom_headers.strings);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);
@@ -644,8 +646,10 @@ static VALUE rb_git_remote_fetch(int argc, VALUE *argv, VALUE self)
 
 	error = git_remote_fetch(remote, &refspecs, &opts, log_message);
 
-	xfree(refspecs.strings);
-	xfree(opts.custom_headers.strings);
+	if (refspecs.strings)
+		xfree(refspecs.strings);
+	if (opts.custom_headers.strings)
+		xfree(opts.custom_headers.strings);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);
@@ -729,8 +733,10 @@ static VALUE rb_git_remote_push(int argc, VALUE *argv, VALUE self)
 
 	error = git_remote_push(remote, &refspecs, &opts);
 
-	xfree(refspecs.strings);
-	xfree(opts.custom_headers.strings);
+	if (refspecs.strings)
+		xfree(refspecs.strings);
+	if (opts.custom_headers.strings)
+		xfree(opts.custom_headers.strings);
 
 	if (payload.exception)
 		rb_jump_tag(payload.exception);

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -2378,7 +2378,7 @@ static VALUE rb_git_checkout_tree(int argc, VALUE *argv, VALUE self)
 	rugged_parse_checkout_options(&opts, rb_options);
 
 	error = git_checkout_tree(repo, treeish, &opts);
-	git_strarray_dispose(	xfree(opts.paths.strings);opts.paths);
+git_strarray_dispose(&opts.paths);
 
 	if ((payload = opts.notify_payload) != NULL) {
 		exception = payload->exception;
@@ -2426,7 +2426,7 @@ static VALUE rb_git_checkout_index(int argc, VALUE *argv, VALUE self)
 	rugged_parse_checkout_options(&opts, rb_options);
 
 	error = git_checkout_index(repo, index, &opts);
-	git_strarray_dispose(	xfree(opts.paths.strings);opts.paths);
+git_strarray_dispose(&opts.paths);
 
 	if ((payload = opts.notify_payload) != NULL) {
 		exception = payload->exception;
@@ -2469,7 +2469,7 @@ static VALUE rb_git_checkout_head(int argc, VALUE *argv, VALUE self)
 	rugged_parse_checkout_options(&opts, rb_options);
 
 	error = git_checkout_head(repo, &opts);
-	git_strarray_dispose(	xfree(opts.paths.strings);opts.paths);
+git_strarray_dispose(&opts.paths);
 
 	if ((payload = opts.notify_payload) != NULL) {
 		exception = payload->exception;

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -1880,7 +1880,7 @@ static VALUE rb_git_repo_reset_path(int argc, VALUE *argv, VALUE self)
 
 	error = git_reset_default(repo, target, &pathspecs);
 
-	xfree(pathspecs.strings);
+	git_strarray_dispose(&pathspecs);
 	git_object_free(target);
 
 	rugged_exception_check(error);
@@ -2378,7 +2378,7 @@ static VALUE rb_git_checkout_tree(int argc, VALUE *argv, VALUE self)
 	rugged_parse_checkout_options(&opts, rb_options);
 
 	error = git_checkout_tree(repo, treeish, &opts);
-	xfree(opts.paths.strings);
+	git_strarray_dispose(	xfree(opts.paths.strings);opts.paths);
 
 	if ((payload = opts.notify_payload) != NULL) {
 		exception = payload->exception;
@@ -2426,7 +2426,7 @@ static VALUE rb_git_checkout_index(int argc, VALUE *argv, VALUE self)
 	rugged_parse_checkout_options(&opts, rb_options);
 
 	error = git_checkout_index(repo, index, &opts);
-	xfree(opts.paths.strings);
+	git_strarray_dispose(	xfree(opts.paths.strings);opts.paths);
 
 	if ((payload = opts.notify_payload) != NULL) {
 		exception = payload->exception;
@@ -2469,7 +2469,7 @@ static VALUE rb_git_checkout_head(int argc, VALUE *argv, VALUE self)
 	rugged_parse_checkout_options(&opts, rb_options);
 
 	error = git_checkout_head(repo, &opts);
-	xfree(opts.paths.strings);
+	git_strarray_dispose(	xfree(opts.paths.strings);opts.paths);
 
 	if ((payload = opts.notify_payload) != NULL) {
 		exception = payload->exception;

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -359,7 +359,7 @@ static VALUE rb_git_diff_tree_to_index(VALUE self, VALUE rb_repo, VALUE rb_self,
 
 	error = git_diff_tree_to_index(&diff, repo, tree, index, &opts);
 
-	xfree(opts.pathspec.strings);
+	git_strarray_dispose(	xfree(opts.pathspec.strings);opts.pathspec);
 	rugged_exception_check(error);
 
 	return rugged_diff_new(rb_cRuggedDiff, rb_repo, diff);
@@ -408,7 +408,7 @@ static VALUE rb_git_diff_tree_to_tree(VALUE self, VALUE rb_repo, VALUE rb_tree, 
 
 	diff = rb_thread_call_without_gvl(rb_git_diff_tree_to_tree_nogvl, &args, RUBY_UBF_PROCESS, NULL);
 
-	xfree(opts.pathspec.strings);
+	git_strarray_dispose(	xfree(opts.pathspec.strings);opts.pathspec);
 	rugged_exception_check(args.error);
 
 	return rugged_diff_new(rb_cRuggedDiff, rb_repo, diff);
@@ -443,7 +443,7 @@ static VALUE rb_git_tree_diff_workdir(int argc, VALUE *argv, VALUE self)
 
 	error = git_diff_tree_to_workdir(&diff, repo, tree, &opts);
 
-	xfree(opts.pathspec.strings);
+	git_strarray_dispose(	xfree(opts.pathspec.strings);opts.pathspec);
 	rugged_exception_check(error);
 
 	return rugged_diff_new(rb_cRuggedDiff, owner, diff);

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -359,7 +359,7 @@ static VALUE rb_git_diff_tree_to_index(VALUE self, VALUE rb_repo, VALUE rb_self,
 
 	error = git_diff_tree_to_index(&diff, repo, tree, index, &opts);
 
-	git_strarray_dispose(	xfree(opts.pathspec.strings);opts.pathspec);
+git_strarray_dispose(&opts.pathspec);
 	rugged_exception_check(error);
 
 	return rugged_diff_new(rb_cRuggedDiff, rb_repo, diff);
@@ -408,7 +408,7 @@ static VALUE rb_git_diff_tree_to_tree(VALUE self, VALUE rb_repo, VALUE rb_tree, 
 
 	diff = rb_thread_call_without_gvl(rb_git_diff_tree_to_tree_nogvl, &args, RUBY_UBF_PROCESS, NULL);
 
-	git_strarray_dispose(	xfree(opts.pathspec.strings);opts.pathspec);
+git_strarray_dispose(&opts.pathspec);
 	rugged_exception_check(args.error);
 
 	return rugged_diff_new(rb_cRuggedDiff, rb_repo, diff);
@@ -443,7 +443,7 @@ static VALUE rb_git_tree_diff_workdir(int argc, VALUE *argv, VALUE self)
 
 	error = git_diff_tree_to_workdir(&diff, repo, tree, &opts);
 
-	git_strarray_dispose(	xfree(opts.pathspec.strings);opts.pathspec);
+git_strarray_dispose(&opts.pathspec);
 	rugged_exception_check(error);
 
 	return rugged_diff_new(rb_cRuggedDiff, owner, diff);

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -359,9 +359,6 @@ static VALUE rb_git_diff_tree_to_index(VALUE self, VALUE rb_repo, VALUE rb_self,
 
 	error = git_diff_tree_to_index(&diff, repo, tree, index, &opts);
 
-git_strarray_dispose(&opts.pathspec);
-	rugged_exception_check(error);
-
 	return rugged_diff_new(rb_cRuggedDiff, rb_repo, diff);
 }
 
@@ -400,7 +397,6 @@ static VALUE rb_git_diff_tree_to_tree(VALUE self, VALUE rb_repo, VALUE rb_tree, 
 	    TypedData_Get_Struct(rb_other_tree, git_tree, &rugged_object_type, other_tree);
 
 	rugged_parse_diff_options(&opts, rb_options);
-
 	args.repo = repo;
 	args.tree = tree;
 	args.other_tree = other_tree;
@@ -442,9 +438,6 @@ static VALUE rb_git_tree_diff_workdir(int argc, VALUE *argv, VALUE self)
 	Data_Get_Struct(owner, git_repository, repo);
 
 	error = git_diff_tree_to_workdir(&diff, repo, tree, &opts);
-
-git_strarray_dispose(&opts.pathspec);
-	rugged_exception_check(error);
 
 	return rugged_diff_new(rb_cRuggedDiff, owner, diff);
 }


### PR DESCRIPTION
The `rugged_rb_ary_to_strarray` function uses `xmalloc` to allocate memory for `str_array->strings`, but there are several cases where this memory might not be allocated:

If `rb_array` is `NIL_P`, the function returns early with `strings = NULL`. If there's an empty array, the count would be 0. However, in the cleanup sections, the code unconditionally calls `xfree(custom_headers.strings)` without checking if it's NULL. This can cause "munmap_chunk(): invalid pointer" errors.

Should fix https://github.com/libgit2/rugged/issues/859