### PR TITLE
index: correct the `NIL_P` check when adding clonflicts

### DIFF
--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -784,8 +784,8 @@ static VALUE rb_git_conflict_add(VALUE self, VALUE rb_conflict)
 
 	error = git_index_conflict_add(index,
 		NIL_P(rb_ancestor) ? NULL : &ancestor,
-		NIL_P(rb_theirs) ? NULL : &ours,
-		NIL_P(rb_ours) ? NULL : &theirs);
+		NIL_P(rb_ours) ? NULL : &ours,
+		NIL_P(rb_theirs) ? NULL : &theirs);
 	rugged_exception_check(error);
 
 	return Qnil;

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -259,6 +259,14 @@ class IndexConflictsTest < Rugged::TestCase
     @repo.index.conflict_add(conflict)
 
     assert_equal @repo.index.conflicts.size, 4
+
+    conflict[:ours] = nil
+    conflict[:theirs][:path] = "yet-another-conflict.txt"
+
+    @repo.index.conflict_add(conflict)
+
+    assert_equal @repo.index.conflicts.size, 5
+
   end
 
   def test_conflict_cleanup


### PR DESCRIPTION
Thanks to Yuhang Wu from firstdepth for reporting.