### PR TITLE
Add base64 gem as development and test dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,7 @@ if RUBY_VERSION <= '2.7'
 end
 
 gemspec
+
+group :development, :test do
+  gem "base64"
+end


### PR DESCRIPTION
Fixes test runs in Ruby 4.0 which no longer includes `base64`