### PR TITLE
Use TypedData APIs exclusively

### DIFF
--- a/ext/rugged/rugged.c
+++ b/ext/rugged/rugged.c
@@ -336,6 +336,16 @@ static void cleanup_cb(void *unused)
 	git_libgit2_shutdown();
 }
 
+static const rb_data_type_t rugged_shutdown_hook_type = {
+	.wrap_struct_name = "Rugged::ShutdownHook",
+	.function = {
+		.dmark = NULL,
+		.dfree = cleanup_cb,
+		.dsize = NULL,
+	},
+	.flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
 void rugged_exception_raise(void)
 {
 	VALUE err_klass, err_obj;
@@ -687,6 +697,7 @@ void Init_rugged(void)
 
 	/* Hook a global object to cleanup the library
 	 * on shutdown */
-	rb_mShutdownHook = Data_Wrap_Struct(rb_cObject, NULL, &cleanup_cb, NULL);
+	/* Non-NULL data so the GC actually invokes cleanup_cb on shutdown. */
+	rb_mShutdownHook = TypedData_Wrap_Struct(rb_cObject, &rugged_shutdown_hook_type, (void *)1);
 	rb_global_variable(&rb_mShutdownHook);
 }

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -225,7 +225,9 @@ static void rugged_repo_new_with_backend(git_repository **repo, VALUE rb_path, V
 		rb_raise(rb_eRuggedError, "Backend must be an instance of Rugged::Backend");
 	}
 
-	Data_Get_Struct(rb_backend, rugged_backend, backend);
+	/* Backends are wrapped by external code with a type descriptor we don't
+	 * own, so we can't TypedData_Get_Struct against a known type. */
+	backend = (rugged_backend *)RTYPEDDATA_DATA(rb_backend);
 
 	error = git_odb_new(&odb);
 	if (error) goto cleanup;


### PR DESCRIPTION
https://github.com/libgit2/rugged/pull/998 updated most of the APIs to use TypedData 🙌. However a few of the legacy uses were still left. This PR converts the remaining two cases.

The legacy API has been removed from Ruby HEAD (likely to be released with Ruby 4.1 in December).

One thing to note is that I don't believe `rb_mShutdownHook` worked before this change. When the wrapped struct is NULL the dfree function is skipped.

A new release after this is merged would be very appreciated for Ruby HEAD compatibility 🙏

Fixes https://github.com/libgit2/rugged/issues/1002