### PR TITLE
Fix libgit2 website links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ portability of libgit2 with the beauty of the Ruby language.
 
 libgit2 is a pure C implementation of the Git core methods. It's designed to be
 fast and portable. For more information about libgit2,
-[check out libgit2's website](http://libgit2.github.com) or browse the
+[check out libgit2's website](https://libgit2.org/) or browse the
 [libgit2 organization](https://github.com/libgit2) on GitHub.
 
 ## Install

--- a/test/fixtures/text_file.md
+++ b/test/fixtures/text_file.md
@@ -8,7 +8,7 @@ portability of libgit2 with the beauty of the Ruby language.
 
 libgit2 is a pure C implementation of the Git core methods. It's designed to be
 fast and portable. For more information about libgit2,
-[check out libgit2's website](http://libgit2.github.com) or browse the
+[check out libgit2's website](https://libgit2.org/) or browse the
 [libgit2 organization](https://github.com/libgit2) on GitHub.
 
 ## Install


### PR DESCRIPTION
Note that there's also this line: https://github.com/libgit2/rugged/blob/762fd37e32c14707d017589a7dfa082dae7d9821/test/coverage/cover.rb#L70

But I couldn't figure out where this file was on the new libgit2 website, or if it was even there still. So I just left it alone.